### PR TITLE
fix(typescript): add missing defaultValue to ResolverFilterArgConfig

### DIFF
--- a/src/Resolver.d.ts
+++ b/src/Resolver.d.ts
@@ -33,6 +33,7 @@ export type ResolverFilterArgConfig<TSource, TContext> = {
     description?: string,
     query?: ResolverFilterArgFn<TSource, TContext>
     filterTypeNameFallback?: string,
+    defaultValue?: any,
 };
 
 export type ResolverSortArgFn = (resolveParams: ResolveParams<any, any>) => any;


### PR DESCRIPTION
Fix little desync between reference impl/types and the .d.ts.