### PR TITLE
WIP: fix(typedefs): fix `source` being resolved as `context`

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,8 @@
     "rimraf": "^2.6.2",
     "semantic-release": "^15.6.0",
     "tslint": "^5.10.0",
+    "tslint-config-prettier": "^1.15.0",
+    "tslint-plugin-prettier": "^1.3.0",
     "typescript": "^2.9.2"
   },
   "dependencies": {

--- a/src/EnumTypeComposer.d.ts
+++ b/src/EnumTypeComposer.d.ts
@@ -20,9 +20,13 @@ export class EnumTypeComposer {
 
   public constructor(gqType: GraphQLEnumType);
 
-  public static create(opts: TypeAsString | GraphQLEnumTypeConfig | GraphQLEnumType): EnumTypeComposer;
+  public static create(
+    opts: TypeAsString | GraphQLEnumTypeConfig | GraphQLEnumType,
+  ): EnumTypeComposer;
 
-  public static createTemp(opts: TypeAsString | GraphQLEnumTypeConfig | GraphQLEnumType): EnumTypeComposer;
+  public static createTemp(
+    opts: TypeAsString | GraphQLEnumTypeConfig | GraphQLEnumType,
+  ): EnumTypeComposer;
 
   // -----------------------------------------------
   // Value methods
@@ -48,9 +52,14 @@ export class EnumTypeComposer {
 
   public reorderFields(names: string[]): this;
 
-  public extendField(name: string, partialValueConfig: GraphQLEnumValueConfig): this;
+  public extendField(
+    name: string,
+    partialValueConfig: GraphQLEnumValueConfig,
+  ): this;
 
-  public deprecateFields(fields: { [fieldName: string]: string } | string[] | string): this;
+  public deprecateFields(
+    fields: { [fieldName: string]: string } | string[] | string,
+  ): this;
 
   // -----------------------------------------------
   // Type methods

--- a/src/InputTypeComposer.d.ts
+++ b/src/InputTypeComposer.d.ts
@@ -1,6 +1,11 @@
 import {
-    GraphQLInputFieldConfig, GraphQLInputFieldConfigMap, GraphQLInputObjectType,
-    GraphQLNonNull, GraphQLList, GraphQLInputType, InputValueDefinitionNode
+  GraphQLInputFieldConfig,
+  GraphQLInputFieldConfigMap,
+  GraphQLInputObjectType,
+  GraphQLNonNull,
+  GraphQLList,
+  GraphQLInputType,
+  InputValueDefinitionNode,
 } from './graphql';
 import { Thunk, ObjMap } from './utils/definitions';
 import { TypeAsString } from './TypeMapper';
@@ -10,128 +15,138 @@ import { EnumTypeComposer } from './EnumTypeComposer';
 export type ComposeInputFieldConfigMap = ObjMap<ComposeInputFieldConfig>;
 
 export type ComposeInputFieldConfig =
-    | ComposeInputFieldConfigAsObject
-    | ComposeInputType
-    | (() => ComposeInputFieldConfigAsObject | ComposeInputType);
+  | ComposeInputFieldConfigAsObject
+  | ComposeInputType
+  | (() => ComposeInputFieldConfigAsObject | ComposeInputType);
 
 export type ComposeInputFieldConfigAsObject = {
-    type: Thunk<ComposeInputType> | GraphQLInputType,
-    defaultValue?: any,
-    description?: string | null,
-    astNode?: InputValueDefinitionNode | null,
-    [key: string]: any,
+  type: Thunk<ComposeInputType> | GraphQLInputType;
+  defaultValue?: any;
+  description?: string | null;
+  astNode?: InputValueDefinitionNode | null;
+  [key: string]: any;
 } & { $call?: void };
 
 export type ComposeInputType =
-    | InputTypeComposer
-    | EnumTypeComposer
-    | GraphQLInputType
-    | TypeAsString
-    | Array<InputTypeComposer | EnumTypeComposer | GraphQLInputType | TypeAsString>;
+  | InputTypeComposer
+  | EnumTypeComposer
+  | GraphQLInputType
+  | TypeAsString
+  | Array<
+      InputTypeComposer | EnumTypeComposer | GraphQLInputType | TypeAsString
+    >;
 
 export type ComposeInputObjectTypeConfig = {
-    name: string,
-    fields: Thunk<ComposeInputFieldConfigMap>,
-    description?: string | null,
+  name: string;
+  fields: Thunk<ComposeInputFieldConfigMap>;
+  description?: string | null;
 };
 
 export class InputTypeComposer {
-    public static schemaComposer: SchemaComposer<any>;
-    public schemaComposer: SchemaComposer<any>;
+  public static schemaComposer: SchemaComposer<any>;
+  public schemaComposer: SchemaComposer<any>;
 
-    public gqType: GraphQLInputObjectType;
+  public gqType: GraphQLInputObjectType;
 
-    public constructor(gqType: GraphQLInputObjectType);
+  public constructor(gqType: GraphQLInputObjectType);
 
-    public static create(opts: TypeAsString |
-        ComposeInputObjectTypeConfig |
-        GraphQLInputObjectType): InputTypeComposer;
+  public static create(
+    opts: TypeAsString | ComposeInputObjectTypeConfig | GraphQLInputObjectType,
+  ): InputTypeComposer;
 
-    public static createTemp(opts: TypeAsString |
-        ComposeInputObjectTypeConfig |
-        GraphQLInputObjectType): InputTypeComposer;
+  public static createTemp(
+    opts: TypeAsString | ComposeInputObjectTypeConfig | GraphQLInputObjectType,
+  ): InputTypeComposer;
 
-    // -----------------------------------------------
-    // Field methods
-    // -----------------------------------------------
+  // -----------------------------------------------
+  // Field methods
+  // -----------------------------------------------
 
-    public getFields(): ComposeInputFieldConfigMap;
+  public getFields(): ComposeInputFieldConfigMap;
 
-    public getFieldNames(): string[];
+  public getFieldNames(): string[];
 
-    public hasField(fieldName: string): boolean;
+  public hasField(fieldName: string): boolean;
 
-    public setFields(fields: ComposeInputFieldConfigMap): this;
+  public setFields(fields: ComposeInputFieldConfigMap): this;
 
-    public setField(fieldName: string, fieldConfig: ComposeInputFieldConfig): this;
+  public setField(
+    fieldName: string,
+    fieldConfig: ComposeInputFieldConfig,
+  ): this;
 
-    /**
-     * Add new fields or replace existed in a GraphQL type
-     */
-    public addFields(newFields: ComposeInputFieldConfigMap): this;
+  /**
+   * Add new fields or replace existed in a GraphQL type
+   */
+  public addFields(newFields: ComposeInputFieldConfigMap): this;
 
-    /**
-     * Add new fields or replace existed (where field name may have dots)
-     */
-    public addNestedFields(newFields: ComposeInputFieldConfigMap): InputTypeComposer;
+  /**
+   * Add new fields or replace existed (where field name may have dots)
+   */
+  public addNestedFields(
+    newFields: ComposeInputFieldConfigMap,
+  ): InputTypeComposer;
 
-    /**
-     * Get fieldConfig by name
-     */
-    public getField(fieldName: string): ComposeInputFieldConfig;
+  /**
+   * Get fieldConfig by name
+   */
+  public getField(fieldName: string): ComposeInputFieldConfig;
 
-    public removeField(fieldNameOrArray: string | string[]): this;
+  public removeField(fieldNameOrArray: string | string[]): this;
 
-    public removeOtherFields(fieldNameOrArray: string | string[]): this;
+  public removeOtherFields(fieldNameOrArray: string | string[]): this;
 
-    public extendField(fieldName: string, parialFieldConfig: ComposeInputFieldConfig): this;
+  public extendField(
+    fieldName: string,
+    parialFieldConfig: ComposeInputFieldConfig,
+  ): this;
 
-    public reorderFields(names: string[]): this;
+  public reorderFields(names: string[]): this;
 
-    public isFieldNonNull(fieldName: string): boolean ;
+  public isFieldNonNull(fieldName: string): boolean;
 
-    // alias for isFieldNonNull
-    public isRequired(fieldName: string): boolean;
+  // alias for isFieldNonNull
+  public isRequired(fieldName: string): boolean;
 
-    public getFieldConfig(fieldName: string): GraphQLInputFieldConfig;
+  public getFieldConfig(fieldName: string): GraphQLInputFieldConfig;
 
-    public getFieldType(fieldName: string): GraphQLInputType;
+  public getFieldType(fieldName: string): GraphQLInputType;
 
-    public getFieldTC(fieldName: string): InputTypeComposer;
+  public getFieldTC(fieldName: string): InputTypeComposer;
 
-    public makeFieldNonNull(fieldNameOrArray: string | string[]): this;
+  public makeFieldNonNull(fieldNameOrArray: string | string[]): this;
 
-    // alias for makeFieldNonNull
-    public makeRequired(fieldNameOrArray: string | string[]): this;
+  // alias for makeFieldNonNull
+  public makeRequired(fieldNameOrArray: string | string[]): this;
 
-    public makeFieldNullable(fieldNameOrArray: string | string[]): this;
+  public makeFieldNullable(fieldNameOrArray: string | string[]): this;
 
-    // alias for makeFieldNullable
-    public makeOptional(fieldNameOrArray: string | string[]): this;
+  // alias for makeFieldNullable
+  public makeOptional(fieldNameOrArray: string | string[]): this;
 
-    // -----------------------------------------------
-    // Type methods
-    // -----------------------------------------------
+  // -----------------------------------------------
+  // Type methods
+  // -----------------------------------------------
 
-    public getType(): GraphQLInputObjectType;
+  public getType(): GraphQLInputObjectType;
 
-    public getTypePlural(): GraphQLList<GraphQLInputObjectType>;
+  public getTypePlural(): GraphQLList<GraphQLInputObjectType>;
 
-    public getTypeNonNull(): GraphQLNonNull<GraphQLInputObjectType>;
+  public getTypeNonNull(): GraphQLNonNull<GraphQLInputObjectType>;
 
-    public getTypeName(): string;
+  public getTypeName(): string;
 
-    public setTypeName(name: string): this;
+  public setTypeName(name: string): this;
 
-    public getDescription(): string;
+  public getDescription(): string;
 
-    public setDescription(description: string): this;
+  public setDescription(description: string): this;
 
-    public clone(newTypeName: string): InputTypeComposer;
+  public clone(newTypeName: string): InputTypeComposer;
 
-    // -----------------------------------------------
-    // Misc methods
-    // -----------------------------------------------
+  // -----------------------------------------------
+  // Misc methods
+  // -----------------------------------------------
 
-    public get(path: string | string[]): any;
+  public get(path: string | string[]): any;
 }

--- a/src/InterfaceTypeComposer.d.ts
+++ b/src/InterfaceTypeComposer.d.ts
@@ -33,7 +33,7 @@ export type GraphQLInterfaceTypeExtended<TSource, TContext> = GraphQLInterfaceTy
 };
 
 export type InterfaceTypeResolversMap<TSource, TContext> = Map<
-  TypeComposer<TContext> | GraphQLObjectType,
+  TypeComposer<any, TContext> | GraphQLObjectType,
   InterfaceTypeResolverCheckFn<TSource, TContext>
 >;
 
@@ -113,7 +113,7 @@ export class InterfaceTypeComposer<TContext> {
 
   public getFieldType(fieldName: string): GraphQLOutputType;
 
-  public getFieldTC(fieldName: string): TypeComposer<TContext>;
+  public getFieldTC<TSource>(fieldName: string): TypeComposer<TSource, TContext>;
 
   public makeFieldNonNull(fieldNameOrArray: string | string[]): InterfaceTypeComposer<TContext>;
 
@@ -153,12 +153,12 @@ export class InterfaceTypeComposer<TContext> {
   // ResolveType methods
   // -----------------------------------------------
 
-  public hasTypeResolver(type: TypeComposer<TContext> | GraphQLObjectType): boolean;
+  public hasTypeResolver(type: TypeComposer<any, TContext> | GraphQLObjectType): boolean;
 
   public getTypeResolvers(): InterfaceTypeResolversMap<any, TContext>;
 
   public getTypeResolverCheckFn(
-    type: TypeComposer<TContext> | GraphQLObjectType
+    type: TypeComposer<any, TContext> | GraphQLObjectType
   ): InterfaceTypeResolverCheckFn<any, TContext>;
 
   public getTypeResolverNames(): string[];
@@ -170,12 +170,12 @@ export class InterfaceTypeComposer<TContext> {
   ): InterfaceTypeComposer<TContext>;
 
   public addTypeResolver(
-    type: TypeComposer<TContext> | GraphQLObjectType,
+    type: TypeComposer<any, TContext> | GraphQLObjectType,
     checkFn: InterfaceTypeResolverCheckFn<any, TContext>
   ): InterfaceTypeComposer<TContext>;
 
   public removeTypeResolver(
-    type: TypeComposer<TContext> | GraphQLObjectType
+    type: TypeComposer<any, TContext> | GraphQLObjectType
   ): InterfaceTypeComposer<TContext>;
 
   // -----------------------------------------------

--- a/src/InterfaceTypeComposer.d.ts
+++ b/src/InterfaceTypeComposer.d.ts
@@ -14,7 +14,12 @@ import {
   GraphQLResolveInfo,
 } from './graphql';
 import { TypeAsString } from './TypeMapper';
-import { Resolver, ResolverOpts, ResolverNextRpCb, ResolverWrapCb } from './Resolver';
+import {
+  Resolver,
+  ResolverOpts,
+  ResolverNextRpCb,
+  ResolverWrapCb,
+} from './Resolver';
 import { ProjectionType } from './utils/projection';
 import { Thunk } from './utils/definitions';
 
@@ -27,9 +32,12 @@ import {
   ComposeFieldConfig,
 } from './TypeComposer';
 
-export type GraphQLInterfaceTypeExtended<TSource, TContext> = GraphQLInterfaceType & {
-  _gqcFields?: ComposeFieldConfigMap<TSource, TContext>,
-  _gqcTypeResolvers?: InterfaceTypeResolversMap<TSource, TContext>,
+export type GraphQLInterfaceTypeExtended<
+  TSource,
+  TContext
+> = GraphQLInterfaceType & {
+  _gqcFields?: ComposeFieldConfigMap<TSource, TContext>;
+  _gqcTypeResolvers?: InterfaceTypeResolversMap<TSource, TContext>;
 };
 
 export type InterfaceTypeResolversMap<TSource, TContext> = Map<
@@ -42,14 +50,14 @@ type MaybePromise<T> = Promise<T> | T;
 export type InterfaceTypeResolverCheckFn<TSource, TContext> = (
   value: TSource,
   context: TContext,
-  info: GraphQLResolveInfo
+  info: GraphQLResolveInfo,
 ) => MaybePromise<boolean | null | undefined>;
 
 export type ComposeInterfaceTypeConfig<TSource, TContext> = {
-  name: string,
-  fields?: Thunk<ComposeFieldConfigMap<TSource, TContext>>,
-  resolveType?: GraphQLTypeResolver<TSource, TContext> | null,
-  description?: string | null,
+  name: string;
+  fields?: Thunk<ComposeFieldConfigMap<TSource, TContext>>;
+  resolveType?: GraphQLTypeResolver<TSource, TContext> | null;
+  description?: string | null;
 };
 
 export class InterfaceTypeComposer<TContext> {
@@ -61,16 +69,18 @@ export class InterfaceTypeComposer<TContext> {
   public constructor(gqType: GraphQLInterfaceType);
 
   public static create<TCtx>(
-      opts:
-        | TypeAsString
-        | ComposeInterfaceTypeConfig<any, TCtx>
-        | GraphQLInterfaceType): InterfaceTypeComposer<TCtx>;
+    opts:
+      | TypeAsString
+      | ComposeInterfaceTypeConfig<any, TCtx>
+      | GraphQLInterfaceType,
+  ): InterfaceTypeComposer<TCtx>;
 
   public static createTemp<TCtx>(
-      opts:
-          | TypeAsString
-          | ComposeInterfaceTypeConfig<any, TCtx>
-          | GraphQLInterfaceType): InterfaceTypeComposer<TCtx>;
+    opts:
+      | TypeAsString
+      | ComposeInterfaceTypeConfig<any, TCtx>
+      | GraphQLInterfaceType,
+  ): InterfaceTypeComposer<TCtx>;
 
   // -----------------------------------------------
   // Field methods
@@ -84,27 +94,35 @@ export class InterfaceTypeComposer<TContext> {
 
   public getFieldNames(): string[];
 
-  public setFields(fields: ComposeFieldConfigMap<any, TContext>): InterfaceTypeComposer<TContext>;
+  public setFields(
+    fields: ComposeFieldConfigMap<any, TContext>,
+  ): InterfaceTypeComposer<TContext>;
 
   public setField(
     name: string,
-    fieldConfig: ComposeFieldConfig<any, TContext>
+    fieldConfig: ComposeFieldConfig<any, TContext>,
   ): InterfaceTypeComposer<TContext>;
 
   /**
    * Add new fields or replace existed in a GraphQL type
    */
-  public addFields(newValues: ComposeFieldConfigMap<any, TContext>): InterfaceTypeComposer<TContext>;
+  public addFields(
+    newValues: ComposeFieldConfigMap<any, TContext>,
+  ): InterfaceTypeComposer<TContext>;
 
-  public removeField(nameOrArray: string | string[]): InterfaceTypeComposer<TContext>;
+  public removeField(
+    nameOrArray: string | string[],
+  ): InterfaceTypeComposer<TContext>;
 
-  public removeOtherFields(fieldNameOrArray: string | string[]): InterfaceTypeComposer<TContext>;
+  public removeOtherFields(
+    fieldNameOrArray: string | string[],
+  ): InterfaceTypeComposer<TContext>;
 
   public reorderFields(names: string[]): InterfaceTypeComposer<TContext>;
 
   public extendField(
     fieldName: string,
-    parialFieldConfig: ComposeFieldConfig<any, TContext>
+    parialFieldConfig: ComposeFieldConfig<any, TContext>,
   ): InterfaceTypeComposer<TContext>;
 
   public isFieldNonNull(fieldName: string): boolean;
@@ -113,13 +131,21 @@ export class InterfaceTypeComposer<TContext> {
 
   public getFieldType(fieldName: string): GraphQLOutputType;
 
-  public getFieldTC<TSource>(fieldName: string): TypeComposer<TSource, TContext>;
+  public getFieldTC<TSource>(
+    fieldName: string,
+  ): TypeComposer<TSource, TContext>;
 
-  public makeFieldNonNull(fieldNameOrArray: string | string[]): InterfaceTypeComposer<TContext>;
+  public makeFieldNonNull(
+    fieldNameOrArray: string | string[],
+  ): InterfaceTypeComposer<TContext>;
 
-  public makeFieldNullable(fieldNameOrArray: string | string[]): InterfaceTypeComposer<TContext>;
+  public makeFieldNullable(
+    fieldNameOrArray: string | string[],
+  ): InterfaceTypeComposer<TContext>;
 
-  public deprecateFields(fields: { [fieldName: string]: string } | string[] | string): this;
+  public deprecateFields(
+    fields: { [fieldName: string]: string } | string[] | string,
+  ): this;
 
   public getFieldArgs(fieldName: string): GraphQLFieldConfigArgumentMap;
 
@@ -153,12 +179,14 @@ export class InterfaceTypeComposer<TContext> {
   // ResolveType methods
   // -----------------------------------------------
 
-  public hasTypeResolver(type: TypeComposer<any, TContext> | GraphQLObjectType): boolean;
+  public hasTypeResolver(
+    type: TypeComposer<any, TContext> | GraphQLObjectType,
+  ): boolean;
 
   public getTypeResolvers(): InterfaceTypeResolversMap<any, TContext>;
 
   public getTypeResolverCheckFn(
-    type: TypeComposer<any, TContext> | GraphQLObjectType
+    type: TypeComposer<any, TContext> | GraphQLObjectType,
   ): InterfaceTypeResolverCheckFn<any, TContext>;
 
   public getTypeResolverNames(): string[];
@@ -166,16 +194,16 @@ export class InterfaceTypeComposer<TContext> {
   public getTypeResolverTypes(): GraphQLObjectType[];
 
   public setTypeResolvers(
-    typeResolversMap: InterfaceTypeResolversMap<any, TContext>
+    typeResolversMap: InterfaceTypeResolversMap<any, TContext>,
   ): InterfaceTypeComposer<TContext>;
 
   public addTypeResolver(
     type: TypeComposer<any, TContext> | GraphQLObjectType,
-    checkFn: InterfaceTypeResolverCheckFn<any, TContext>
+    checkFn: InterfaceTypeResolverCheckFn<any, TContext>,
   ): InterfaceTypeComposer<TContext>;
 
   public removeTypeResolver(
-    type: TypeComposer<any, TContext> | GraphQLObjectType
+    type: TypeComposer<any, TContext> | GraphQLObjectType,
   ): InterfaceTypeComposer<TContext>;
 
   // -----------------------------------------------

--- a/src/Resolver.d.ts
+++ b/src/Resolver.d.ts
@@ -22,7 +22,7 @@ export type ResolveParams<TSource, TContext, TArgs = any> = {
   args: { [argName in keyof TArgs]: TArgs[argName] };
   context: TContext;
   info: graphql.GraphQLResolveInfo;
-  projection: Partial<ProjectionType>;
+  projection: Partial<ProjectionType<TSource>>;
   [opt: string]: any;
 };
 
@@ -219,7 +219,7 @@ export class Resolver<TSource = any, TContext = any, TArgs = any> {
   // -----------------------------------------------
 
   public getFieldConfig(opts?: {
-    projection?: ProjectionType;
+    projection?: ProjectionType<TSource>;
   }): GraphQLFieldConfig<TSource, TContext, TArgs>;
 
   public getKind(): ResolverKinds | null;

--- a/src/Resolver.d.ts
+++ b/src/Resolver.d.ts
@@ -1,22 +1,21 @@
 import {
+  GraphQLArgumentConfig,
   GraphQLFieldConfig,
-  GraphQLFieldConfigArgumentMap,
   GraphQLInputType,
   GraphQLOutputType,
-  GraphQLArgumentConfig,
 } from 'graphql';
 import * as graphql from './graphql';
+import { InputTypeComposer } from './InputTypeComposer';
 import { SchemaComposer } from './SchemaComposer';
 import {
   ComposeArgumentConfig,
+  ComposeArgumentType,
   ComposeFieldConfigArgumentMap,
   ComposeOutputType,
-  ComposeArgumentType,
+  TypeComposer,
 } from './TypeComposer';
-import { InputTypeComposer } from './InputTypeComposer';
-import { TypeComposer } from './TypeComposer';
-import { ProjectionType } from './utils/projection';
 import { GenericMap } from './utils/definitions';
+import { ProjectionType } from './utils/projection';
 
 export type ResolveParams<TSource, TContext> = {
   source: TSource;
@@ -189,7 +188,17 @@ export class Resolver<TSource, TContext> {
     newResolverOpts: ResolverOpts<TSource, TContext> | null,
   ): Resolver<TSource, TContext>;
 
+  public wrap<TSource>(
+    cb: ResolverWrapCb<TSource, TContext> | null,
+    newResolverOpts: ResolverOpts<TSource, TContext> | null,
+  ): Resolver<TSource, TContext>;
+
   public wrapResolve(
+    cb: ResolverNextRpCb<TSource, TContext>,
+    wrapperName?: string,
+  ): Resolver<TSource, TContext>;
+
+  public wrapResolve<TSource>(
     cb: ResolverNextRpCb<TSource, TContext>,
     wrapperName?: string,
   ): Resolver<TSource, TContext>;
@@ -199,12 +208,27 @@ export class Resolver<TSource, TContext> {
     wrapperName?: string,
   ): Resolver<TSource, TContext>;
 
+  public wrapArgs<TSource>(
+    cb: ResolverWrapArgsCb,
+    wrapperName?: string,
+  ): Resolver<TSource, TContext>;
+
   public wrapCloneArg(
     argName: string,
     newTypeName: string,
   ): Resolver<TSource, TContext>;
 
+  public wrapCloneArg<TSource>(
+    argName: string,
+    newTypeName: string,
+  ): Resolver<TSource, TContext>;
+
   public wrapType(
+    cb: ResolverWrapTypeCb,
+    wrapperName?: string,
+  ): Resolver<TSource, TContext>;
+
+  public wrapType<TSource>(
     cb: ResolverWrapTypeCb,
     wrapperName?: string,
   ): Resolver<TSource, TContext>;
@@ -228,6 +252,10 @@ export class Resolver<TSource, TContext> {
   public get(path: string | string[]): any;
 
   public clone(
+    opts?: ResolverOpts<TSource, TContext>,
+  ): Resolver<TSource, TContext>;
+
+  public clone<TSource>(
     opts?: ResolverOpts<TSource, TContext>,
   ): Resolver<TSource, TContext>;
 

--- a/src/Resolver.d.ts
+++ b/src/Resolver.d.ts
@@ -1,10 +1,17 @@
 import {
-    GraphQLFieldConfig, GraphQLFieldConfigArgumentMap, GraphQLInputType, GraphQLOutputType, GraphQLArgumentConfig
+  GraphQLFieldConfig,
+  GraphQLFieldConfigArgumentMap,
+  GraphQLInputType,
+  GraphQLOutputType,
+  GraphQLArgumentConfig,
 } from 'graphql';
 import * as graphql from './graphql';
 import { SchemaComposer } from './SchemaComposer';
 import {
-    ComposeArgumentConfig, ComposeFieldConfigArgumentMap, ComposeOutputType, ComposeArgumentType
+  ComposeArgumentConfig,
+  ComposeFieldConfigArgumentMap,
+  ComposeOutputType,
+  ComposeArgumentType,
 } from './TypeComposer';
 import { InputTypeComposer } from './InputTypeComposer';
 import { TypeComposer } from './TypeComposer';
@@ -12,200 +19,247 @@ import { ProjectionType } from './utils/projection';
 import { GenericMap } from './utils/definitions';
 
 export type ResolveParams<TSource, TContext> = {
-    source: TSource,
-    args: { [argName: string]: any },
-    context: TContext,
-    info: graphql.GraphQLResolveInfo,
-    projection: Partial<ProjectionType>,
-    [opt: string]: any,
+  source: TSource;
+  args: { [argName: string]: any };
+  context: TContext;
+  info: graphql.GraphQLResolveInfo;
+  projection: Partial<ProjectionType>;
+  [opt: string]: any;
 };
 
 export type ResolverKinds = 'query' | 'mutation' | 'subscription';
 
 export type ResolverFilterArgFn<TSource, TContext> = (
-    query: any,
-    value: any,
-    resolveParams: ResolveParams<TSource, TContext>) => any;
+  query: any,
+  value: any,
+  resolveParams: ResolveParams<TSource, TContext>,
+) => any;
 
 export type ResolverFilterArgConfig<TSource, TContext> = {
-    name: string,
-    type: ComposeArgumentType,
-    description?: string,
-    query?: ResolverFilterArgFn<TSource, TContext>
-    filterTypeNameFallback?: string,
-    defaultValue?: any,
+  name: string;
+  type: ComposeArgumentType;
+  description?: string;
+  query?: ResolverFilterArgFn<TSource, TContext>;
+  filterTypeNameFallback?: string;
+  defaultValue?: any;
 };
 
 export type ResolverSortArgFn = (resolveParams: ResolveParams<any, any>) => any;
 
 export type ResolverSortArgConfig<TSource, TContext> = {
-    name: string,
-    sortTypeNameFallback?: string,
-    value: ResolverSortArgFn | string | number | boolean | any[] | GenericMap<any>,
-    deprecationReason?: string | null,
-    description?: string | null,
+  name: string;
+  sortTypeNameFallback?: string;
+  value:
+    | ResolverSortArgFn
+    | string
+    | number
+    | boolean
+    | any[]
+    | GenericMap<any>;
+  deprecationReason?: string | null;
+  description?: string | null;
 };
 
 export type ResolverOpts<TSource, TContext> = {
-    type?: ComposeOutputType<TContext>,
-    resolve?: ResolverRpCb<TSource, TContext>,
-    args?: ComposeFieldConfigArgumentMap,
-    name?: string,
-    displayName?: string,
-    kind?: ResolverKinds,
-    description?: string,
-    parent?: Resolver<TSource, TContext>,
+  type?: ComposeOutputType<TContext>;
+  resolve?: ResolverRpCb<TSource, TContext>;
+  args?: ComposeFieldConfigArgumentMap;
+  name?: string;
+  displayName?: string;
+  kind?: ResolverKinds;
+  description?: string;
+  parent?: Resolver<TSource, TContext>;
 };
 
 export type ResolverWrapCb<TSource, TContext> = (
-    newResolver: Resolver<TSource, TContext>,
-    prevResolver: Resolver<TSource, TContext>) => Resolver<TSource, TContext>;
+  newResolver: Resolver<TSource, TContext>,
+  prevResolver: Resolver<TSource, TContext>,
+) => Resolver<TSource, TContext>;
 
 export type ResolverRpCb<TSource, TContext> = (
-    resolveParams: Partial<ResolveParams<TSource, TContext>>) => Promise<any> | any;
+  resolveParams: Partial<ResolveParams<TSource, TContext>>,
+) => Promise<any> | any;
 export type ResolverNextRpCb<TSource, TContext> = (
-    next: ResolverRpCb<TSource, TContext>) => ResolverRpCb<TSource, TContext>;
+  next: ResolverRpCb<TSource, TContext>,
+) => ResolverRpCb<TSource, TContext>;
 
-export type ResolverWrapArgsCb = (prevArgs: graphql.GraphQLFieldConfigArgumentMap) => ComposeFieldConfigArgumentMap;
+export type ResolverWrapArgsCb = (
+  prevArgs: graphql.GraphQLFieldConfigArgumentMap,
+) => ComposeFieldConfigArgumentMap;
 
-export type ResolverWrapTypeCb = (prevType: graphql.GraphQLOutputType) => ComposeOutputType<any>;
+export type ResolverWrapTypeCb = (
+  prevType: graphql.GraphQLOutputType,
+) => ComposeOutputType<any>;
 
 export type ResolveDebugOpts = {
-    showHidden?: boolean,
-    depth?: number,
-    colors?: boolean,
+  showHidden?: boolean;
+  depth?: number;
+  colors?: boolean;
 };
 
 export class Resolver<TSource, TContext> {
-    public static schemaComposer: SchemaComposer<any>;
-    public schemaComposer: SchemaComposer<any>;
+  public static schemaComposer: SchemaComposer<any>;
+  public schemaComposer: SchemaComposer<any>;
 
-    public type: ComposeOutputType<TContext>;
-    public args: ComposeFieldConfigArgumentMap;
-    public resolve: ResolverRpCb<TSource, TContext>;
-    public name: string;
-    public displayName: string | null;
-    public kind: ResolverKinds | null;
-    public description: string | null;
-    public parent: Resolver<TSource, TContext> | null;
+  public type: ComposeOutputType<TContext>;
+  public args: ComposeFieldConfigArgumentMap;
+  public resolve: ResolverRpCb<TSource, TContext>;
+  public name: string;
+  public displayName: string | null;
+  public kind: ResolverKinds | null;
+  public description: string | null;
+  public parent: Resolver<TSource, TContext> | null;
 
-    constructor(opts: ResolverOpts<TSource, TContext>);
+  constructor(opts: ResolverOpts<TSource, TContext>);
 
-    // -----------------------------------------------
-    // Output type methods
-    // -----------------------------------------------
+  // -----------------------------------------------
+  // Output type methods
+  // -----------------------------------------------
 
-    public getType(): GraphQLOutputType;
+  public getType(): GraphQLOutputType;
 
-    public getTypeComposer(): TypeComposer<TSource, TContext>;
+  public getTypeComposer(): TypeComposer<TSource, TContext>;
 
-    public setType(gqType: ComposeOutputType<TContext>): this;
+  public setType(gqType: ComposeOutputType<TContext>): this;
 
-    // -----------------------------------------------
-    // Args methods
-    // -----------------------------------------------
+  // -----------------------------------------------
+  // Args methods
+  // -----------------------------------------------
 
-    public hasArg(argName: string): boolean;
+  public hasArg(argName: string): boolean;
 
-    public getArg(argName: string): ComposeArgumentConfig;
+  public getArg(argName: string): ComposeArgumentConfig;
 
-    public getArgConfig(argName: string): GraphQLArgumentConfig;
+  public getArgConfig(argName: string): GraphQLArgumentConfig;
 
-    public getArgType(argName: string): GraphQLInputType;
+  public getArgType(argName: string): GraphQLInputType;
 
-    public getArgTC(argName: string): InputTypeComposer;
+  public getArgTC(argName: string): InputTypeComposer;
 
-    public getArgs(): ComposeFieldConfigArgumentMap;
+  public getArgs(): ComposeFieldConfigArgumentMap;
 
-    public getArgNames(): string[];
+  public getArgNames(): string[];
 
-    public setArgs(args: ComposeFieldConfigArgumentMap): this;
+  public setArgs(args: ComposeFieldConfigArgumentMap): this;
 
-    public setArg(argName: string, argConfig: ComposeArgumentConfig): this;
+  public setArg(argName: string, argConfig: ComposeArgumentConfig): this;
 
-    public extendArg(argName: string, partialArgConfig: any): this;
+  public extendArg(argName: string, partialArgConfig: any): this;
 
-    public addArgs(newArgs: ComposeFieldConfigArgumentMap): this;
+  public addArgs(newArgs: ComposeFieldConfigArgumentMap): this;
 
-    public removeArg(argNameOrArray: string | string[]): this;
+  public removeArg(argNameOrArray: string | string[]): this;
 
-    public removeOtherArgs(argNameOrArray: string | string[]): this;
+  public removeOtherArgs(argNameOrArray: string | string[]): this;
 
-    public reorderArgs(names: string[]): this;
+  public reorderArgs(names: string[]): this;
 
-    public cloneArg(argName: string, newTypeName: string): this;
+  public cloneArg(argName: string, newTypeName: string): this;
 
-    public isRequired(argName: string): boolean;
+  public isRequired(argName: string): boolean;
 
-    public makeRequired(argNameOrArray: string | string[]): this;
+  public makeRequired(argNameOrArray: string | string[]): this;
 
-    public makeOptional(argNameOrArray: string | string[]): this;
+  public makeOptional(argNameOrArray: string | string[]): this;
 
-    public addFilterArg(opts: ResolverFilterArgConfig<TSource, TContext>): Resolver<TSource, TContext>;
+  public addFilterArg(
+    opts: ResolverFilterArgConfig<TSource, TContext>,
+  ): Resolver<TSource, TContext>;
 
-    public addSortArg(opts: ResolverSortArgConfig<TSource, TContext>): Resolver<TSource, TContext>;
+  public addSortArg(
+    opts: ResolverSortArgConfig<TSource, TContext>,
+  ): Resolver<TSource, TContext>;
 
-    // -----------------------------------------------
-    // Resolve methods
-    // -----------------------------------------------
+  // -----------------------------------------------
+  // Resolve methods
+  // -----------------------------------------------
 
-    public getResolve(): ResolverRpCb<TSource, TContext>;
+  public getResolve(): ResolverRpCb<TSource, TContext>;
 
-    public setResolve(resolve: ResolverRpCb<TSource, TContext>): Resolver<TSource, TContext>;
+  public setResolve(
+    resolve: ResolverRpCb<TSource, TContext>,
+  ): Resolver<TSource, TContext>;
 
-    // -----------------------------------------------
-    // Wrap methods
-    // -----------------------------------------------
+  // -----------------------------------------------
+  // Wrap methods
+  // -----------------------------------------------
 
-    public wrap(
-        cb: ResolverWrapCb<TSource, TContext> | null,
-        newResolverOpts: ResolverOpts<TSource, TContext> | null): Resolver<TSource, TContext>;
+  public wrap(
+    cb: ResolverWrapCb<TSource, TContext> | null,
+    newResolverOpts: ResolverOpts<TSource, TContext> | null,
+  ): Resolver<TSource, TContext>;
 
-    public wrapResolve(cb: ResolverNextRpCb<TSource, TContext>, wrapperName?: string): Resolver<TSource, TContext>;
+  public wrapResolve(
+    cb: ResolverNextRpCb<TSource, TContext>,
+    wrapperName?: string,
+  ): Resolver<TSource, TContext>;
 
-    public wrapArgs(cb: ResolverWrapArgsCb, wrapperName?: string): Resolver<TSource, TContext>;
+  public wrapArgs(
+    cb: ResolverWrapArgsCb,
+    wrapperName?: string,
+  ): Resolver<TSource, TContext>;
 
-    public wrapCloneArg(argName: string, newTypeName: string): Resolver<TSource, TContext>;
+  public wrapCloneArg(
+    argName: string,
+    newTypeName: string,
+  ): Resolver<TSource, TContext>;
 
-    public wrapType(cb: ResolverWrapTypeCb, wrapperName?: string): Resolver<TSource, TContext>;
+  public wrapType(
+    cb: ResolverWrapTypeCb,
+    wrapperName?: string,
+  ): Resolver<TSource, TContext>;
 
-    // -----------------------------------------------
-    // Misc methods
-    // -----------------------------------------------
+  // -----------------------------------------------
+  // Misc methods
+  // -----------------------------------------------
 
-    public getFieldConfig(opts?: { projection?: ProjectionType }): GraphQLFieldConfig<TSource, TContext>;
+  public getFieldConfig(opts?: {
+    projection?: ProjectionType;
+  }): GraphQLFieldConfig<TSource, TContext>;
 
-    public getKind(): ResolverKinds | null;
+  public getKind(): ResolverKinds | null;
 
-    public setKind(kind: string): this;
+  public setKind(kind: string): this;
 
-    public getDescription(): string | null;
+  public getDescription(): string | null;
 
-    public setDescription(description: string): this;
+  public setDescription(description: string): this;
 
-    public get(path: string | string[]): any;
+  public get(path: string | string[]): any;
 
-    public clone(opts?: ResolverOpts<TSource, TContext>): Resolver<TSource, TContext>;
+  public clone(
+    opts?: ResolverOpts<TSource, TContext>,
+  ): Resolver<TSource, TContext>;
 
-    // -----------------------------------------------
-    // Debug methods
-    // -----------------------------------------------
+  // -----------------------------------------------
+  // Debug methods
+  // -----------------------------------------------
 
-    public getNestedName(): string;
+  public getNestedName(): string;
 
-    public toString(colors?: boolean): string;
+  public toString(colors?: boolean): string;
 
-    public setDisplayName(name: string): this;
+  public setDisplayName(name: string): this;
 
-    public toDebugStructure(colors?: boolean): object;
+  public toDebugStructure(colors?: boolean): object;
 
-    public debugExecTime(): Resolver<TSource, TContext>;
+  public debugExecTime(): Resolver<TSource, TContext>;
 
-    public debugParams(filterPaths: (string | string[]) | null, opts?: ResolveDebugOpts): Resolver<TSource, TContext>;
+  public debugParams(
+    filterPaths: (string | string[]) | null,
+    opts?: ResolveDebugOpts,
+  ): Resolver<TSource, TContext>;
 
-    public debugPayload(filterPaths: (string | string[]) | null, opts?: ResolveDebugOpts): Resolver<TSource, TContext>;
+  public debugPayload(
+    filterPaths: (string | string[]) | null,
+    opts?: ResolveDebugOpts,
+  ): Resolver<TSource, TContext>;
 
-    public debug(
-        filterDotPaths?: { params?: (string | string[]), payload?: (string | string[]) },
-        opts?: ResolveDebugOpts): Resolver<TSource, TContext>;
+  public debug(
+    filterDotPaths?: {
+      params?: string | string[];
+      payload?: string | string[];
+    },
+    opts?: ResolveDebugOpts,
+  ): Resolver<TSource, TContext>;
 }

--- a/src/Resolver.d.ts
+++ b/src/Resolver.d.ts
@@ -70,10 +70,10 @@ export type ResolverOpts<TSource, TContext> = {
   parent?: Resolver<TSource, TContext>;
 };
 
-export type ResolverWrapCb<TSource, TContext> = (
-  newResolver: Resolver<TSource, TContext>,
-  prevResolver: Resolver<TSource, TContext>,
-) => Resolver<TSource, TContext>;
+export type ResolverWrapCb<TNewSource, TPrevSource, TContext> = (
+  newResolver: Resolver<TNewSource, TContext>,
+  prevResolver: Resolver<TPrevSource, TContext>,
+) => Resolver<TNewSource, TContext>;
 
 export type ResolverRpCb<TSource, TContext> = (
   resolveParams: Partial<ResolveParams<TSource, TContext>>,
@@ -96,7 +96,7 @@ export type ResolveDebugOpts = {
   colors?: boolean;
 };
 
-export class Resolver<TSource, TContext> {
+export class Resolver<TSource = any, TContext = any> {
   public static schemaComposer: SchemaComposer<any>;
   public schemaComposer: SchemaComposer<any>;
 
@@ -183,32 +183,17 @@ export class Resolver<TSource, TContext> {
   // Wrap methods
   // -----------------------------------------------
 
-  public wrap(
-    cb: ResolverWrapCb<TSource, TContext> | null,
-    newResolverOpts: ResolverOpts<TSource, TContext> | null,
-  ): Resolver<TSource, TContext>;
+  public wrap<TCSource = TSource>(
+    cb?: ResolverWrapCb<TCSource, TSource, TContext>,
+    newResolverOpts?: ResolverOpts<TCSource, TContext>,
+  ): Resolver<TCSource, TContext>;
 
-  public wrap<TSource>(
-    cb: ResolverWrapCb<TSource, TContext> | null,
-    newResolverOpts: ResolverOpts<TSource, TContext> | null,
-  ): Resolver<TSource, TContext>;
-
-  public wrapResolve(
-    cb: ResolverNextRpCb<TSource, TContext>,
+  public wrapResolve<TCSource = TSource>(
+    cb: ResolverNextRpCb<TCSource, TContext>,
     wrapperName?: string,
-  ): Resolver<TSource, TContext>;
-
-  public wrapResolve<TSource>(
-    cb: ResolverNextRpCb<TSource, TContext>,
-    wrapperName?: string,
-  ): Resolver<TSource, TContext>;
+  ): Resolver<TCSource, TContext>;
 
   public wrapArgs(
-    cb: ResolverWrapArgsCb,
-    wrapperName?: string,
-  ): Resolver<TSource, TContext>;
-
-  public wrapArgs<TSource>(
     cb: ResolverWrapArgsCb,
     wrapperName?: string,
   ): Resolver<TSource, TContext>;
@@ -218,17 +203,7 @@ export class Resolver<TSource, TContext> {
     newTypeName: string,
   ): Resolver<TSource, TContext>;
 
-  public wrapCloneArg<TSource>(
-    argName: string,
-    newTypeName: string,
-  ): Resolver<TSource, TContext>;
-
   public wrapType(
-    cb: ResolverWrapTypeCb,
-    wrapperName?: string,
-  ): Resolver<TSource, TContext>;
-
-  public wrapType<TSource>(
     cb: ResolverWrapTypeCb,
     wrapperName?: string,
   ): Resolver<TSource, TContext>;
@@ -251,13 +226,9 @@ export class Resolver<TSource, TContext> {
 
   public get(path: string | string[]): any;
 
-  public clone(
+  public clone<TCloneSource = TSource>(
     opts?: ResolverOpts<TSource, TContext>,
-  ): Resolver<TSource, TContext>;
-
-  public clone<TSource>(
-    opts?: ResolverOpts<TSource, TContext>,
-  ): Resolver<TSource, TContext>;
+  ): Resolver<TCloneSource, TContext>;
 
   // -----------------------------------------------
   // Debug methods

--- a/src/Resolver.d.ts
+++ b/src/Resolver.d.ts
@@ -1,6 +1,6 @@
 import {
     GraphQLFieldConfig, GraphQLFieldConfigArgumentMap, GraphQLInputType, GraphQLOutputType, GraphQLArgumentConfig
-} from './graphql';
+} from 'graphql';
 import * as graphql from './graphql';
 import { SchemaComposer } from './SchemaComposer';
 import {
@@ -97,7 +97,7 @@ export class Resolver<TSource, TContext> {
 
     public getType(): GraphQLOutputType;
 
-    public getTypeComposer(): TypeComposer<TContext>;
+    public getTypeComposer(): TypeComposer<TSource, TContext>;
 
     public setType(gqType: ComposeOutputType<TContext>): this;
 

--- a/src/SchemaComposer.d.ts
+++ b/src/SchemaComposer.d.ts
@@ -8,7 +8,7 @@ import { InterfaceTypeComposer } from './InterfaceTypeComposer';
 import { Resolver } from './Resolver';
 
 type MustHaveTypes<TContext> =
-  | TypeComposer<TContext>
+  | TypeComposer<any, TContext>
   | InputTypeComposer
   | EnumTypeComposer
   | InterfaceTypeComposer<TContext>
@@ -28,30 +28,30 @@ export class SchemaComposer<TContext> extends TypeStorage<TContext> {
   public InterfaceTypeComposer: typeof InterfaceTypeComposer;
   public Resolver: typeof Resolver;
 
-  public Query: TypeComposer<TContext>;
-  public Mutation: TypeComposer<TContext>;
-  public Subscription: TypeComposer<TContext>;
+  public Query: TypeComposer<any, TContext>;
+  public Mutation: TypeComposer<any, TContext>;
+  public Subscription: TypeComposer<any, TContext>;
 
   protected _schemaMustHaveTypes: Array<MustHaveTypes<TContext>>;
 
   public constructor();
 
-  public rootQuery(): TypeComposer<TContext>;
+  public rootQuery<TRootQuery>(): TypeComposer<TRootQuery, TContext>;
 
-  public rootMutation(): TypeComposer<TContext>;
+  public rootMutation<TRootMutation>(): TypeComposer<TRootMutation, TContext>;
 
-  public rootSubscription(): TypeComposer<TContext>;
+  public rootSubscription<TRootSubscription>(): TypeComposer<TRootSubscription, TContext>;
 
   public buildSchema(extraConfig?: ExtraSchemaConfig): GraphQLSchema;
 
   public addSchemaMustHaveType(type: MustHaveTypes<TContext>): this;
 
-  public removeEmptyTypes(typeComposer: TypeComposer<TContext>, passedTypes: Set<string>): void;
+  public removeEmptyTypes<TSource>(typeComposer: TypeComposer<TSource, TContext>, passedTypes: Set<string>): void;
 
-  public getOrCreateTC(
+  public getOrCreateTC<TSource>(
     typeName: string,
-    onCreate?: (tc: TypeComposer<TContext>) => any
-  ): TypeComposer<TContext>;
+    onCreate?: (tc: TypeComposer<TSource, TContext>) => any
+  ): TypeComposer<TSource, TContext>;
 
   public getOrCreateITC(
     typeName: string,

--- a/src/SchemaComposer.d.ts
+++ b/src/SchemaComposer.d.ts
@@ -3,7 +3,7 @@ import {
   GraphQLNamedType,
   GraphQLDirective,
   SchemaDefinitionNode,
-} from './graphql';
+} from 'graphql';
 import { TypeComposer } from './TypeComposer';
 import { InputTypeComposer } from './InputTypeComposer';
 import { TypeStorage } from './TypeStorage';
@@ -41,9 +41,15 @@ export class SchemaComposer<TContext> extends TypeStorage<TContext> {
 
   public constructor();
 
+  public rootQuery(): TypeComposer<any, TContext>;
+
   public rootQuery<TRootQuery>(): TypeComposer<TRootQuery, TContext>;
 
+  public rootMutation(): TypeComposer<any, TContext>;
+
   public rootMutation<TRootMutation>(): TypeComposer<TRootMutation, TContext>;
+
+  public rootSubscription(): TypeComposer<any, TContext>;
 
   public rootSubscription<TRootSubscription>(): TypeComposer<
     TRootSubscription,
@@ -54,10 +60,15 @@ export class SchemaComposer<TContext> extends TypeStorage<TContext> {
 
   public addSchemaMustHaveType(type: MustHaveTypes<TContext>): this;
 
-  public removeEmptyTypes<TSource>(
-    typeComposer: TypeComposer<TSource, TContext>,
+  public removeEmptyTypes(
+    typeComposer: TypeComposer<any, TContext>,
     passedTypes: Set<string>,
   ): void;
+
+  public getOrCreateTC(
+    typeName: string,
+    onCreate?: (tc: TypeComposer<any, TContext>) => any,
+  ): TypeComposer<any, TContext>;
 
   public getOrCreateTC<TSource>(
     typeName: string,

--- a/src/SchemaComposer.d.ts
+++ b/src/SchemaComposer.d.ts
@@ -1,4 +1,9 @@
-import { GraphQLSchema, GraphQLNamedType, GraphQLDirective, SchemaDefinitionNode } from './graphql';
+import {
+  GraphQLSchema,
+  GraphQLNamedType,
+  GraphQLDirective,
+  SchemaDefinitionNode,
+} from './graphql';
 import { TypeComposer } from './TypeComposer';
 import { InputTypeComposer } from './InputTypeComposer';
 import { TypeStorage } from './TypeStorage';
@@ -15,9 +20,9 @@ type MustHaveTypes<TContext> =
   | GraphQLNamedType;
 
 type ExtraSchemaConfig = {
-  types?: GraphQLNamedType[] | null,
-  directives?: GraphQLDirective[] | null,
-  astNode?: SchemaDefinitionNode | null,
+  types?: GraphQLNamedType[] | null;
+  directives?: GraphQLDirective[] | null;
+  astNode?: SchemaDefinitionNode | null;
 };
 
 export class SchemaComposer<TContext> extends TypeStorage<TContext> {
@@ -40,31 +45,37 @@ export class SchemaComposer<TContext> extends TypeStorage<TContext> {
 
   public rootMutation<TRootMutation>(): TypeComposer<TRootMutation, TContext>;
 
-  public rootSubscription<TRootSubscription>(): TypeComposer<TRootSubscription, TContext>;
+  public rootSubscription<TRootSubscription>(): TypeComposer<
+    TRootSubscription,
+    TContext
+  >;
 
   public buildSchema(extraConfig?: ExtraSchemaConfig): GraphQLSchema;
 
   public addSchemaMustHaveType(type: MustHaveTypes<TContext>): this;
 
-  public removeEmptyTypes<TSource>(typeComposer: TypeComposer<TSource, TContext>, passedTypes: Set<string>): void;
+  public removeEmptyTypes<TSource>(
+    typeComposer: TypeComposer<TSource, TContext>,
+    passedTypes: Set<string>,
+  ): void;
 
   public getOrCreateTC<TSource>(
     typeName: string,
-    onCreate?: (tc: TypeComposer<TSource, TContext>) => any
+    onCreate?: (tc: TypeComposer<TSource, TContext>) => any,
   ): TypeComposer<TSource, TContext>;
 
   public getOrCreateITC(
     typeName: string,
-    onCreate?: (itc: InputTypeComposer) => any
+    onCreate?: (itc: InputTypeComposer) => any,
   ): InputTypeComposer;
 
   public getOrCreateETC(
     typeName: string,
-    onCreate?: (etc: EnumTypeComposer) => any
+    onCreate?: (etc: EnumTypeComposer) => any,
   ): EnumTypeComposer;
 
   public getOrCreateIFTC(
     typeName: string,
-    onCreate?: (iftc: InterfaceTypeComposer<TContext>) => any
+    onCreate?: (iftc: InterfaceTypeComposer<TContext>) => any,
   ): InterfaceTypeComposer<TContext>;
 }

--- a/src/SchemaComposer.d.ts
+++ b/src/SchemaComposer.d.ts
@@ -41,17 +41,14 @@ export class SchemaComposer<TContext> extends TypeStorage<TContext> {
 
   public constructor();
 
-  public rootQuery(): TypeComposer<any, TContext>;
+  public rootQuery<TRootQuery = any>(): TypeComposer<TRootQuery, TContext>;
 
-  public rootQuery<TRootQuery>(): TypeComposer<TRootQuery, TContext>;
+  public rootMutation<TRootMutation = any>(): TypeComposer<
+    TRootMutation,
+    TContext
+  >;
 
-  public rootMutation(): TypeComposer<any, TContext>;
-
-  public rootMutation<TRootMutation>(): TypeComposer<TRootMutation, TContext>;
-
-  public rootSubscription(): TypeComposer<any, TContext>;
-
-  public rootSubscription<TRootSubscription>(): TypeComposer<
+  public rootSubscription<TRootSubscription = any>(): TypeComposer<
     TRootSubscription,
     TContext
   >;
@@ -65,12 +62,7 @@ export class SchemaComposer<TContext> extends TypeStorage<TContext> {
     passedTypes: Set<string>,
   ): void;
 
-  public getOrCreateTC(
-    typeName: string,
-    onCreate?: (tc: TypeComposer<any, TContext>) => any,
-  ): TypeComposer<any, TContext>;
-
-  public getOrCreateTC<TSource>(
+  public getOrCreateTC<TSource = any>(
     typeName: string,
     onCreate?: (tc: TypeComposer<TSource, TContext>) => any,
   ): TypeComposer<TSource, TContext>;

--- a/src/TypeComposer.d.ts
+++ b/src/TypeComposer.d.ts
@@ -138,8 +138,8 @@ export type RelationOptsWithResolver<
   TArgs = any
 > = {
   resolver: Thunk<Resolver<TRelationSource, TContext, TArgs>>;
-  prepareArgs?: RelationArgsMapper<TSource, TContext>;
-  projection?: ProjectionType;
+  prepareArgs?: RelationArgsMapper<TSource, TContext, TArgs>;
+  projection?: Partial<ProjectionType<TSource>>;
   description?: string | null;
   deprecationReason?: string | null;
   catchErrors?: boolean;

--- a/src/TypeComposer.d.ts
+++ b/src/TypeComposer.d.ts
@@ -287,7 +287,7 @@ export class TypeComposer<TSource, TContext> {
 
   public setDescription(description: string): this;
 
-  public clone<TCloneSource>(
+  public clone<TCloneSource = any>(
     newTypeName: string,
   ): TypeComposer<TCloneSource, TContext>;
 
@@ -311,24 +311,16 @@ export class TypeComposer<TSource, TContext> {
 
   public hasResolver(name: string): boolean;
 
-  public getResolver(name: string): Resolver<any, TContext>;
-
-  public getResolver<TResolverSource>(
+  public getResolver<TResolverSource = any>(
     name: string,
   ): Resolver<TResolverSource, TContext>;
 
-  public setResolver(name: string, resolver: Resolver<any, TContext>): this;
-
-  public setResolver<TResolverSource>(
+  public setResolver<TResolverSource = any>(
     name: string,
     resolver: Resolver<TResolverSource, TContext>,
   ): this;
 
-  public addResolver(
-    resolver: Resolver<any, TContext> | ResolverOpts<any, TContext>,
-  ): this;
-
-  public addResolver<TResolverSource>(
+  public addResolver<TResolverSource = any>(
     resolver:
       | Resolver<TResolverSource, TContext>
       | ResolverOpts<TResolverSource, TContext>,
@@ -336,34 +328,18 @@ export class TypeComposer<TSource, TContext> {
 
   public removeResolver(resolverName: string): this;
 
-  public wrapResolver(
-    resolverName: string,
-    cbResolver: ResolverWrapCb<any, TContext>,
-  ): this;
-
-  public wrapResolver<TResolverSource>(
+  public wrapResolver<TResolverSource = any>(
     resolverName: string,
     cbResolver: ResolverWrapCb<TResolverSource, TContext>,
   ): this;
 
-  public wrapResolverAs(
-    resolverName: string,
-    fromResolverName: string,
-    cbResolver: ResolverWrapCb<any, TContext>,
-  ): this;
-
-  public wrapResolverAs<TResolverSource>(
+  public wrapResolverAs<TResolverSource = any>(
     resolverName: string,
     fromResolverName: string,
     cbResolver: ResolverWrapCb<TResolverSource, TContext>,
   ): this;
 
-  public wrapResolverResolve(
-    resolverName: string,
-    cbNextRp: ResolverNextRpCb<any, TContext>,
-  ): this;
-
-  public wrapResolverResolve<TResolverSource>(
+  public wrapResolverResolve<TResolverSource = any>(
     resolverName: string,
     cbNextRp: ResolverNextRpCb<TResolverSource, TContext>,
   ): this;
@@ -396,7 +372,7 @@ export class TypeComposer<TSource, TContext> {
   // Misc methods
   // -----------------------------------------------
 
-  public addRelation<TRelationSource>(
+  public addRelation<TRelationSource = any>(
     fieldName: string,
     relationOpts: RelationOpts<TRelationSource, TSource, TContext>,
   ): this;

--- a/src/TypeComposer.d.ts
+++ b/src/TypeComposer.d.ts
@@ -214,29 +214,29 @@ export class TypeComposer<TSource, TContext> {
   /**
    * Add new fields or replace existed in a GraphQL type
    */
-  public addFields<TNewSource>(
-    newFields: ComposeFieldConfigMap<TNewSource, TContext>,
-  ): TypeComposer<TNewSource, TContext>;
+  public addFields(
+    newFields: ComposeFieldConfigMap<TSource, TContext>,
+  ): TypeComposer<TSource, TContext>;
 
   /**
    * Add new fields or replace existed (where field name may have dots)
    */
-  public addNestedFields(newFields: ComposeFieldConfigMap<any, TContext>): this;
+  public addNestedFields(
+    newFields: ComposeFieldConfigMap<TSource, TContext>,
+  ): this;
 
   /**
    * Get fieldConfig by name
    */
-  public getField<TField>(
-    fieldName: string,
-  ): ComposeFieldConfig<TField, TContext>;
+  public getField(fieldName: string): ComposeFieldConfig<TSource, TContext>;
 
-  public removeField<TNewSource>(
+  public removeField(
     fieldNameOrArray: string | string[],
-  ): TypeComposer<TNewSource, TContext>;
+  ): TypeComposer<TSource, TContext>;
 
-  public removeOtherFields<TNewSource>(
+  public removeOtherFields(
     fieldNameOrArray: string | string[],
-  ): TypeComposer<TNewSource, TContext>;
+  ): TypeComposer<TSource, TContext>;
 
   public extendField(
     fieldName: string,
@@ -245,13 +245,11 @@ export class TypeComposer<TSource, TContext> {
 
   public reorderFields(names: string[]): this;
 
-  public getFieldConfig<TField>(
-    fieldName: string,
-  ): GraphQLFieldConfig<TField, TContext>;
+  public getFieldConfig(fieldName: string): GraphQLFieldConfig<any, TContext>;
 
   public getFieldType(fieldName: string): GraphQLOutputType;
 
-  public getFieldTC<TField>(fieldName: string): TypeComposer<TField, TContext>;
+  public getFieldTC(fieldName: string): TypeComposer<TSource, TContext>;
 
   public isFieldNonNull(fieldName: string): boolean;
 
@@ -313,13 +311,13 @@ export class TypeComposer<TSource, TContext> {
 
   public hasResolver(name: string): boolean;
 
-  public getResolver(name: string): Resolver<TSource, TContext>;
+  public getResolver(name: string): Resolver<any, TContext>;
 
   public getResolver<TResolverSource>(
     name: string,
   ): Resolver<TResolverSource, TContext>;
 
-  public setResolver(name: string, resolver: Resolver<TSource, TContext>): this;
+  public setResolver(name: string, resolver: Resolver<any, TContext>): this;
 
   public setResolver<TResolverSource>(
     name: string,
@@ -327,7 +325,7 @@ export class TypeComposer<TSource, TContext> {
   ): this;
 
   public addResolver(
-    resolver: Resolver<TSource, TContext> | ResolverOpts<TSource, TContext>,
+    resolver: Resolver<any, TContext> | ResolverOpts<any, TContext>,
   ): this;
 
   public addResolver<TResolverSource>(
@@ -340,7 +338,7 @@ export class TypeComposer<TSource, TContext> {
 
   public wrapResolver(
     resolverName: string,
-    cbResolver: ResolverWrapCb<TSource, TContext>,
+    cbResolver: ResolverWrapCb<any, TContext>,
   ): this;
 
   public wrapResolver<TResolverSource>(
@@ -351,7 +349,7 @@ export class TypeComposer<TSource, TContext> {
   public wrapResolverAs(
     resolverName: string,
     fromResolverName: string,
-    cbResolver: ResolverWrapCb<TSource, TContext>,
+    cbResolver: ResolverWrapCb<any, TContext>,
   ): this;
 
   public wrapResolverAs<TResolverSource>(
@@ -362,7 +360,7 @@ export class TypeComposer<TSource, TContext> {
 
   public wrapResolverResolve(
     resolverName: string,
-    cbNextRp: ResolverNextRpCb<TSource, TContext>,
+    cbNextRp: ResolverNextRpCb<any, TContext>,
   ): this;
 
   public wrapResolverResolve<TResolverSource>(

--- a/src/TypeComposer.d.ts
+++ b/src/TypeComposer.d.ts
@@ -1,72 +1,91 @@
 import {
-    GraphQLArgumentConfig, GraphQLFieldConfig, GraphQLFieldConfigArgumentMap, GraphQLFieldConfigMap,
-    GraphQLInputObjectType, GraphQLInterfaceType, GraphQLList, GraphQLObjectType, GraphQLInputType,
-    GraphQLOutputType, GraphQLFieldResolver, GraphQLIsTypeOfFn, GraphQLResolveInfo,
-    FieldDefinitionNode, GraphQLNonNull
-} from './graphql';
-import { SchemaComposer } from './SchemaComposer';
-import { InputTypeComposer } from './InputTypeComposer';
+    FieldDefinitionNode,
+    GraphQLArgumentConfig,
+    GraphQLFieldConfig,
+    GraphQLFieldConfigArgumentMap,
+    GraphQLFieldConfigMap,
+    GraphQLFieldResolver,
+    GraphQLInputObjectType,
+    GraphQLInputType,
+    GraphQLInterfaceType,
+    GraphQLIsTypeOfFn,
+    GraphQLList,
+    GraphQLNonNull,
+    GraphQLObjectType,
+    GraphQLOutputType,
+    GraphQLResolveInfo
+} from 'graphql';
 import { EnumTypeComposer } from './EnumTypeComposer';
+import { InputTypeComposer } from './InputTypeComposer';
 import { InterfaceTypeComposer } from './InterfaceTypeComposer';
+import { Resolver, ResolverNextRpCb, ResolverOpts, ResolverWrapCb } from './Resolver';
+import { SchemaComposer } from './SchemaComposer';
 import { TypeAsString } from './TypeMapper';
-import { Resolver, ResolverOpts, ResolverNextRpCb, ResolverWrapCb } from './Resolver';
-import { ProjectionType } from './utils/projection';
 import { GenericMap, ObjMap, Thunk } from './utils/definitions';
+import { ProjectionType } from './utils/projection';
 
-export type GetRecordIdFn<TSource, TContext> = (source: TSource, args: any, context: TContext) => string;
+export type GetRecordIdFn<TSource, TContext> = (
+    source: TSource,
+    args: any,
+    context: TContext
+) => string;
 
 export type GraphQLObjectTypeExtended<TSource, TContext> = GraphQLObjectType & {
-    _gqcInputTypeComposer?: InputTypeComposer,
-    _gqcResolvers?: Map<string, Resolver<TSource, TContext>>,
-    _gqcGetRecordIdFn?: GetRecordIdFn<TSource, TContext>,
-    _gqcRelations?: RelationThunkMap<TSource, TContext>,
-    _gqcFields?: ComposeFieldConfigMap<TSource, TContext>,
-    _gqcInterfaces?: Array<GraphQLInterfaceType | InterfaceTypeComposer<TContext>>,
-    description: string | null,
+    _gqcInputTypeComposer?: InputTypeComposer;
+    _gqcResolvers?: Map<string, Resolver<TSource, TContext>>;
+    _gqcGetRecordIdFn?: GetRecordIdFn<TSource, TContext>;
+    _gqcRelations?: RelationThunkMap<TSource, TContext>;
+    _gqcFields?: ComposeFieldConfigMap<TSource, TContext>;
+    _gqcInterfaces?: Array<GraphQLInterfaceType | InterfaceTypeComposer<TContext>>;
+    description: string | null;
 };
 
 export type ComposeObjectTypeConfig<TSource, TContext> = {
-    name: string,
-    interfaces?: Thunk<GraphQLInterfaceType[] | null>,
-    fields?: Thunk<ComposeFieldConfigMap<TSource, TContext>>,
-    isTypeOf?: GraphQLIsTypeOfFn<TSource, TContext> | null,
-    description?: string | null,
-    isIntrospection?: boolean,
+    name: string;
+    interfaces?: Thunk<GraphQLInterfaceType[] | null>;
+    fields?: Thunk<ComposeFieldConfigMap<TSource, TContext>>;
+    isTypeOf?: GraphQLIsTypeOfFn<TSource, TContext> | null;
+    description?: string | null;
+    isIntrospection?: boolean;
 };
 
 // extended GraphQLFieldConfigMap
-export type ComposeFieldConfigMap<TSource, TContext> = ObjMap<
-    ComposeFieldConfig<TSource, TContext>
->;
+export type ComposeFieldConfigMap<TSource, TContext> = ObjMap<ComposeFieldConfig<TSource, TContext>>;
 
 export type ComposeFieldConfig<TSource, TContext> =
     | ComposeFieldConfigAsObject<TSource, TContext>
     | ComposeOutputType<TContext>
-    | (() => ComposeFieldConfigAsObject<TSource, TContext> | ComposeOutputType<TContext>);
+    | (() =>
+    | ComposeFieldConfigAsObject<TSource, TContext>
+    | ComposeOutputType<TContext>);
 
 // extended GraphQLFieldConfig
-export type GraphqlFieldConfigExtended<TSource, TContext> =
-    GraphQLFieldConfig<TSource, TContext> & { projection?: any };
+export type GraphqlFieldConfigExtended<TSource, TContext> = GraphQLFieldConfig<TSource,
+    TContext> & { projection?: any };
 
 export type ComposeFieldConfigAsObject<TSource, TContext> = {
-    type: Thunk<ComposeOutputType<TContext>> | GraphQLOutputType,
-    args?: ComposeFieldConfigArgumentMap,
-    resolve?: GraphQLFieldResolver<TSource, TContext>,
-    subscribe?: GraphQLFieldResolver<TSource, TContext>,
-    deprecationReason?: string | null,
-    description?: string | null,
-    astNode?: FieldDefinitionNode | null,
-    [key: string]: any,
+    type: Thunk<ComposeOutputType<TContext>> | GraphQLOutputType;
+    args?: ComposeFieldConfigArgumentMap;
+    resolve?: GraphQLFieldResolver<TSource, TContext>;
+    subscribe?: GraphQLFieldResolver<TSource, TContext>;
+    deprecationReason?: string | null;
+    description?: string | null;
+    astNode?: FieldDefinitionNode | null;
+    [ key: string ]: any;
 } & { $call?: void };
 
 // extended GraphQLOutputType
 export type ComposeOutputType<TContext> =
     | GraphQLOutputType
-    | TypeComposer<TContext>
+    | TypeComposer<any, TContext>
     | EnumTypeComposer
     | TypeAsString
     | Resolver<any, TContext>
-    | Array<GraphQLOutputType | TypeComposer<TContext> | EnumTypeComposer | TypeAsString | Resolver<any, TContext>>;
+    | Array<| GraphQLOutputType
+    | TypeComposer<any, TContext>
+    | EnumTypeComposer
+    | TypeAsString
+    | Resolver<any, TContext>>;
 
 // Compose Args -----------------------------
 export type ComposeArgumentType =
@@ -76,21 +95,21 @@ export type ComposeArgumentType =
     | EnumTypeComposer
     | Array<GraphQLInputType | TypeAsString | InputTypeComposer | EnumTypeComposer>;
 export type ComposeArgumentConfigAsObject = {
-    type: Thunk<ComposeArgumentType> | GraphQLInputType,
-    defaultValue?: any,
-    description?: string | null,
+    type: Thunk<ComposeArgumentType> | GraphQLInputType;
+    defaultValue?: any;
+    description?: string | null;
 } & { $call?: void };
 export type ComposeArgumentConfig =
     | ComposeArgumentConfigAsObject
     | ComposeArgumentType
     | (() => ComposeArgumentConfigAsObject | ComposeArgumentType);
 export type ComposeFieldConfigArgumentMap = {
-    [argName: string]: ComposeArgumentConfig,
+    [ argName: string ]: ComposeArgumentConfig;
 };
 
 // RELATION -----------------------------
 export type RelationThunkMap<TSource, TContext> = {
-    [fieldName: string]: Thunk<RelationOpts<TSource, TContext>>,
+    [ fieldName: string ]: Thunk<RelationOpts<TSource, TContext>>;
 };
 
 export type RelationOpts<TSource, TContext> =
@@ -98,106 +117,122 @@ export type RelationOpts<TSource, TContext> =
     | RelationOptsWithFieldConfig<TSource, TContext>;
 
 export type RelationOptsWithResolver<TSource, TContext> = {
-    resolver: Thunk<Resolver<TSource, TContext>>,
-    prepareArgs?: RelationArgsMapper<TSource, TContext>,
-    projection?: ProjectionType,
-    description?: string | null,
-    deprecationReason?: string | null,
-    catchErrors?: boolean,
+    resolver: Thunk<Resolver<TSource, TContext>>;
+    prepareArgs?: RelationArgsMapper<TSource, TContext>;
+    projection?: ProjectionType;
+    description?: string | null;
+    deprecationReason?: string | null;
+    catchErrors?: boolean;
 };
 
-export type RelationOptsWithFieldConfig<TSource, TContext> =
-    ComposeFieldConfigAsObject<TSource, TContext> & { resolve: GraphQLFieldResolver<TSource, TContext> };
+export type RelationOptsWithFieldConfig<TSource,
+    TContext> = ComposeFieldConfigAsObject<TSource, TContext> & {
+    resolve: GraphQLFieldResolver<TSource, TContext>;
+};
 
-export type ArgsType = { [argName: string]: any };
+export type ArgsType = { [ argName: string ]: any };
 
 export type RelationArgsMapperFn<TSource, TContext> = (
     source: TSource,
     args: ArgsType,
     context: TContext,
-    info: GraphQLResolveInfo) => any;
+    info: GraphQLResolveInfo
+) => any;
 
 export type RelationArgsMapper<TSource, TContext> = {
-    [argName: string]: | RelationArgsMapperFn<TSource, TContext>
+    [ argName: string ]:
+        | RelationArgsMapperFn<TSource, TContext>
         | null
         | void
         | string
         | number
         | any[]
-        | GenericMap<any>
+        | GenericMap<any>;
 };
 
-export class TypeComposer<TContext> {
+export class TypeComposer<TSource, TContext> {
     public static schemaComposer: SchemaComposer<any>;
-    public schemaComposer: SchemaComposer<any>;
+    public schemaComposer: SchemaComposer<TContext>;
 
-    protected gqType: GraphQLObjectTypeExtended<any, TContext>;
-    protected _fields: GraphQLFieldConfigMap<any, TContext>;
+    protected gqType: GraphQLObjectTypeExtended<TSource, TContext>;
+    protected _fields: GraphQLFieldConfigMap<TSource, TContext>;
 
     public constructor(gqType: GraphQLObjectType);
 
-    public static create<TCtx>(
-        opts:
-            | TypeAsString
-            | ComposeObjectTypeConfig<any, TCtx>
-            | GraphQLObjectType): TypeComposer<TCtx>;
+    public static create<TSrc, TCtx>(
+        opts: TypeAsString | ComposeObjectTypeConfig<TSrc, TCtx> | GraphQLObjectType
+    ): TypeComposer<TSrc, TCtx>;
 
-    public static createTemp<TCtx>(
-        opts:
-            | TypeAsString
-            | ComposeObjectTypeConfig<any, TCtx>
-            | GraphQLObjectType): TypeComposer<TCtx>;
+    public static createTemp<TSrc, TCtx>(
+        opts: TypeAsString | ComposeObjectTypeConfig<TSrc, TCtx> | GraphQLObjectType
+    ): TypeComposer<TSrc, TCtx>;
 
     // -----------------------------------------------
     // Field methods
     // -----------------------------------------------
 
-    public getFields(): GraphQLFieldConfigMap<any, TContext>;
+    public getFields(): GraphQLFieldConfigMap<TSource, TContext>;
 
     public getFieldNames(): string[];
 
-    public setFields(fields: ComposeFieldConfigMap<any, TContext> | GraphQLFieldConfigMap<any, TContext>): this;
+    public setFields(
+        fields:
+            | ComposeFieldConfigMap<TSource, any>
+            | GraphQLFieldConfigMap<TSource, any>
+    ): this;
 
     public hasField(fieldName: string): boolean;
 
-    public setField<TSource, TContext>(fieldName: string, fieldConfig: ComposeFieldConfig<TSource, TContext>): this;
+    public setField(
+        fieldName: string,
+        fieldConfig: ComposeFieldConfig<TSource, any>
+    ): this;
 
     /**
      * Add new fields or replace existed in a GraphQL type
      */
-    public addFields(newFields: ComposeFieldConfigMap<any, TContext>): this;
+    public addFields(newFields: ComposeFieldConfigMap<TSource, TContext>): this;
 
     /**
      * Add new fields or replace existed (where field name may have dots)
      */
-    public addNestedFields(newFields: ComposeFieldConfigMap<any, TContext>): this;
+    public addNestedFields(
+        newFields: ComposeFieldConfigMap<TSource, TContext>
+    ): this;
 
     /**
      * Get fieldConfig by name
      */
-    public getField(fieldName: string): ComposeFieldConfig<any, TContext>;
+    public getField(fieldName: string): ComposeFieldConfig<TSource, TContext>;
 
     public removeField(fieldNameOrArray: string | string[]): this;
 
     public removeOtherFields(fieldNameOrArray: string | string[]): this;
 
-    public extendField(fieldName: string, parialFieldConfig: ComposeFieldConfig<any, TContext>): this;
+    public extendField(
+        fieldName: string,
+        partialFieldConfig: ComposeFieldConfig<TSource, TContext>
+    ): this;
 
     public reorderFields(names: string[]): this;
 
-    public getFieldConfig(fieldName: string): GraphQLFieldConfig<any, TContext>;
+    public getFieldConfig(
+        fieldName: string
+    ): GraphQLFieldConfig<TSource, TContext>;
 
     public getFieldType(fieldName: string): GraphQLOutputType;
 
-    public getFieldTC(fieldName: string): TypeComposer<TContext>;
+    public getFieldTC(fieldName: string): this;
 
     public isFieldNonNull(fieldName: string): boolean;
 
-    public makeFieldNonNull(fieldNameOrArray: string | string[]): TypeComposer<TContext>;
+    public makeFieldNonNull(fieldNameOrArray: string | string[]): this;
 
-    public makeFieldNullable(fieldNameOrArray: string | string[]): TypeComposer<TContext>;
+    public makeFieldNullable(fieldNameOrArray: string | string[]): this;
 
-    public deprecateFields(fields: { [fieldName: string]: string } | string[] | string): this;
+    public deprecateFields(
+        fields: { [ fieldName: string ]: string } | string[] | string
+    ): this;
 
     public getFieldArgs(fieldName: string): GraphQLFieldConfigArgumentMap;
 
@@ -225,7 +260,9 @@ export class TypeComposer<TContext> {
 
     public setDescription(description: string): this;
 
-    public clone(newTypeName: string): TypeComposer<TContext>;
+    public clone<TCloneSource>(
+        newTypeName: string
+    ): TypeComposer<TCloneSource, TContext>;
 
     // -----------------------------------------------
     // InputType methods
@@ -243,44 +280,66 @@ export class TypeComposer<TContext> {
     // Resolver methods
     // -----------------------------------------------
 
-    public getResolvers(): Map<string, Resolver<any, TContext>>;
+    public getResolvers(): Map<string, Resolver<TSource, TContext>>;
 
     public hasResolver(name: string): boolean;
 
-    public getResolver(name: string): Resolver<any, TContext>;
+    public getResolver(name: string): Resolver<TSource, TContext>;
 
-    public setResolver(name: string, resolver: Resolver<any, TContext>): this;
+    public setResolver(name: string, resolver: Resolver<TSource, TContext>): this;
 
-    public addResolver(resolver: Resolver<any, TContext> | ResolverOpts<any, TContext>): this;
+    public addResolver(
+        resolver: Resolver<TSource, TContext> | ResolverOpts<TSource, TContext>
+    ): this;
 
     public removeResolver(resolverName: string): this;
 
-    public wrapResolver(resolverName: string, cbResolver: ResolverWrapCb<any, TContext>): this;
+    public wrapResolver(
+        resolverName: string,
+        cbResolver: ResolverWrapCb<TSource, TContext>
+    ): this;
 
     public wrapResolverAs(
-      resolverName: string, fromResolverName: string, cbResolver: ResolverWrapCb<any, TContext>): this;
+        resolverName: string,
+        fromResolverName: string,
+        cbResolver: ResolverWrapCb<TSource, TContext>
+    ): this;
 
-    public wrapResolverResolve(resolverName: string, cbNextRp: ResolverNextRpCb<any, TContext>): this;
+    public wrapResolverResolve(
+        resolverName: string,
+        cbNextRp: ResolverNextRpCb<TSource, TContext>
+    ): this;
 
     // -----------------------------------------------
     // Interface methods
     // -----------------------------------------------
 
-    public getInterfaces(): Array<InterfaceTypeComposer<TContext> | GraphQLInterfaceType>;
+    public getInterfaces(): Array<InterfaceTypeComposer<any> | GraphQLInterfaceType>;
 
-    public setInterfaces(interfaces: Array<InterfaceTypeComposer<TContext> | GraphQLInterfaceType>): this;
+    public setInterfaces(
+        interfaces: Array<InterfaceTypeComposer<any> | GraphQLInterfaceType>
+    ): this;
 
-    public hasInterface(interfaceObj: InterfaceTypeComposer<TContext> | GraphQLInterfaceType): boolean;
+    public hasInterface(
+        interfaceObj: InterfaceTypeComposer<any> | GraphQLInterfaceType
+    ): boolean;
 
-    public addInterface(interfaceObj: InterfaceTypeComposer<TContext> | GraphQLInterfaceType): this;
+    public addInterface(
+        interfaceObj: InterfaceTypeComposer<any> | GraphQLInterfaceType
+    ): this;
 
-    public removeInterface(interfaceObj: InterfaceTypeComposer<TContext> | GraphQLInterfaceType): this;
+    public removeInterface(
+        interfaceObj: InterfaceTypeComposer<any> | GraphQLInterfaceType
+    ): this;
 
     // -----------------------------------------------
     // Misc methods
     // -----------------------------------------------
 
-    public addRelation(fieldName: string, relationOpts: RelationOpts<any, TContext>): this;
+    public addRelation<TRelationSource>(
+        fieldName: string,
+        relationOpts: RelationOpts<TRelationSource, TContext>
+    ): this;
 
     public getRelations(): RelationThunkMap<any, TContext>;
 
@@ -288,16 +347,21 @@ export class TypeComposer<TContext> {
 
     public hasRecordIdFn(): boolean;
 
-    public getRecordIdFn(): GetRecordIdFn<any, TContext>;
+    public getRecordIdFn(): GetRecordIdFn<TSource, TContext>;
 
     /**
      * Get function that returns record id, from provided object.
      */
-    public getRecordId(source: any, args: any, context: TContext): string | number;
+    public getRecordId(
+        source: TSource,
+        args: any,
+        context: TContext
+    ): string | number;
 
     public get(path: string | string[]): any;
 
     private _relationWithResolverToFC<TSource>(
         opts: RelationOptsWithResolver<TSource, TContext>,
-        fieldName?: string): ComposeFieldConfigAsObject<TSource, TContext>;
+        fieldName?: string
+    ): ComposeFieldConfigAsObject<TSource, TContext>;
 }

--- a/src/TypeComposer.d.ts
+++ b/src/TypeComposer.d.ts
@@ -167,7 +167,7 @@ export type RelationArgsMapper<TSource, TContext> = {
     | GenericMap<any>;
 };
 
-export class TypeComposer<TSource, TContext> {
+export class TypeComposer<TSource = any, TContext = any> {
   public static schemaComposer: SchemaComposer<any>;
   public schemaComposer: SchemaComposer<TContext>;
 
@@ -176,14 +176,14 @@ export class TypeComposer<TSource, TContext> {
 
   public constructor(gqType: GraphQLObjectType);
 
-  public static create<TSrc, TCtx>(
+  public static create<TSrc = any, TCtx = any>(
     opts:
       | TypeAsString
       | ComposeObjectTypeConfig<TSrc, TCtx>
       | GraphQLObjectType,
   ): TypeComposer<TSrc, TCtx>;
 
-  public static createTemp<TSrc, TCtx>(
+  public static createTemp<TSrc = any, TCtx = any>(
     opts:
       | TypeAsString
       | ComposeObjectTypeConfig<TSrc, TCtx>
@@ -330,13 +330,13 @@ export class TypeComposer<TSource, TContext> {
 
   public wrapResolver<TResolverSource = any>(
     resolverName: string,
-    cbResolver: ResolverWrapCb<TResolverSource, TContext>,
+    cbResolver: ResolverWrapCb<TResolverSource, TSource, TContext>,
   ): this;
 
   public wrapResolverAs<TResolverSource = any>(
     resolverName: string,
     fromResolverName: string,
-    cbResolver: ResolverWrapCb<TResolverSource, TContext>,
+    cbResolver: ResolverWrapCb<TResolverSource, TSource, TContext>,
   ): this;
 
   public wrapResolverResolve<TResolverSource = any>(

--- a/src/TypeComposer.d.ts
+++ b/src/TypeComposer.d.ts
@@ -109,15 +109,15 @@ export type ComposeFieldConfigArgumentMap = {
 
 // RELATION -----------------------------
 export type RelationThunkMap<TSource, TContext> = {
-  [ fieldName: string ]: Thunk<RelationOpts<TSource, TContext>>;
+  [ fieldName: string ]: Thunk<RelationOpts<any, TSource, TContext>>;
 };
 
-export type RelationOpts<TSource, TContext> =
-  | RelationOptsWithResolver<TSource, TContext>
+export type RelationOpts<TRelationSource, TSource, TContext> =
+  | RelationOptsWithResolver<TRelationSource, TSource, TContext>
   | RelationOptsWithFieldConfig<TSource, TContext>;
 
-export type RelationOptsWithResolver<TSource, TContext> = {
-  resolver: Thunk<Resolver<TSource, TContext>>;
+export type RelationOptsWithResolver<TRelationSource, TSource, TContext> = {
+  resolver: Thunk<Resolver<TRelationSource, TContext>>;
   prepareArgs?: RelationArgsMapper<TSource, TContext>;
   projection?: ProjectionType;
   description?: string | null;
@@ -375,7 +375,7 @@ export class TypeComposer<TSource, TContext> {
 
   public addRelation<TRelationSource>(
     fieldName: string,
-    relationOpts: RelationOpts<TRelationSource, TContext>
+    relationOpts: RelationOpts<TRelationSource, TSource, TContext>
   ): this;
 
   public getRelations(): RelationThunkMap<any, TContext>;
@@ -397,8 +397,8 @@ export class TypeComposer<TSource, TContext> {
 
   public get(path: string | string[]): any;
 
-  private _relationWithResolverToFC<TSource>(
-    opts: RelationOptsWithResolver<TSource, TContext>,
+  private _relationWithResolverToFC<TRelationSource>(
+    opts: RelationOptsWithResolver<TRelationSource, TSource, TContext>,
     fieldName?: string
-  ): ComposeFieldConfigAsObject<TSource, TContext>;
+  ): ComposeFieldConfigAsObject<TRelationSource, TContext>;
 }

--- a/src/TypeComposer.d.ts
+++ b/src/TypeComposer.d.ts
@@ -13,12 +13,17 @@ import {
   GraphQLNonNull,
   GraphQLObjectType,
   GraphQLOutputType,
-  GraphQLResolveInfo
+  GraphQLResolveInfo,
 } from 'graphql';
 import { EnumTypeComposer } from './EnumTypeComposer';
 import { InputTypeComposer } from './InputTypeComposer';
 import { InterfaceTypeComposer } from './InterfaceTypeComposer';
-import { Resolver, ResolverNextRpCb, ResolverOpts, ResolverWrapCb } from './Resolver';
+import {
+  Resolver,
+  ResolverNextRpCb,
+  ResolverOpts,
+  ResolverWrapCb,
+} from './Resolver';
 import { SchemaComposer } from './SchemaComposer';
 import { TypeAsString } from './TypeMapper';
 import { GenericMap, ObjMap, Thunk } from './utils/definitions';
@@ -27,7 +32,7 @@ import { ProjectionType } from './utils/projection';
 export type GetRecordIdFn<TSource, TContext> = (
   source: TSource,
   args: any,
-  context: TContext
+  context: TContext,
 ) => string;
 
 export type GraphQLObjectTypeExtended<TSource, TContext> = GraphQLObjectType & {
@@ -36,7 +41,9 @@ export type GraphQLObjectTypeExtended<TSource, TContext> = GraphQLObjectType & {
   _gqcGetRecordIdFn?: GetRecordIdFn<TSource, TContext>;
   _gqcRelations?: RelationThunkMap<TSource, TContext>;
   _gqcFields?: ComposeFieldConfigMap<TSource, TContext>;
-  _gqcInterfaces?: Array<GraphQLInterfaceType | InterfaceTypeComposer<TContext>>;
+  _gqcInterfaces?: Array<
+    GraphQLInterfaceType | InterfaceTypeComposer<TContext>
+  >;
   description: string | null;
 };
 
@@ -50,18 +57,22 @@ export type ComposeObjectTypeConfig<TSource, TContext> = {
 };
 
 // extended GraphQLFieldConfigMap
-export type ComposeFieldConfigMap<TSource, TContext> = ObjMap<ComposeFieldConfig<TSource, TContext>>;
+export type ComposeFieldConfigMap<TSource, TContext> = ObjMap<
+  ComposeFieldConfig<TSource, TContext>
+>;
 
 export type ComposeFieldConfig<TSource, TContext> =
   | ComposeFieldConfigAsObject<TSource, TContext>
   | ComposeOutputType<TContext>
   | (() =>
-  | ComposeFieldConfigAsObject<TSource, TContext>
-  | ComposeOutputType<TContext>);
+      | ComposeFieldConfigAsObject<TSource, TContext>
+      | ComposeOutputType<TContext>);
 
 // extended GraphQLFieldConfig
-export type GraphqlFieldConfigExtended<TSource, TContext> = GraphQLFieldConfig<TSource,
-  TContext> & { projection?: any };
+export type GraphqlFieldConfigExtended<TSource, TContext> = GraphQLFieldConfig<
+  TSource,
+  TContext
+> & { projection?: any };
 
 export type ComposeFieldConfigAsObject<TSource, TContext> = {
   type: Thunk<ComposeOutputType<TContext>> | GraphQLOutputType;
@@ -71,7 +82,7 @@ export type ComposeFieldConfigAsObject<TSource, TContext> = {
   deprecationReason?: string | null;
   description?: string | null;
   astNode?: FieldDefinitionNode | null;
-  [ key: string ]: any;
+  [key: string]: any;
 } & { $call?: void };
 
 // extended GraphQLOutputType
@@ -81,11 +92,13 @@ export type ComposeOutputType<TContext> =
   | EnumTypeComposer
   | TypeAsString
   | Resolver<any, TContext>
-  | Array<| GraphQLOutputType
-  | TypeComposer<any, TContext>
-  | EnumTypeComposer
-  | TypeAsString
-  | Resolver<any, TContext>>;
+  | Array<
+      | GraphQLOutputType
+      | TypeComposer<any, TContext>
+      | EnumTypeComposer
+      | TypeAsString
+      | Resolver<any, TContext>
+    >;
 
 // Compose Args -----------------------------
 export type ComposeArgumentType =
@@ -93,7 +106,9 @@ export type ComposeArgumentType =
   | TypeAsString
   | InputTypeComposer
   | EnumTypeComposer
-  | Array<GraphQLInputType | TypeAsString | InputTypeComposer | EnumTypeComposer>;
+  | Array<
+      GraphQLInputType | TypeAsString | InputTypeComposer | EnumTypeComposer
+    >;
 export type ComposeArgumentConfigAsObject = {
   type: Thunk<ComposeArgumentType> | GraphQLInputType;
   defaultValue?: any;
@@ -104,12 +119,12 @@ export type ComposeArgumentConfig =
   | ComposeArgumentType
   | (() => ComposeArgumentConfigAsObject | ComposeArgumentType);
 export type ComposeFieldConfigArgumentMap = {
-  [ argName: string ]: ComposeArgumentConfig;
+  [argName: string]: ComposeArgumentConfig;
 };
 
 // RELATION -----------------------------
 export type RelationThunkMap<TSource, TContext> = {
-  [ fieldName: string ]: Thunk<RelationOpts<any, TSource, TContext>>;
+  [fieldName: string]: Thunk<RelationOpts<any, TSource, TContext>>;
 };
 
 export type RelationOpts<TRelationSource, TSource, TContext> =
@@ -125,22 +140,24 @@ export type RelationOptsWithResolver<TRelationSource, TSource, TContext> = {
   catchErrors?: boolean;
 };
 
-export type RelationOptsWithFieldConfig<TSource,
-  TContext> = ComposeFieldConfigAsObject<TSource, TContext> & {
+export type RelationOptsWithFieldConfig<
+  TSource,
+  TContext
+> = ComposeFieldConfigAsObject<TSource, TContext> & {
   resolve: GraphQLFieldResolver<TSource, TContext>;
 };
 
-export type ArgsType = { [ argName: string ]: any };
+export type ArgsType = { [argName: string]: any };
 
 export type RelationArgsMapperFn<TSource, TContext> = (
   source: TSource,
   args: ArgsType,
   context: TContext,
-  info: GraphQLResolveInfo
+  info: GraphQLResolveInfo,
 ) => any;
 
 export type RelationArgsMapper<TSource, TContext> = {
-  [ argName: string ]:
+  [argName: string]:
     | RelationArgsMapperFn<TSource, TContext>
     | null
     | void
@@ -160,11 +177,17 @@ export class TypeComposer<TSource, TContext> {
   public constructor(gqType: GraphQLObjectType);
 
   public static create<TSrc, TCtx>(
-    opts: TypeAsString | ComposeObjectTypeConfig<TSrc, TCtx> | GraphQLObjectType
+    opts:
+      | TypeAsString
+      | ComposeObjectTypeConfig<TSrc, TCtx>
+      | GraphQLObjectType,
   ): TypeComposer<TSrc, TCtx>;
 
   public static createTemp<TSrc, TCtx>(
-    opts: TypeAsString | ComposeObjectTypeConfig<TSrc, TCtx> | GraphQLObjectType
+    opts:
+      | TypeAsString
+      | ComposeObjectTypeConfig<TSrc, TCtx>
+      | GraphQLObjectType,
   ): TypeComposer<TSrc, TCtx>;
 
   // -----------------------------------------------
@@ -178,21 +201,21 @@ export class TypeComposer<TSource, TContext> {
   public setFields(
     fields:
       | ComposeFieldConfigMap<TSource, TContext>
-      | GraphQLFieldConfigMap<TSource, TContext>
+      | GraphQLFieldConfigMap<TSource, TContext>,
   ): this;
 
   public hasField(fieldName: string): boolean;
 
   public setField(
     fieldName: string,
-    fieldConfig: ComposeFieldConfig<TSource, TContext>
+    fieldConfig: ComposeFieldConfig<TSource, TContext>,
   ): this;
 
   /**
    * Add new fields or replace existed in a GraphQL type
    */
   public addFields<TNewSource>(
-    newFields: ComposeFieldConfigMap<TNewSource, TContext>
+    newFields: ComposeFieldConfigMap<TNewSource, TContext>,
   ): TypeComposer<TNewSource, TContext>;
 
   /**
@@ -204,26 +227,26 @@ export class TypeComposer<TSource, TContext> {
    * Get fieldConfig by name
    */
   public getField<TField>(
-    fieldName: string
+    fieldName: string,
   ): ComposeFieldConfig<TField, TContext>;
 
   public removeField<TNewSource>(
-    fieldNameOrArray: string | string[]
+    fieldNameOrArray: string | string[],
   ): TypeComposer<TNewSource, TContext>;
 
   public removeOtherFields<TNewSource>(
-    fieldNameOrArray: string | string[]
+    fieldNameOrArray: string | string[],
   ): TypeComposer<TNewSource, TContext>;
 
   public extendField(
     fieldName: string,
-    partialFieldConfig: ComposeFieldConfig<any, TContext>
+    partialFieldConfig: ComposeFieldConfig<any, TContext>,
   ): this;
 
   public reorderFields(names: string[]): this;
 
   public getFieldConfig<TField>(
-    fieldName: string
+    fieldName: string,
   ): GraphQLFieldConfig<TField, TContext>;
 
   public getFieldType(fieldName: string): GraphQLOutputType;
@@ -237,7 +260,7 @@ export class TypeComposer<TSource, TContext> {
   public makeFieldNullable(fieldNameOrArray: string | string[]): this;
 
   public deprecateFields(
-    fields: { [ fieldName: string ]: string } | string[] | string
+    fields: { [fieldName: string]: string } | string[] | string,
   ): this;
 
   public getFieldArgs(fieldName: string): GraphQLFieldConfigArgumentMap;
@@ -267,7 +290,7 @@ export class TypeComposer<TSource, TContext> {
   public setDescription(description: string): this;
 
   public clone<TCloneSource>(
-    newTypeName: string
+    newTypeName: string,
   ): TypeComposer<TCloneSource, TContext>;
 
   // -----------------------------------------------
@@ -293,80 +316,82 @@ export class TypeComposer<TSource, TContext> {
   public getResolver(name: string): Resolver<TSource, TContext>;
 
   public getResolver<TResolverSource>(
-    name: string
+    name: string,
   ): Resolver<TResolverSource, TContext>;
 
   public setResolver(name: string, resolver: Resolver<TSource, TContext>): this;
 
   public setResolver<TResolverSource>(
     name: string,
-    resolver: Resolver<TResolverSource, TContext>
+    resolver: Resolver<TResolverSource, TContext>,
   ): this;
 
   public addResolver(
-    resolver: Resolver<TSource, TContext> | ResolverOpts<TSource, TContext>
+    resolver: Resolver<TSource, TContext> | ResolverOpts<TSource, TContext>,
   ): this;
 
   public addResolver<TResolverSource>(
     resolver:
       | Resolver<TResolverSource, TContext>
-      | ResolverOpts<TResolverSource, TContext>
+      | ResolverOpts<TResolverSource, TContext>,
   ): this;
 
   public removeResolver(resolverName: string): this;
 
   public wrapResolver(
     resolverName: string,
-    cbResolver: ResolverWrapCb<TSource, TContext>
+    cbResolver: ResolverWrapCb<TSource, TContext>,
   ): this;
 
   public wrapResolver<TResolverSource>(
     resolverName: string,
-    cbResolver: ResolverWrapCb<TResolverSource, TContext>
+    cbResolver: ResolverWrapCb<TResolverSource, TContext>,
   ): this;
 
   public wrapResolverAs(
     resolverName: string,
     fromResolverName: string,
-    cbResolver: ResolverWrapCb<TSource, TContext>
+    cbResolver: ResolverWrapCb<TSource, TContext>,
   ): this;
 
   public wrapResolverAs<TResolverSource>(
     resolverName: string,
     fromResolverName: string,
-    cbResolver: ResolverWrapCb<TResolverSource, TContext>
+    cbResolver: ResolverWrapCb<TResolverSource, TContext>,
   ): this;
 
   public wrapResolverResolve(
     resolverName: string,
-    cbNextRp: ResolverNextRpCb<TSource, TContext>
+    cbNextRp: ResolverNextRpCb<TSource, TContext>,
   ): this;
 
   public wrapResolverResolve<TResolverSource>(
     resolverName: string,
-    cbNextRp: ResolverNextRpCb<TResolverSource, TContext>
+    cbNextRp: ResolverNextRpCb<TResolverSource, TContext>,
   ): this;
 
   // -----------------------------------------------
   // Interface methods
   // -----------------------------------------------
 
-  public getInterfaces(): Array<InterfaceTypeComposer<any> | GraphQLInterfaceType>;
+  public getInterfaces(): Array<
+    InterfaceTypeComposer<any> | GraphQLInterfaceType
+  >;
 
   public setInterfaces(
-    interfaces: Array<InterfaceTypeComposer<any> | GraphQLInterfaceType>
+    interfaces: Array<InterfaceTypeComposer<any> | GraphQLInterfaceType>,
   ): this;
 
   public hasInterface(
-    interfaceObj: InterfaceTypeComposer<any> | GraphQLInterfaceType
+    interfaceObj: InterfaceTypeComposer<any> | GraphQLInterfaceType,
   ): boolean;
 
   public addInterface(
-    interfaceObj: InterfaceTypeComposer<any> | GraphQLInterfaceType
+    interfaceObj: InterfaceTypeComposer<any> | GraphQLInterfaceType,
   ): this;
 
   public removeInterface(
-    interfaceObj: InterfaceTypeComposer<any> | GraphQLInterfaceType
+    interfaceObj: InterfaceTypeComposer<any> | GraphQLInterfaceType,
   ): this;
 
   // -----------------------------------------------
@@ -375,7 +400,7 @@ export class TypeComposer<TSource, TContext> {
 
   public addRelation<TRelationSource>(
     fieldName: string,
-    relationOpts: RelationOpts<TRelationSource, TSource, TContext>
+    relationOpts: RelationOpts<TRelationSource, TSource, TContext>,
   ): this;
 
   public getRelations(): RelationThunkMap<any, TContext>;
@@ -392,13 +417,13 @@ export class TypeComposer<TSource, TContext> {
   public getRecordId(
     source: TSource,
     args: any,
-    context: TContext
+    context: TContext,
   ): string | number;
 
   public get(path: string | string[]): any;
 
   private _relationWithResolverToFC<TRelationSource>(
     opts: RelationOptsWithResolver<TRelationSource, TSource, TContext>,
-    fieldName?: string
+    fieldName?: string,
   ): ComposeFieldConfigAsObject<TRelationSource, TContext>;
 }

--- a/src/TypeComposer.d.ts
+++ b/src/TypeComposer.d.ts
@@ -1,19 +1,19 @@
 import {
-    FieldDefinitionNode,
-    GraphQLArgumentConfig,
-    GraphQLFieldConfig,
-    GraphQLFieldConfigArgumentMap,
-    GraphQLFieldConfigMap,
-    GraphQLFieldResolver,
-    GraphQLInputObjectType,
-    GraphQLInputType,
-    GraphQLInterfaceType,
-    GraphQLIsTypeOfFn,
-    GraphQLList,
-    GraphQLNonNull,
-    GraphQLObjectType,
-    GraphQLOutputType,
-    GraphQLResolveInfo
+  FieldDefinitionNode,
+  GraphQLArgumentConfig,
+  GraphQLFieldConfig,
+  GraphQLFieldConfigArgumentMap,
+  GraphQLFieldConfigMap,
+  GraphQLFieldResolver,
+  GraphQLInputObjectType,
+  GraphQLInputType,
+  GraphQLInterfaceType,
+  GraphQLIsTypeOfFn,
+  GraphQLList,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLOutputType,
+  GraphQLResolveInfo
 } from 'graphql';
 import { EnumTypeComposer } from './EnumTypeComposer';
 import { InputTypeComposer } from './InputTypeComposer';
@@ -25,343 +25,380 @@ import { GenericMap, ObjMap, Thunk } from './utils/definitions';
 import { ProjectionType } from './utils/projection';
 
 export type GetRecordIdFn<TSource, TContext> = (
-    source: TSource,
-    args: any,
-    context: TContext
+  source: TSource,
+  args: any,
+  context: TContext
 ) => string;
 
 export type GraphQLObjectTypeExtended<TSource, TContext> = GraphQLObjectType & {
-    _gqcInputTypeComposer?: InputTypeComposer;
-    _gqcResolvers?: Map<string, Resolver<TSource, TContext>>;
-    _gqcGetRecordIdFn?: GetRecordIdFn<TSource, TContext>;
-    _gqcRelations?: RelationThunkMap<TSource, TContext>;
-    _gqcFields?: ComposeFieldConfigMap<TSource, TContext>;
-    _gqcInterfaces?: Array<GraphQLInterfaceType | InterfaceTypeComposer<TContext>>;
-    description: string | null;
+  _gqcInputTypeComposer?: InputTypeComposer;
+  _gqcResolvers?: Map<string, Resolver<TSource, TContext>>;
+  _gqcGetRecordIdFn?: GetRecordIdFn<TSource, TContext>;
+  _gqcRelations?: RelationThunkMap<TSource, TContext>;
+  _gqcFields?: ComposeFieldConfigMap<TSource, TContext>;
+  _gqcInterfaces?: Array<GraphQLInterfaceType | InterfaceTypeComposer<TContext>>;
+  description: string | null;
 };
 
 export type ComposeObjectTypeConfig<TSource, TContext> = {
-    name: string;
-    interfaces?: Thunk<GraphQLInterfaceType[] | null>;
-    fields?: Thunk<ComposeFieldConfigMap<TSource, TContext>>;
-    isTypeOf?: GraphQLIsTypeOfFn<TSource, TContext> | null;
-    description?: string | null;
-    isIntrospection?: boolean;
+  name: string;
+  interfaces?: Thunk<GraphQLInterfaceType[] | null>;
+  fields?: Thunk<ComposeFieldConfigMap<TSource, TContext>>;
+  isTypeOf?: GraphQLIsTypeOfFn<TSource, TContext> | null;
+  description?: string | null;
+  isIntrospection?: boolean;
 };
 
 // extended GraphQLFieldConfigMap
 export type ComposeFieldConfigMap<TSource, TContext> = ObjMap<ComposeFieldConfig<TSource, TContext>>;
 
 export type ComposeFieldConfig<TSource, TContext> =
-    | ComposeFieldConfigAsObject<TSource, TContext>
-    | ComposeOutputType<TContext>
-    | (() =>
-    | ComposeFieldConfigAsObject<TSource, TContext>
-    | ComposeOutputType<TContext>);
+  | ComposeFieldConfigAsObject<TSource, TContext>
+  | ComposeOutputType<TContext>
+  | (() =>
+  | ComposeFieldConfigAsObject<TSource, TContext>
+  | ComposeOutputType<TContext>);
 
 // extended GraphQLFieldConfig
 export type GraphqlFieldConfigExtended<TSource, TContext> = GraphQLFieldConfig<TSource,
-    TContext> & { projection?: any };
+  TContext> & { projection?: any };
 
 export type ComposeFieldConfigAsObject<TSource, TContext> = {
-    type: Thunk<ComposeOutputType<TContext>> | GraphQLOutputType;
-    args?: ComposeFieldConfigArgumentMap;
-    resolve?: GraphQLFieldResolver<TSource, TContext>;
-    subscribe?: GraphQLFieldResolver<TSource, TContext>;
-    deprecationReason?: string | null;
-    description?: string | null;
-    astNode?: FieldDefinitionNode | null;
-    [ key: string ]: any;
+  type: Thunk<ComposeOutputType<TContext>> | GraphQLOutputType;
+  args?: ComposeFieldConfigArgumentMap;
+  resolve?: GraphQLFieldResolver<TSource, TContext>;
+  subscribe?: GraphQLFieldResolver<TSource, TContext>;
+  deprecationReason?: string | null;
+  description?: string | null;
+  astNode?: FieldDefinitionNode | null;
+  [ key: string ]: any;
 } & { $call?: void };
 
 // extended GraphQLOutputType
 export type ComposeOutputType<TContext> =
-    | GraphQLOutputType
-    | TypeComposer<any, TContext>
-    | EnumTypeComposer
-    | TypeAsString
-    | Resolver<any, TContext>
-    | Array<| GraphQLOutputType
-    | TypeComposer<any, TContext>
-    | EnumTypeComposer
-    | TypeAsString
-    | Resolver<any, TContext>>;
+  | GraphQLOutputType
+  | TypeComposer<any, TContext>
+  | EnumTypeComposer
+  | TypeAsString
+  | Resolver<any, TContext>
+  | Array<| GraphQLOutputType
+  | TypeComposer<any, TContext>
+  | EnumTypeComposer
+  | TypeAsString
+  | Resolver<any, TContext>>;
 
 // Compose Args -----------------------------
 export type ComposeArgumentType =
-    | GraphQLInputType
-    | TypeAsString
-    | InputTypeComposer
-    | EnumTypeComposer
-    | Array<GraphQLInputType | TypeAsString | InputTypeComposer | EnumTypeComposer>;
+  | GraphQLInputType
+  | TypeAsString
+  | InputTypeComposer
+  | EnumTypeComposer
+  | Array<GraphQLInputType | TypeAsString | InputTypeComposer | EnumTypeComposer>;
 export type ComposeArgumentConfigAsObject = {
-    type: Thunk<ComposeArgumentType> | GraphQLInputType;
-    defaultValue?: any;
-    description?: string | null;
+  type: Thunk<ComposeArgumentType> | GraphQLInputType;
+  defaultValue?: any;
+  description?: string | null;
 } & { $call?: void };
 export type ComposeArgumentConfig =
-    | ComposeArgumentConfigAsObject
-    | ComposeArgumentType
-    | (() => ComposeArgumentConfigAsObject | ComposeArgumentType);
+  | ComposeArgumentConfigAsObject
+  | ComposeArgumentType
+  | (() => ComposeArgumentConfigAsObject | ComposeArgumentType);
 export type ComposeFieldConfigArgumentMap = {
-    [ argName: string ]: ComposeArgumentConfig;
+  [ argName: string ]: ComposeArgumentConfig;
 };
 
 // RELATION -----------------------------
 export type RelationThunkMap<TSource, TContext> = {
-    [ fieldName: string ]: Thunk<RelationOpts<TSource, TContext>>;
+  [ fieldName: string ]: Thunk<RelationOpts<TSource, TContext>>;
 };
 
 export type RelationOpts<TSource, TContext> =
-    | RelationOptsWithResolver<TSource, TContext>
-    | RelationOptsWithFieldConfig<TSource, TContext>;
+  | RelationOptsWithResolver<TSource, TContext>
+  | RelationOptsWithFieldConfig<TSource, TContext>;
 
 export type RelationOptsWithResolver<TSource, TContext> = {
-    resolver: Thunk<Resolver<TSource, TContext>>;
-    prepareArgs?: RelationArgsMapper<TSource, TContext>;
-    projection?: ProjectionType;
-    description?: string | null;
-    deprecationReason?: string | null;
-    catchErrors?: boolean;
+  resolver: Thunk<Resolver<TSource, TContext>>;
+  prepareArgs?: RelationArgsMapper<TSource, TContext>;
+  projection?: ProjectionType;
+  description?: string | null;
+  deprecationReason?: string | null;
+  catchErrors?: boolean;
 };
 
 export type RelationOptsWithFieldConfig<TSource,
-    TContext> = ComposeFieldConfigAsObject<TSource, TContext> & {
-    resolve: GraphQLFieldResolver<TSource, TContext>;
+  TContext> = ComposeFieldConfigAsObject<TSource, TContext> & {
+  resolve: GraphQLFieldResolver<TSource, TContext>;
 };
 
 export type ArgsType = { [ argName: string ]: any };
 
 export type RelationArgsMapperFn<TSource, TContext> = (
-    source: TSource,
-    args: ArgsType,
-    context: TContext,
-    info: GraphQLResolveInfo
+  source: TSource,
+  args: ArgsType,
+  context: TContext,
+  info: GraphQLResolveInfo
 ) => any;
 
 export type RelationArgsMapper<TSource, TContext> = {
-    [ argName: string ]:
-        | RelationArgsMapperFn<TSource, TContext>
-        | null
-        | void
-        | string
-        | number
-        | any[]
-        | GenericMap<any>;
+  [ argName: string ]:
+    | RelationArgsMapperFn<TSource, TContext>
+    | null
+    | void
+    | string
+    | number
+    | any[]
+    | GenericMap<any>;
 };
 
 export class TypeComposer<TSource, TContext> {
-    public static schemaComposer: SchemaComposer<any>;
-    public schemaComposer: SchemaComposer<TContext>;
+  public static schemaComposer: SchemaComposer<any>;
+  public schemaComposer: SchemaComposer<TContext>;
 
-    protected gqType: GraphQLObjectTypeExtended<TSource, TContext>;
-    protected _fields: GraphQLFieldConfigMap<TSource, TContext>;
+  protected gqType: GraphQLObjectTypeExtended<TSource, TContext>;
+  protected _fields: GraphQLFieldConfigMap<TSource, TContext>;
 
-    public constructor(gqType: GraphQLObjectType);
+  public constructor(gqType: GraphQLObjectType);
 
-    public static create<TSrc, TCtx>(
-        opts: TypeAsString | ComposeObjectTypeConfig<TSrc, TCtx> | GraphQLObjectType
-    ): TypeComposer<TSrc, TCtx>;
+  public static create<TSrc, TCtx>(
+    opts: TypeAsString | ComposeObjectTypeConfig<TSrc, TCtx> | GraphQLObjectType
+  ): TypeComposer<TSrc, TCtx>;
 
-    public static createTemp<TSrc, TCtx>(
-        opts: TypeAsString | ComposeObjectTypeConfig<TSrc, TCtx> | GraphQLObjectType
-    ): TypeComposer<TSrc, TCtx>;
+  public static createTemp<TSrc, TCtx>(
+    opts: TypeAsString | ComposeObjectTypeConfig<TSrc, TCtx> | GraphQLObjectType
+  ): TypeComposer<TSrc, TCtx>;
 
-    // -----------------------------------------------
-    // Field methods
-    // -----------------------------------------------
+  // -----------------------------------------------
+  // Field methods
+  // -----------------------------------------------
 
-    public getFields(): GraphQLFieldConfigMap<TSource, TContext>;
+  public getFields(): GraphQLFieldConfigMap<TSource, TContext>;
 
-    public getFieldNames(): string[];
+  public getFieldNames(): string[];
 
-    public setFields(
-        fields:
-            | ComposeFieldConfigMap<TSource, any>
-            | GraphQLFieldConfigMap<TSource, any>
-    ): this;
+  public setFields(
+    fields:
+      | ComposeFieldConfigMap<TSource, TContext>
+      | GraphQLFieldConfigMap<TSource, TContext>
+  ): this;
 
-    public hasField(fieldName: string): boolean;
+  public hasField(fieldName: string): boolean;
 
-    public setField(
-        fieldName: string,
-        fieldConfig: ComposeFieldConfig<TSource, any>
-    ): this;
+  public setField(
+    fieldName: string,
+    fieldConfig: ComposeFieldConfig<TSource, TContext>
+  ): this;
 
-    /**
-     * Add new fields or replace existed in a GraphQL type
-     */
-    public addFields(newFields: ComposeFieldConfigMap<TSource, TContext>): this;
+  /**
+   * Add new fields or replace existed in a GraphQL type
+   */
+  public addFields<TNewSource>(
+    newFields: ComposeFieldConfigMap<TNewSource, TContext>
+  ): TypeComposer<TNewSource, TContext>;
 
-    /**
-     * Add new fields or replace existed (where field name may have dots)
-     */
-    public addNestedFields(
-        newFields: ComposeFieldConfigMap<TSource, TContext>
-    ): this;
+  /**
+   * Add new fields or replace existed (where field name may have dots)
+   */
+  public addNestedFields(newFields: ComposeFieldConfigMap<any, TContext>): this;
 
-    /**
-     * Get fieldConfig by name
-     */
-    public getField(fieldName: string): ComposeFieldConfig<TSource, TContext>;
+  /**
+   * Get fieldConfig by name
+   */
+  public getField<TField>(
+    fieldName: string
+  ): ComposeFieldConfig<TField, TContext>;
 
-    public removeField(fieldNameOrArray: string | string[]): this;
+  public removeField<TNewSource>(
+    fieldNameOrArray: string | string[]
+  ): TypeComposer<TNewSource, TContext>;
 
-    public removeOtherFields(fieldNameOrArray: string | string[]): this;
+  public removeOtherFields<TNewSource>(
+    fieldNameOrArray: string | string[]
+  ): TypeComposer<TNewSource, TContext>;
 
-    public extendField(
-        fieldName: string,
-        partialFieldConfig: ComposeFieldConfig<TSource, TContext>
-    ): this;
+  public extendField(
+    fieldName: string,
+    partialFieldConfig: ComposeFieldConfig<any, TContext>
+  ): this;
 
-    public reorderFields(names: string[]): this;
+  public reorderFields(names: string[]): this;
 
-    public getFieldConfig(
-        fieldName: string
-    ): GraphQLFieldConfig<TSource, TContext>;
+  public getFieldConfig<TField>(
+    fieldName: string
+  ): GraphQLFieldConfig<TField, TContext>;
 
-    public getFieldType(fieldName: string): GraphQLOutputType;
+  public getFieldType(fieldName: string): GraphQLOutputType;
 
-    public getFieldTC(fieldName: string): this;
+  public getFieldTC<TField>(fieldName: string): TypeComposer<TField, TContext>;
 
-    public isFieldNonNull(fieldName: string): boolean;
+  public isFieldNonNull(fieldName: string): boolean;
 
-    public makeFieldNonNull(fieldNameOrArray: string | string[]): this;
+  public makeFieldNonNull(fieldNameOrArray: string | string[]): this;
 
-    public makeFieldNullable(fieldNameOrArray: string | string[]): this;
+  public makeFieldNullable(fieldNameOrArray: string | string[]): this;
 
-    public deprecateFields(
-        fields: { [ fieldName: string ]: string } | string[] | string
-    ): this;
+  public deprecateFields(
+    fields: { [ fieldName: string ]: string } | string[] | string
+  ): this;
 
-    public getFieldArgs(fieldName: string): GraphQLFieldConfigArgumentMap;
+  public getFieldArgs(fieldName: string): GraphQLFieldConfigArgumentMap;
 
-    public hasFieldArg(fieldName: string, argName: string): boolean;
+  public hasFieldArg(fieldName: string, argName: string): boolean;
 
-    public getFieldArg(fieldName: string, argName: string): GraphQLArgumentConfig;
+  public getFieldArg(fieldName: string, argName: string): GraphQLArgumentConfig;
 
-    public getFieldArgType(fieldName: string, argName: string): GraphQLInputType;
+  public getFieldArgType(fieldName: string, argName: string): GraphQLInputType;
 
-    // -----------------------------------------------
-    // Type methods
-    // -----------------------------------------------
+  // -----------------------------------------------
+  // Type methods
+  // -----------------------------------------------
 
-    public getType(): GraphQLObjectType;
+  public getType(): GraphQLObjectType;
 
-    public getTypePlural(): GraphQLList<GraphQLObjectType>;
+  public getTypePlural(): GraphQLList<GraphQLObjectType>;
 
-    public getTypeNonNull(): GraphQLNonNull<GraphQLObjectType>;
+  public getTypeNonNull(): GraphQLNonNull<GraphQLObjectType>;
 
-    public getTypeName(): string;
+  public getTypeName(): string;
 
-    public setTypeName(name: string): this;
+  public setTypeName(name: string): this;
 
-    public getDescription(): string;
+  public getDescription(): string;
 
-    public setDescription(description: string): this;
+  public setDescription(description: string): this;
 
-    public clone<TCloneSource>(
-        newTypeName: string
-    ): TypeComposer<TCloneSource, TContext>;
+  public clone<TCloneSource>(
+    newTypeName: string
+  ): TypeComposer<TCloneSource, TContext>;
 
-    // -----------------------------------------------
-    // InputType methods
-    // -----------------------------------------------
+  // -----------------------------------------------
+  // InputType methods
+  // -----------------------------------------------
 
-    public getInputType(): GraphQLInputObjectType;
+  public getInputType(): GraphQLInputObjectType;
 
-    public hasInputTypeComposer(): boolean;
+  public hasInputTypeComposer(): boolean;
 
-    public getInputTypeComposer(): InputTypeComposer;
+  public getInputTypeComposer(): InputTypeComposer;
 
-    public getITC(): InputTypeComposer;
+  public getITC(): InputTypeComposer;
 
-    // -----------------------------------------------
-    // Resolver methods
-    // -----------------------------------------------
+  // -----------------------------------------------
+  // Resolver methods
+  // -----------------------------------------------
 
-    public getResolvers(): Map<string, Resolver<TSource, TContext>>;
+  public getResolvers(): Map<string, Resolver<any, TContext>>;
 
-    public hasResolver(name: string): boolean;
+  public hasResolver(name: string): boolean;
 
-    public getResolver(name: string): Resolver<TSource, TContext>;
+  public getResolver(name: string): Resolver<TSource, TContext>;
 
-    public setResolver(name: string, resolver: Resolver<TSource, TContext>): this;
+  public getResolver<TResolverSource>(
+    name: string
+  ): Resolver<TResolverSource, TContext>;
 
-    public addResolver(
-        resolver: Resolver<TSource, TContext> | ResolverOpts<TSource, TContext>
-    ): this;
+  public setResolver(name: string, resolver: Resolver<TSource, TContext>): this;
 
-    public removeResolver(resolverName: string): this;
+  public setResolver<TResolverSource>(
+    name: string,
+    resolver: Resolver<TResolverSource, TContext>
+  ): this;
 
-    public wrapResolver(
-        resolverName: string,
-        cbResolver: ResolverWrapCb<TSource, TContext>
-    ): this;
+  public addResolver(
+    resolver: Resolver<TSource, TContext> | ResolverOpts<TSource, TContext>
+  ): this;
 
-    public wrapResolverAs(
-        resolverName: string,
-        fromResolverName: string,
-        cbResolver: ResolverWrapCb<TSource, TContext>
-    ): this;
+  public addResolver<TResolverSource>(
+    resolver:
+      | Resolver<TResolverSource, TContext>
+      | ResolverOpts<TResolverSource, TContext>
+  ): this;
 
-    public wrapResolverResolve(
-        resolverName: string,
-        cbNextRp: ResolverNextRpCb<TSource, TContext>
-    ): this;
+  public removeResolver(resolverName: string): this;
 
-    // -----------------------------------------------
-    // Interface methods
-    // -----------------------------------------------
+  public wrapResolver(
+    resolverName: string,
+    cbResolver: ResolverWrapCb<TSource, TContext>
+  ): this;
 
-    public getInterfaces(): Array<InterfaceTypeComposer<any> | GraphQLInterfaceType>;
+  public wrapResolver<TResolverSource>(
+    resolverName: string,
+    cbResolver: ResolverWrapCb<TResolverSource, TContext>
+  ): this;
 
-    public setInterfaces(
-        interfaces: Array<InterfaceTypeComposer<any> | GraphQLInterfaceType>
-    ): this;
+  public wrapResolverAs(
+    resolverName: string,
+    fromResolverName: string,
+    cbResolver: ResolverWrapCb<TSource, TContext>
+  ): this;
 
-    public hasInterface(
-        interfaceObj: InterfaceTypeComposer<any> | GraphQLInterfaceType
-    ): boolean;
+  public wrapResolverAs<TResolverSource>(
+    resolverName: string,
+    fromResolverName: string,
+    cbResolver: ResolverWrapCb<TResolverSource, TContext>
+  ): this;
 
-    public addInterface(
-        interfaceObj: InterfaceTypeComposer<any> | GraphQLInterfaceType
-    ): this;
+  public wrapResolverResolve(
+    resolverName: string,
+    cbNextRp: ResolverNextRpCb<TSource, TContext>
+  ): this;
 
-    public removeInterface(
-        interfaceObj: InterfaceTypeComposer<any> | GraphQLInterfaceType
-    ): this;
+  public wrapResolverResolve<TResolverSource>(
+    resolverName: string,
+    cbNextRp: ResolverNextRpCb<TResolverSource, TContext>
+  ): this;
 
-    // -----------------------------------------------
-    // Misc methods
-    // -----------------------------------------------
+  // -----------------------------------------------
+  // Interface methods
+  // -----------------------------------------------
 
-    public addRelation<TRelationSource>(
-        fieldName: string,
-        relationOpts: RelationOpts<TRelationSource, TContext>
-    ): this;
+  public getInterfaces(): Array<InterfaceTypeComposer<any> | GraphQLInterfaceType>;
 
-    public getRelations(): RelationThunkMap<any, TContext>;
+  public setInterfaces(
+    interfaces: Array<InterfaceTypeComposer<any> | GraphQLInterfaceType>
+  ): this;
 
-    public setRecordIdFn(fn: GetRecordIdFn<any, TContext>): this;
+  public hasInterface(
+    interfaceObj: InterfaceTypeComposer<any> | GraphQLInterfaceType
+  ): boolean;
 
-    public hasRecordIdFn(): boolean;
+  public addInterface(
+    interfaceObj: InterfaceTypeComposer<any> | GraphQLInterfaceType
+  ): this;
 
-    public getRecordIdFn(): GetRecordIdFn<TSource, TContext>;
+  public removeInterface(
+    interfaceObj: InterfaceTypeComposer<any> | GraphQLInterfaceType
+  ): this;
 
-    /**
-     * Get function that returns record id, from provided object.
-     */
-    public getRecordId(
-        source: TSource,
-        args: any,
-        context: TContext
-    ): string | number;
+  // -----------------------------------------------
+  // Misc methods
+  // -----------------------------------------------
 
-    public get(path: string | string[]): any;
+  public addRelation<TRelationSource>(
+    fieldName: string,
+    relationOpts: RelationOpts<TRelationSource, TContext>
+  ): this;
 
-    private _relationWithResolverToFC<TSource>(
-        opts: RelationOptsWithResolver<TSource, TContext>,
-        fieldName?: string
-    ): ComposeFieldConfigAsObject<TSource, TContext>;
+  public getRelations(): RelationThunkMap<any, TContext>;
+
+  public setRecordIdFn(fn: GetRecordIdFn<TSource, TContext>): this;
+
+  public hasRecordIdFn(): boolean;
+
+  public getRecordIdFn(): GetRecordIdFn<TSource, TContext>;
+
+  /**
+   * Get function that returns record id, from provided object.
+   */
+  public getRecordId(
+    source: TSource,
+    args: any,
+    context: TContext
+  ): string | number;
+
+  public get(path: string | string[]): any;
+
+  private _relationWithResolverToFC<TSource>(
+    opts: RelationOptsWithResolver<TSource, TContext>,
+    fieldName?: string
+  ): ComposeFieldConfigAsObject<TSource, TContext>;
 }

--- a/src/TypeMapper.d.ts
+++ b/src/TypeMapper.d.ts
@@ -1,74 +1,96 @@
 import {
-    DocumentNode,
-    GraphQLArgumentConfig,
-    GraphQLFieldConfig,
-    GraphQLFieldConfigArgumentMap,
-    GraphQLFieldConfigMap,
-    GraphQLInputFieldConfig,
-    GraphQLInputFieldConfigMap,
-    GraphQLNamedType,
-    GraphQLType
+  DocumentNode,
+  GraphQLArgumentConfig,
+  GraphQLFieldConfig,
+  GraphQLFieldConfigArgumentMap,
+  GraphQLFieldConfigMap,
+  GraphQLInputFieldConfig,
+  GraphQLInputFieldConfigMap,
+  GraphQLNamedType,
+  GraphQLType,
 } from 'graphql';
-import { ComposeInputFieldConfig, ComposeInputFieldConfigMap } from './InputTypeComposer';
 import {
-    ComposeArgumentConfig,
-    ComposeFieldConfig,
-    ComposeFieldConfigArgumentMap,
-    ComposeFieldConfigMap
+  ComposeInputFieldConfig,
+  ComposeInputFieldConfigMap,
+} from './InputTypeComposer';
+import {
+  ComposeArgumentConfig,
+  ComposeFieldConfig,
+  ComposeFieldConfigArgumentMap,
+  ComposeFieldConfigMap,
 } from './TypeComposer';
-import { TypeDefinitionString, TypeNameString, TypeWrappedString } from './TypeMapper';
+import {
+  TypeDefinitionString,
+  TypeNameString,
+  TypeWrappedString,
+} from './TypeMapper';
 import { TypeStorage } from './TypeStorage';
 
 export type TypeDefinitionString = string; // eg. type Name { field: Int }
 export type TypeWrappedString = string; // eg. Int, Int!, [Int]
 export type TypeNameString = string; // eg. Int, Float
-export type TypeAsString = TypeDefinitionString | TypeWrappedString | TypeNameString;
+export type TypeAsString =
+  | TypeDefinitionString
+  | TypeWrappedString
+  | TypeNameString;
 
 declare class TypeMapper {
-    public basicScalars: Map<string, GraphQLNamedType>;
+  public basicScalars: Map<string, GraphQLNamedType>;
 
-    public constructor();
+  public constructor();
 
-    public get(name: string): GraphQLNamedType | null;
+  public get(name: string): GraphQLNamedType | null;
 
-    public set(name: string, type: GraphQLNamedType): void;
+  public set(name: string, type: GraphQLNamedType): void;
 
-    public has(name: string): boolean;
+  public has(name: string): boolean;
 
-    public getWrapped(str: TypeWrappedString | TypeNameString): GraphQLType | null;
+  public getWrapped(
+    str: TypeWrappedString | TypeNameString,
+  ): GraphQLType | null;
 
-    public createType(str: TypeDefinitionString): GraphQLNamedType | null;
+  public createType(str: TypeDefinitionString): GraphQLNamedType | null;
 
-    public parseTypesFromString(str: string): TypeStorage<GraphQLNamedType>;
+  public parseTypesFromString(str: string): TypeStorage<GraphQLNamedType>;
 
-    public parseTypesFromAst(astDocument: DocumentNode): TypeStorage<GraphQLNamedType>;
+  public parseTypesFromAst(
+    astDocument: DocumentNode,
+  ): TypeStorage<GraphQLNamedType>;
 
-    public convertOutputFieldConfig<TSource, TContext>(
-        composeFC: ComposeFieldConfig<TSource, TContext>,
-        fieldName?: string,
-        typeName?: string): GraphQLFieldConfig<TSource, TContext>;
+  public convertOutputFieldConfig<TSource, TContext>(
+    composeFC: ComposeFieldConfig<TSource, TContext>,
+    fieldName?: string,
+    typeName?: string,
+  ): GraphQLFieldConfig<TSource, TContext>;
 
-    public convertOutputFieldConfigMap<TSource, TContext>(
-        composeFields: ComposeFieldConfigMap<TSource, TContext> | GraphQLFieldConfigMap<TSource, TContext>,
-        typeName?: string): GraphQLFieldConfigMap<TSource, TContext>;
+  public convertOutputFieldConfigMap<TSource, TContext>(
+    composeFields:
+      | ComposeFieldConfigMap<TSource, TContext>
+      | GraphQLFieldConfigMap<TSource, TContext>,
+    typeName?: string,
+  ): GraphQLFieldConfigMap<TSource, TContext>;
 
-    public convertArgConfig(
-        composeAC: ComposeArgumentConfig,
-        argName?: string,
-        fieldName?: string,
-        typeName?: string): GraphQLArgumentConfig;
+  public convertArgConfig(
+    composeAC: ComposeArgumentConfig,
+    argName?: string,
+    fieldName?: string,
+    typeName?: string,
+  ): GraphQLArgumentConfig;
 
-    public convertArgConfigMap(
-        composeArgsConfigMap: ComposeFieldConfigArgumentMap,
-        fieldName?: string,
-        typeName?: string): GraphQLFieldConfigArgumentMap;
+  public convertArgConfigMap(
+    composeArgsConfigMap: ComposeFieldConfigArgumentMap,
+    fieldName?: string,
+    typeName?: string,
+  ): GraphQLFieldConfigArgumentMap;
 
-    public convertInputFieldConfig(
-        composeIFC: ComposeInputFieldConfig,
-        fieldName?: string,
-        typeName?: string): GraphQLInputFieldConfig;
+  public convertInputFieldConfig(
+    composeIFC: ComposeInputFieldConfig,
+    fieldName?: string,
+    typeName?: string,
+  ): GraphQLInputFieldConfig;
 
-    public convertInputFieldConfigMap(
-        composeFields: ComposeInputFieldConfigMap,
-        typeName?: string): GraphQLInputFieldConfigMap;
+  public convertInputFieldConfigMap(
+    composeFields: ComposeInputFieldConfigMap,
+    typeName?: string,
+  ): GraphQLInputFieldConfigMap;
 }

--- a/src/TypeMapper.d.ts
+++ b/src/TypeMapper.d.ts
@@ -1,15 +1,23 @@
 import {
-    GraphQLArgumentConfig, GraphQLFieldConfig, GraphQLFieldConfigArgumentMap, GraphQLFieldConfigMap,
-    GraphQLInputFieldConfig, GraphQLInputFieldConfigMap, GraphQLNamedType, GraphQLType, DocumentNode
-} from './graphql';
+    DocumentNode,
+    GraphQLArgumentConfig,
+    GraphQLFieldConfig,
+    GraphQLFieldConfigArgumentMap,
+    GraphQLFieldConfigMap,
+    GraphQLInputFieldConfig,
+    GraphQLInputFieldConfigMap,
+    GraphQLNamedType,
+    GraphQLType
+} from 'graphql';
+import { ComposeInputFieldConfig, ComposeInputFieldConfigMap } from './InputTypeComposer';
 import {
-    ComposeArgumentConfig, ComposeFieldConfig, ComposeFieldConfigArgumentMap,
+    ComposeArgumentConfig,
+    ComposeFieldConfig,
+    ComposeFieldConfigArgumentMap,
     ComposeFieldConfigMap
 } from './TypeComposer';
 import { TypeDefinitionString, TypeNameString, TypeWrappedString } from './TypeMapper';
-import { ComposeInputFieldConfig, ComposeInputFieldConfigMap } from './InputTypeComposer';
 import { TypeStorage } from './TypeStorage';
-import { Thunk } from './utils/definitions';
 
 export type TypeDefinitionString = string; // eg. type Name { field: Int }
 export type TypeWrappedString = string; // eg. Int, Int!, [Int]

--- a/src/TypeMapper.d.ts
+++ b/src/TypeMapper.d.ts
@@ -57,13 +57,13 @@ declare class TypeMapper {
     astDocument: DocumentNode,
   ): TypeStorage<GraphQLNamedType>;
 
-  public convertOutputFieldConfig<TSource, TContext>(
+  public convertOutputFieldConfig<TSource = any, TContext = any>(
     composeFC: ComposeFieldConfig<TSource, TContext>,
     fieldName?: string,
     typeName?: string,
   ): GraphQLFieldConfig<TSource, TContext>;
 
-  public convertOutputFieldConfigMap<TSource, TContext>(
+  public convertOutputFieldConfigMap<TSource = any, TContext = any>(
     composeFields:
       | ComposeFieldConfigMap<TSource, TContext>
       | GraphQLFieldConfigMap<TSource, TContext>,

--- a/src/TypeStorage.d.ts
+++ b/src/TypeStorage.d.ts
@@ -51,7 +51,7 @@ export class TypeStorage<TContext> {
 
   public getTC(typeName: K): TypeComposer<any, TContext>;
 
-  public getTC<TSource>(typeName: K): TypeComposer<TSource, TContext>;
+  public getTC<TSource = any>(typeName: K): TypeComposer<TSource, TContext>;
 
   public getITC(typeName: K): InputTypeComposer;
 

--- a/src/TypeStorage.d.ts
+++ b/src/TypeStorage.d.ts
@@ -1,13 +1,12 @@
-import { GraphQLNamedType, GraphQLScalarType } from './graphql';
-import { TypeComposer } from './TypeComposer';
-import { InputTypeComposer } from './InputTypeComposer';
+import { GraphQLNamedType, GraphQLScalarType } from 'graphql';
 import { EnumTypeComposer } from './EnumTypeComposer';
+import { InputTypeComposer } from './InputTypeComposer';
 import { InterfaceTypeComposer } from './InterfaceTypeComposer';
-import { Resolver } from './Resolver';
+import { TypeComposer } from './TypeComposer';
 
 type K = any;
 type V<TContext> =
-    | TypeComposer<TContext>
+    | TypeComposer<any, TContext>
     | InputTypeComposer
     | EnumTypeComposer
     | InterfaceTypeComposer<TContext>
@@ -44,7 +43,7 @@ export class TypeStorage<TContext> {
 
   public getOrSet(key: K, typeOrThunk: V<TContext> | (() => V<TContext>)): V<TContext>;
 
-  public getTC(typeName: K): TypeComposer<TContext>;
+  public getTC<TSource>(typeName: K): TypeComposer<TSource, TContext>;
 
   public getITC(typeName: K): InputTypeComposer;
 

--- a/src/TypeStorage.d.ts
+++ b/src/TypeStorage.d.ts
@@ -6,12 +6,12 @@ import { TypeComposer } from './TypeComposer';
 
 type K = any;
 type V<TContext> =
-    | TypeComposer<any, TContext>
-    | InputTypeComposer
-    | EnumTypeComposer
-    | InterfaceTypeComposer<TContext>
-    | GraphQLNamedType
-    | GraphQLScalarType;
+  | TypeComposer<any, TContext>
+  | InputTypeComposer
+  | EnumTypeComposer
+  | InterfaceTypeComposer<TContext>
+  | GraphQLNamedType
+  | GraphQLScalarType;
 
 export class TypeStorage<TContext> {
   public types: Map<K, V<TContext>>;
@@ -25,7 +25,10 @@ export class TypeStorage<TContext> {
 
   public entries(): Iterator<[K, V<TContext>]>;
 
-  public forEach(callbackfn: (value: V<TContext>, index: K, map: Map<K, V<TContext>>) => any, thisArg?: any): void;
+  public forEach(
+    callbackfn: (value: V<TContext>, index: K, map: Map<K, V<TContext>>) => any,
+    thisArg?: any,
+  ): void;
 
   public get(key: K): V<TContext>;
 
@@ -41,7 +44,10 @@ export class TypeStorage<TContext> {
 
   public hasInstance(key: K, ClassObj: any): boolean;
 
-  public getOrSet(key: K, typeOrThunk: V<TContext> | (() => V<TContext>)): V<TContext>;
+  public getOrSet(
+    key: K,
+    typeOrThunk: V<TContext> | (() => V<TContext>),
+  ): V<TContext>;
 
   public getTC<TSource>(typeName: K): TypeComposer<TSource, TContext>;
 

--- a/src/TypeStorage.d.ts
+++ b/src/TypeStorage.d.ts
@@ -49,6 +49,8 @@ export class TypeStorage<TContext> {
     typeOrThunk: V<TContext> | (() => V<TContext>),
   ): V<TContext>;
 
+  public getTC(typeName: K): TypeComposer<any, TContext>;
+
   public getTC<TSource>(typeName: K): TypeComposer<TSource, TContext>;
 
   public getITC(typeName: K): InputTypeComposer;

--- a/src/__tests__/typedefs/Others.spec.ts
+++ b/src/__tests__/typedefs/Others.spec.ts
@@ -1,0 +1,4 @@
+import { Post, schemaComposerWithContext } from './mock-typedefs';
+
+// getTC from TypeStorage
+const Post = schemaComposerWithContext.getTC<Post>('Post');

--- a/src/__tests__/typedefs/Resolver.spec.ts
+++ b/src/__tests__/typedefs/Resolver.spec.ts
@@ -55,3 +55,65 @@ findManyPost.wrapResolve(next => rp => {
     rp.source.title = 'A Title';
   }
 });
+
+// args intro
+interface FindManyArtArgs {
+  filter: { id: string; personId: string };
+  skip: number;
+}
+
+const findManyArt1 = new Resolver<any, any, FindManyArtArgs>({
+  resolve: rp => {
+    if (rp.args) {
+      // rp.args.skip = 'dsd';
+      rp.args.skip = 4;
+      rp.args.filter.id = 'string';
+    }
+  },
+});
+
+// all any
+const findManyPost1 = new Resolver({
+  resolve: ({ source, context, args }) => {
+    source.title = 555; // pass as source is any fails
+    source.title = 'A Title';
+
+    if (args) {
+      args.skip = 'hello';
+      args.skip = 4;
+    }
+  },
+});
+
+// inherits findManyArtArgs, can be overwritten
+findManyArt1.wrapResolve<Art, FindManyArtArgs>(next => rp => {
+  if (rp.source && rp.context && rp.args) {
+    // rp.source.id = 'string' fails
+    rp.source.id = 444;
+
+    // rp.args.skip = 'string';
+    rp.args.skip = 4;
+  }
+});
+
+findManyArt1.wrap(
+  (newResolver, prevResolver) => {
+    newResolver.cloneArg('filter', 'AuthorFilterForUsers');
+
+    newResolver
+      .getArgTC('filter')
+      .removeField(['age', 'other_sensetive_filter']);
+
+    return newResolver;
+  },
+  {
+    resolve: ({ source, context, args }) => {
+      if (source && context && args) {
+        // source.id = 'string' fails
+        source.id = 444;
+        // args.skip = 'fails';
+        args.skip = 3;
+      }
+    },
+  },
+);

--- a/src/__tests__/typedefs/Resolver.spec.ts
+++ b/src/__tests__/typedefs/Resolver.spec.ts
@@ -1,0 +1,57 @@
+import { Resolver } from '../../Resolver';
+import { Art, Context, Post } from './mock-typedefs';
+
+const findManyPost = new Resolver<Post, Context>({
+  resolve: rp => {
+    if (rp.source && rp.context) {
+      // rp.source.timestamp = 'fails';
+      rp.source.timestamp = 4;
+      rp.source.author = 'GraphQL superb with Compose';
+    }
+  },
+});
+
+const findOnePostAny = new Resolver({
+  resolve: rp => {
+    if (rp.source && rp.context) {
+      // rp.source.timestamp = 'fails';
+      rp.source.timestamp = 'compose';
+      rp.source.author = 4;
+    }
+  },
+});
+
+// wrap
+const findManyArt = findManyPost.wrap<Art>(
+  (newResolver, prevResolver) => {
+    newResolver.cloneArg('filter', 'AuthorFilterForUsers');
+
+    newResolver
+      .getArgTC('filter')
+      .removeField(['age', 'other_sensetive_filter']);
+
+    return newResolver;
+  },
+  {
+    resolve: ({ source, context }) => {
+      if (source && context) {
+        // source.id = 'string' fails
+        source.id = 444;
+      }
+    },
+  },
+);
+
+findManyArt.wrapResolve(next => rp => {
+  if (rp.source && rp.context) {
+    // rp.source.id = 'string' fails
+    rp.source.id = 444;
+  }
+});
+
+findManyPost.wrapResolve(next => rp => {
+  if (rp.source && rp.context) {
+    // rp.source.title = 555 fails
+    rp.source.title = 'A Title';
+  }
+});

--- a/src/__tests__/typedefs/TypeComposer.spec.ts
+++ b/src/__tests__/typedefs/TypeComposer.spec.ts
@@ -1,41 +1,20 @@
-import { SchemaComposer } from '../index';
-import { TypeComposer } from '../TypeComposer';
-
-// Changes a driven by the quest for better typing and a better Intelisense experience
-// hence boosting productivity
-// The following passed tsCheck
-
-interface DeepOptions {
-  deep1: string;
-  deep2: number;
-}
-
-interface GenericUID {
-  uid: string;
-}
-
-interface Person extends GenericUID {
-  uid: string;
-  name: string;
-  nickName: string;
-  age: number;
-  deep: DeepOptions;
-}
-
-interface Context {
-  req: any;
-  res: any;
-  uid: string;
-}
-
-// works for cases where u create your instance of
-const schemaComposer = new SchemaComposer<Context>();
+import { TypeComposer } from '../../TypeComposer';
 
 // Person from this schemaComposer gets the context defined for that schemaComposer
-const PersonTC2 = schemaComposer.getOrCreateTC<Person>('Person');
+import {
+  Art,
+  Context,
+  DeepOptions,
+  GenericUID,
+  Person,
+  Post,
+  schemaComposerWithContext,
+} from './mock-typedefs';
+
+// I understand the schemaComposers are different, here is just for demos
 
 // create from default schemaComposer uses the context type passed in
-// or uses `any` as type
+// TSource Person, TContext Context
 const PersonTC = TypeComposer.create<Person, Context>({
   name: 'Person',
   fields: {
@@ -45,7 +24,11 @@ const PersonTC = TypeComposer.create<Person, Context>({
   },
 });
 
-// Both PersonTC and PersonTC2 have same TSource and TContext
+// TSource Art, TContext Context
+const ArtTC = schemaComposerWithContext.getOrCreateTC<Art>('Art');
+
+// TSource any, TContext any
+const PostTC = TypeComposer.create('Post');
 
 // ****************************
 // Resolvers
@@ -72,7 +55,7 @@ interface QuerySource {
   name: number;
   age: number;
 }
-schemaComposer.Query.addFields({
+schemaComposerWithContext.Query.addFields({
   user: PersonTC.getResolver('findOne').wrapResolve<QuerySource>(next => rp => {
     if (rp.source) {
       rp.source.name = 5; // source any
@@ -129,7 +112,7 @@ PersonTC.addResolver<GenericUID>({
 });
 
 // wrapResolverResolve
-PersonTC.wrapResolverResolve<any>('findMany', next => rp => {
+PersonTC.wrapResolverResolve('findMany', next => rp => {
   rp.source.name = 5; // source any
   rp.source.age = 'string';
 
@@ -197,12 +180,6 @@ PersonTC.addFields({
 // This particular case has been a bit of a problem, that is before i did the changes
 // resolver was always conflicting with the invoking TC
 // **************************
-interface Art {
-  id: number;
-  personId: string;
-}
-const ArtTC = schemaComposer.getOrCreateTC<Art>('Art');
-
 ArtTC.addRelation('extends', {
   resolver: PersonTC.getResolver('findById'), // comes from other (resolve to)
   prepareArgs: {

--- a/src/__tests__/typedefs/TypeComposer.spec.ts
+++ b/src/__tests__/typedefs/TypeComposer.spec.ts
@@ -196,3 +196,100 @@ ArtTC.addRelation('extends', {
 //   },
 //   projection: { extends: true }
 // });
+
+// with TArgs
+interface GeneralArgs {
+  filter: { id: string };
+  skip: number;
+  limit: number;
+}
+
+// in resolvers
+PersonTC.addResolver<GenericUID, GeneralArgs>({
+  // <--- this is ok, if we want to provide really Basic/Global/Generic interface, which will be implemented in several types/models. And then to these types we will add current resolver.
+  resolve: ({ source, context, args }) => {
+    // check availability
+    if (source && context && args) {
+      if (context.uid !== source.uid) {
+        // args.skip = 'st';
+        args.skip = 4;
+        // do something if not the current user ...
+      }
+    }
+  },
+});
+
+// wrapResolverResolve
+PersonTC.wrapResolverResolve('findMany', next => rp => {
+  rp.source.name = 5; // source any
+  rp.source.age = 'string';
+
+  if (rp.args) {
+    rp.args.skip = 'string';
+    rp.args.skip = 4;
+  }
+
+  return next(rp);
+});
+
+PersonTC.wrapResolverResolve<Person, GeneralArgs>('findMany', next => rp => {
+  // rp.source.name = 5;  // source Person
+  // rp.source.age = 'string';
+
+  // source Person | undefined  as a result of Partial<ResolveParams...
+  if (rp.source && rp.args) {
+    rp.source.name = 'string';
+    rp.source.age = 5;
+    // rp.args.skip = 'ss';
+    rp.args.skip = 4;
+  }
+
+  return next(rp);
+});
+
+// in relations
+ArtTC.addRelation('extends', {
+  resolver: PersonTC.getResolver('findById').wrapResolve(next => rp => {
+    if (rp.args) {
+      // rp.args.skip = 'hey';
+      rp.args.skip = 4;
+    }
+  }),
+  prepareArgs: {
+    _id: source => source.personId, // type checks well now
+  },
+  projection: { personId: true },
+});
+
+ArtTC.addRelation<Person, GeneralArgs>('extends', {
+  resolver: PersonTC.getResolver('findById').wrapResolve(next => rp => {
+    if (rp.args) {
+      // rp.args.skip = 'hey';
+      rp.args.skip = 4;
+    }
+  }),
+  prepareArgs: {
+    _id: source => source.personId, // type checks well now
+  },
+  projection: { personId: true },
+});
+
+ArtTC.addRelation('extends', {
+  type: 'Int',
+  resolve: (source, args, context) => {
+    source.id = 33;
+    args.skip = 'string';
+    args.skip = 33;
+    context.uid = 'string';
+  },
+});
+
+ArtTC.addRelation<Art, GeneralArgs>('extends', {
+  type: 'Int',
+  resolve: (source, args, context) => {
+    source.id = 33;
+    // args.skip = 'string';
+    args.skip = 33;
+    context.uid = 'string';
+  },
+});

--- a/src/__tests__/typedefs/mock-typedefs.ts
+++ b/src/__tests__/typedefs/mock-typedefs.ts
@@ -1,0 +1,43 @@
+import { SchemaComposer } from '../../index';
+
+// Changes a driven by the quest for better typing and a better Intelisense experience
+// hence boosting productivity
+// The following passed tsCheck
+
+export interface DeepOptions {
+  deep1: string;
+  deep2: number;
+}
+
+export interface GenericUID {
+  uid: string;
+}
+
+export interface Person extends GenericUID {
+  uid: string;
+  name: string;
+  nickName: string;
+  age: number;
+  deep: DeepOptions;
+}
+
+export interface Post {
+  title: string;
+  author: string;
+  body: string;
+  timestamp: number;
+}
+
+export interface Art {
+  id: number;
+  personId: string;
+}
+
+export interface Context {
+  req: any;
+  res: any;
+  uid: string;
+}
+
+// works for cases where u create your instance of
+export const schemaComposerWithContext = new SchemaComposer<Context>();

--- a/src/__tests__/typescript-typedef.spec.ts
+++ b/src/__tests__/typescript-typedef.spec.ts
@@ -177,3 +177,25 @@ PersonExtendedTC.getResolver('findOne').wrapResolve(next => rp => {
 PersonExtendedTC.getResolver<any>('findOne').wrapResolve(next => rp => {
   rp.source.new1 = 5;
 });
+
+// **************************
+// Relations
+//
+// This particular case has been a bit of a problem, that is before i did the changes
+// resolver was always conflicting with the invoking TC
+// **************************
+PersonExtendedTC.addRelation<Person>('extends', {
+  resolver: PersonTC.getResolver('findById'), // comes from other (resolve to)
+  prepareArgs: {
+    _id: source => source.extends  // type checks well now
+  },
+  projection: { extends: true }
+});
+
+PersonExtendedTC.addRelation('extends', {
+  resolver: PersonTC.getResolver('findById'), // comes from other (resolve to)
+  prepareArgs: {
+    _id: source => source.extends  // type checks well now
+  },
+  projection: { extends: true }
+});

--- a/src/__tests__/typescript-typedef.spec.ts
+++ b/src/__tests__/typescript-typedef.spec.ts
@@ -1,49 +1,179 @@
 import { SchemaComposer } from '../index';
 import { TypeComposer } from '../TypeComposer';
 
+// Changes a driven by the quest for better typing and a better Intelisense experience
+// hence boosting productivity
+// The following passed tsCheck
+
+interface DeepOptions {
+  deep1: string;
+  deep2: number;
+}
+
 interface Person {
-    uid: string;
-    name: string;
-    nickName: string;
-    age: number;
+  uid: string;
+  name: string;
+  nickName: string;
+  age: number;
+  deep: DeepOptions;
 }
 
 interface Context {
-    req: any;
-    res: any;
-    uid: string;
+  req: any;
+  res: any;
+  uid: string;
 }
 
 // works for cases where u create your instance of
 const schemaComposer = new SchemaComposer<Context>();
 
 // Person from this schemaComposer gets the context defined for that schemaComposer
-const Person = schemaComposer.getOrCreateTC<Person>('Person');
+const PersonTC2 = schemaComposer.getOrCreateTC<Person>('Person');
 
 // create from default schemaComposer uses the context type passed in
 // or uses `any` as type
 const PersonTC = TypeComposer.create<Person, Context>({
-    name: 'Person',
-    fields: {
-        name: 'String',
-        nickName: 'String',
-        age: 'Int'
-    }
+  name: 'Person',
+  fields: {
+    name: 'String',
+    nickName: 'String',
+    age: 'Int'
+  }
 });
 
-PersonTC.addResolver({
-    resolve: ({ source, context }) => {
-        // check availability
-        if (source && context) {
-            source.age = 2;
-            source.name = 'XYZ';
-            if (context.uid !== source.uid) {
-                // do something if not the current user ...
-            }
-        }
-    }
+// Both PersonTC and PersonTC2 have same TSource and TContext
+
+// ****************************
+// Resolvers
+//
+// overloads works quite well when describing the typedefs separate from implementations ;)
+// so we might be having issues with the flow types as it comes with implementation
+// If we ditch overloads, then user may need to always specify any if he doesn't want to specify source type
+// works for no Type passed and for Person
+// ****************************
+
+// TC.getResolver()
+PersonTC.getResolver<any>('findOne').wrapResolve(next => rp => {
+  rp.source.name = 5; // source any
+  rp.source.age = 'string';
+
+  return next(rp);
 });
 
-// Changes a driven by the quest for better typing and a better Intelisense experience
-// hence boosting productivity
-// It passes linting
+// TResolverSource is Person or you may specify
+PersonTC.getResolver('findOne').wrapResolve(next => rp => {
+  // rp.source.name = 5;  // source Person
+  // rp.source.age = 'string';
+
+  // source Person | undefined  as a result of Partial<ResolveParams...
+  if (rp.source) {
+    rp.source.name = 'string';
+    rp.source.age = 5;
+  }
+
+  return next(rp);
+});
+
+// TC.addResolver()
+// add resolver with no type passed in
+PersonTC.addResolver<any>({
+  resolve: ({ source, context }) => {
+    // check availability
+    if (source && context) {
+      source.age = 2;
+      source.name = 'XYZ';
+      if (context.uid !== source.uid) {
+        // do something if not the current user ...
+      }
+    }
+  }
+});
+
+// add resolver with a source type
+PersonTC.addResolver<Person>({
+  resolve: ({ source, context }) => {
+    // check availability
+    if (source && context) {
+      source.age = 2;
+      source.name = 'XYZ';
+      if (context.uid !== source.uid) {
+        // do something if not the current user ...
+      }
+    }
+  }
+});
+
+// wrapResolverResolve
+PersonTC.wrapResolverResolve<any>('findMany', next => rp => {
+  rp.source.name = 5; // source any
+  rp.source.age = 'string';
+
+  return next(rp);
+});
+
+PersonTC.wrapResolverResolve<Person>('findMany', next => rp => {
+  // rp.source.name = 5;  // source Person
+  // rp.source.age = 'string';
+
+  // source Person | undefined  as a result of Partial<ResolveParams...
+  if (rp.source) {
+    rp.source.name = 'string';
+    rp.source.age = 5;
+  }
+
+  return next(rp);
+});
+
+// ****************************
+// Fields
+// No Overloads created for fields
+// ****************************
+PersonTC.getFieldTC<DeepOptions>('deep')
+  .getResolver('findOne')
+  .wrapResolve(next => rp => {
+    // check source and context because they are defined as Partial<ResolveParams...
+    if (rp.source && rp.context) {
+      rp.source.deep1 = 'string';
+      rp.context.uid = 'string'; // passes
+    }
+  });
+
+PersonTC.getFieldTC<any>('deep')
+  .getResolver('findOne')
+  .wrapResolve(next => rp => {
+    // no checking of rp.source as it is any, but we check context as it is inherited
+    rp.source.deep1 = 5; // passes
+    rp.source.deep1 = 'ssas'; // passes
+
+    // not checked errors, rp may be undefined
+    // rp.context... // fails
+
+    if (rp.context) {
+      // rp.context.uid = 5;   // fails
+      rp.context.uid = 'string'; // passes
+    }
+  });
+
+// addFields
+interface PersonExtended extends Person {
+  new1: string;
+  new2: number;
+  extends: string; // Person
+}
+
+// If you want to use the extended person source types then you need a variable to collect
+const PersonExtendedTC = PersonTC.addFields<PersonExtended>({
+  new1: 'String',
+  new2: 'Int'
+});
+
+PersonExtendedTC.getResolver('findOne').wrapResolve(next => rp => {
+  if (rp.source && rp.context) {
+    rp.source.new1 = 'string';
+    rp.context.uid = 'string'; // passes
+  }
+});
+
+PersonExtendedTC.getResolver<any>('findOne').wrapResolve(next => rp => {
+  rp.source.new1 = 5;
+});

--- a/src/__tests__/typescript-typedef.spec.ts
+++ b/src/__tests__/typescript-typedef.spec.ts
@@ -1,0 +1,49 @@
+import { SchemaComposer } from '../index';
+import { TypeComposer } from '../TypeComposer';
+
+interface Person {
+    uid: string;
+    name: string;
+    nickName: string;
+    age: number;
+}
+
+interface Context {
+    req: any;
+    res: any;
+    uid: string;
+}
+
+// works for cases where u create your instance of
+const schemaComposer = new SchemaComposer<Context>();
+
+// Person from this schemaComposer gets the context defined for that schemaComposer
+const Person = schemaComposer.getOrCreateTC<Person>('Person');
+
+// create from default schemaComposer uses the context type passed in
+// or uses `any` as type
+const PersonTC = TypeComposer.create<Person, Context>({
+    name: 'Person',
+    fields: {
+        name: 'String',
+        nickName: 'String',
+        age: 'Int'
+    }
+});
+
+PersonTC.addResolver({
+    resolve: ({ source, context }) => {
+        // check availability
+        if (source && context) {
+            source.age = 2;
+            source.name = 'XYZ';
+            if (context.uid !== source.uid) {
+                // do something if not the current user ...
+            }
+        }
+    }
+});
+
+// Changes a driven by the quest for better typing and a better Intelisense experience
+// hence boosting productivity
+// It passes linting

--- a/src/__tests__/typescript-typedef.spec.ts
+++ b/src/__tests__/typescript-typedef.spec.ts
@@ -53,12 +53,27 @@ const PersonTC = TypeComposer.create<Person, Context>({
 // ****************************
 
 // TC.getResolver()
-PersonTC.getResolver<any>('findOne').wrapResolve(next => rp => {
+// TODO: should be without errors! By default in resolvers source should be `any` even if provided TypeComposer.create<Person, Context> 
+PersonTC.getResolver('findOne').wrapResolve(next => rp => {
   rp.source.name = 5; // source any
   rp.source.age = 'string';
 
   return next(rp);
 });
+
+// BUT I see your what you want to do. So let provide source correctly to `wrapResolve` function:
+// We keep standard resolvers untyped forsource. BUT almost all wrappers created for some exact type,
+// so let make it typed! I think it's a right place.
+interface QuerySource { name: number, age: number };
+schemaComposer.Query.addFields({
+  user: PersonTC.getResolver('findOne').wrapResolve<QuerySource>(next => rp => {
+    rp.source.name = 5; // source any
+    rp.source.age = 'string'; // <----- here must be an error
+  
+    return next(rp);
+  })
+});
+
 
 // TResolverSource is Person or you may specify
 PersonTC.getResolver('findOne').wrapResolve(next => rp => {
@@ -67,7 +82,7 @@ PersonTC.getResolver('findOne').wrapResolve(next => rp => {
 
   // source Person | undefined  as a result of Partial<ResolveParams...
   if (rp.source) {
-    rp.source.name = 'string';
+    rp.source.name = 2;  // <---- for backward compatibility for TS users, here should be mo errors (by default source: any)
     rp.source.age = 5;
   }
 
@@ -76,12 +91,12 @@ PersonTC.getResolver('findOne').wrapResolve(next => rp => {
 
 // TC.addResolver()
 // add resolver with no type passed in
-PersonTC.addResolver<any>({
+PersonTC.addResolver({   // <---------------- by default resolver has `source: any` an it can not be defined explicitly like it was
   resolve: ({ source, context }) => {
     // check availability
     if (source && context) {
       source.age = 2;
-      source.name = 'XYZ';
+      source.name = 2;           // <---- should not be error
       if (context.uid !== source.uid) {
         // do something if not the current user ...
       }
@@ -90,7 +105,7 @@ PersonTC.addResolver<any>({
 });
 
 // add resolver with a source type
-PersonTC.addResolver<Person>({
+PersonTC.addResolver<Person>({ // <--- this is ok, if we want to provide really Basic/Global/Generic interface, which will be implemented in several types/models. And then to this types we will add this resolver.
   resolve: ({ source, context }) => {
     // check availability
     if (source && context) {
@@ -128,9 +143,9 @@ PersonTC.wrapResolverResolve<Person>('findMany', next => rp => {
 // Fields
 // No Overloads created for fields
 // ****************************
-PersonTC.getFieldTC<DeepOptions>('deep')
+PersonTC.getFieldTC('deep') // <----- no matter what type you provide here, it should not affect on rp.source below
   .getResolver('findOne')
-  .wrapResolve(next => rp => {
+  .wrapResolve<DeepOptions>(next => rp => { // <----- provide type be here, if you want to check rp.source
     // check source and context because they are defined as Partial<ResolveParams...
     if (rp.source && rp.context) {
       rp.source.deep1 = 'string';
@@ -138,7 +153,7 @@ PersonTC.getFieldTC<DeepOptions>('deep')
     }
   });
 
-PersonTC.getFieldTC<any>('deep')
+PersonTC.getFieldTC('deep') // <-------------- this case should not have errors
   .getResolver('findOne')
   .wrapResolve(next => rp => {
     // no checking of rp.source as it is any, but we check context as it is inherited
@@ -154,29 +169,44 @@ PersonTC.getFieldTC<any>('deep')
     }
   });
 
-// addFields
-interface PersonExtended extends Person {
-  new1: string;
-  new2: number;
-  extends: string; // Person
-}
 
-// If you want to use the extended person source types then you need a variable to collect
-const PersonExtendedTC = PersonTC.addFields<PersonExtended>({
-  new1: 'String',
-  new2: 'Int'
-});
+// -------- miss understanding, corrext tests provided below
 
-PersonExtendedTC.getResolver('findOne').wrapResolve(next => rp => {
-  if (rp.source && rp.context) {
-    rp.source.new1 = 'string';
-    rp.context.uid = 'string'; // passes
-  }
-});
+// // addFields
+// interface PersonExtended extends Person {
+//   new1: string;
+//   new2: number;
+//   extends: string; // Person
+// }
 
-PersonExtendedTC.getResolver<any>('findOne').wrapResolve(next => rp => {
-  rp.source.new1 = 5;
-});
+// // If you want to use the extended person source types then you need a variable to collect
+// const PersonExtendedTC = PersonTC.addFields<PersonExtended>({
+//   new1: 'String',
+//   new2: 'Int'
+// });
+
+// PersonExtendedTC.getResolver('findOne').wrapResolve(next => rp => {
+//   if (rp.source && rp.context) {
+//     rp.source.new1 = 'string';
+//     rp.context.uid = 'string'; // passes
+//   }
+// });
+
+// PersonExtendedTC.getResolver<any>('findOne').wrapResolve(next => rp => {
+//   rp.source.new1 = 5;
+// });
+
+// adding new field to graphql type, its fieldConfig.resolve method should have TSource type
+PersonTC.addFields({
+  ageIn2030: {
+    type: 'Int',
+    resolve: (source) => {  // <------------  here `source` MUST have `Person` type
+      return source.age + 12;
+    },
+  },
+})
+
+
 
 // **************************
 // Relations
@@ -184,18 +214,22 @@ PersonExtendedTC.getResolver<any>('findOne').wrapResolve(next => rp => {
 // This particular case has been a bit of a problem, that is before i did the changes
 // resolver was always conflicting with the invoking TC
 // **************************
-PersonExtendedTC.addRelation<Person>('extends', {
+interface Art { id: number, personId: string } 
+const ArtTC = schemaComposer.getOrCreateTC<Art>('Art');
+
+ArtTC.addRelation('extends', { // <------------ NO NEED IN addRelation<Person> here 
   resolver: PersonTC.getResolver('findById'), // comes from other (resolve to)
   prepareArgs: {
-    _id: source => source.extends  // type checks well now
+    _id: source => source.personId  // type checks well now
   },
-  projection: { extends: true }
+  projection: { personId: true }
 });
 
-PersonExtendedTC.addRelation('extends', {
-  resolver: PersonTC.getResolver('findById'), // comes from other (resolve to)
-  prepareArgs: {
-    _id: source => source.extends  // type checks well now
-  },
-  projection: { extends: true }
-});
+// <----------- became the same as above, so comment this case.
+// ArtTC.addRelation('extends', {
+//   resolver: PersonTC.getResolver('findById'), // comes from other (resolve to)
+//   prepareArgs: {
+//     _id: source => source.extends  // type checks well now
+//   },
+//   projection: { extends: true }
+// });

--- a/src/__tests__/typescript-typedef.spec.ts
+++ b/src/__tests__/typescript-typedef.spec.ts
@@ -10,7 +10,11 @@ interface DeepOptions {
   deep2: number;
 }
 
-interface Person {
+interface GenericUID {
+  uid: string;
+}
+
+interface Person extends GenericUID{
   uid: string;
   name: string;
   nickName: string;
@@ -105,12 +109,11 @@ PersonTC.addResolver({   // <---------------- by default resolver has `source: a
 });
 
 // add resolver with a source type
-PersonTC.addResolver<Person>({ // <--- this is ok, if we want to provide really Basic/Global/Generic interface, which will be implemented in several types/models. And then to this types we will add this resolver.
+// <<<------ here I change Person on something basic GenericUID. Let assume that from GenericUID extended all other models, which will use this resolver.
+PersonTC.addResolver<GenericUID>({ // <--- this is ok, if we want to provide really Basic/Global/Generic interface, which will be implemented in several types/models. And then to these types we will add current resolver.
   resolve: ({ source, context }) => {
     // check availability
     if (source && context) {
-      source.age = 2;
-      source.name = 'XYZ';
       if (context.uid !== source.uid) {
         // do something if not the current user ...
       }
@@ -145,7 +148,7 @@ PersonTC.wrapResolverResolve<Person>('findMany', next => rp => {
 // ****************************
 PersonTC.getFieldTC('deep') // <----- no matter what type you provide here, it should not affect on rp.source below
   .getResolver('findOne')
-  .wrapResolve<DeepOptions>(next => rp => { // <----- provide type be here, if you want to check rp.source
+  .wrapResolve<DeepOptions>(next => rp => { // <----- provide type here, if you want to check rp.source
     // check source and context because they are defined as Partial<ResolveParams...
     if (rp.source && rp.context) {
       rp.source.deep1 = 'string';

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -14,19 +14,34 @@ declare const schemaComposer: SchemaComposer<any>;
 export { SchemaComposer, schemaComposer, GQC };
 
 export { TypeComposer as TypeComposerClass } from './TypeComposer';
-export { InputTypeComposer as InputTypeComposerClass } from './InputTypeComposer';
+export {
+  InputTypeComposer as InputTypeComposerClass,
+} from './InputTypeComposer';
 export { EnumTypeComposer as EnumTypeComposerClass } from './EnumTypeComposer';
-export { InterfaceTypeComposer as InterfaceTypeComposerClass } from './InterfaceTypeComposer';
+export {
+  InterfaceTypeComposer as InterfaceTypeComposerClass,
+} from './InterfaceTypeComposer';
 export { Resolver as ResolverClass } from './Resolver';
 
 export { TypeStorage } from './TypeStorage';
 
 // Scalar types
-export { GraphQLDate, GraphQLBuffer, GraphQLGeneric, GraphQLJSON } from './type';
+export {
+  GraphQLDate,
+  GraphQLBuffer,
+  GraphQLGeneric,
+  GraphQLJSON,
+} from './type';
 
 // Utils
-export { getProjectionFromAST, getFlatProjectionFromAST } from './utils/projection';
-export { toInputObjectType, ConvertInputObjectFieldOpts } from './utils/toInputObjectType';
+export {
+  getProjectionFromAST,
+  getFlatProjectionFromAST,
+} from './utils/projection';
+export {
+  toInputObjectType,
+  ConvertInputObjectFieldOpts,
+} from './utils/toInputObjectType';
 export * from './utils/misc';
 export * from './utils/is';
 export * from './utils/graphqlVersion';
@@ -79,9 +94,10 @@ export {
   ResolveDebugOpts,
 } from './Resolver';
 
-export {
-  ProjectionType,
-  ProjectionNode,
-} from './utils/projection';
+export { ProjectionType, ProjectionNode } from './utils/projection';
 
-export { TypeDefinitionString, TypeWrappedString, TypeNameString } from './TypeMapper';
+export {
+  TypeDefinitionString,
+  TypeWrappedString,
+  TypeNameString,
+} from './TypeMapper';

--- a/src/utils/filterByDotPaths.d.ts
+++ b/src/utils/filterByDotPaths.d.ts
@@ -1,8 +1,12 @@
 export interface FilterOpts {
-    hideFields: { [fieldPath: string]: string };
-    hideFieldsNote?: string;
+  hideFields: { [fieldPath: string]: string };
+  hideFieldsNote?: string;
 }
 
 export type PathsFilter = string | string[];
 
-export default function filterByDotPaths(obj: object, pathsFilter: PathsFilter|null, opts?: FilterOpts): object;
+export default function filterByDotPaths(
+  obj: object,
+  pathsFilter: PathsFilter | null,
+  opts?: FilterOpts,
+): object;

--- a/src/utils/is.d.ts
+++ b/src/utils/is.d.ts
@@ -1,6 +1,6 @@
-export function isString(value: string|null): value is string;
+export function isString(value: string | null): value is string;
 
-export function isObject(value: object|null): boolean;
+export function isObject(value: object | null): boolean;
 
 // tslint:disable-next-line:ban-types
-export function isFunction(value: Function|null): value is Function;
+export function isFunction(value: Function | null): value is Function;

--- a/src/utils/projection.d.ts
+++ b/src/utils/projection.d.ts
@@ -6,8 +6,10 @@ import {
   GraphQLOutputType,
 } from '../graphql';
 
-export type ProjectionType = { [fieldName: string]: any };
 export type ProjectionNode = { [fieldName: string]: any };
+export type ProjectionType<TSource = any> = {
+  [fieldName in keyof TSource]: any
+};
 
 export function getProjectionFromAST(
   context: GraphQLResolveInfo,

--- a/src/utils/projection.d.ts
+++ b/src/utils/projection.d.ts
@@ -1,18 +1,25 @@
 import {
-    FieldNode, FragmentDefinitionNode, GraphQLResolveInfo, InlineFragmentNode, GraphQLOutputType
+  FieldNode,
+  FragmentDefinitionNode,
+  GraphQLResolveInfo,
+  InlineFragmentNode,
+  GraphQLOutputType,
 } from '../graphql';
 
 export type ProjectionType = { [fieldName: string]: any };
 export type ProjectionNode = { [fieldName: string]: any };
 
 export function getProjectionFromAST(
-    context: GraphQLResolveInfo,
-    fieldNode?: FieldNode | InlineFragmentNode | FragmentDefinitionNode): ProjectionType;
+  context: GraphQLResolveInfo,
+  fieldNode?: FieldNode | InlineFragmentNode | FragmentDefinitionNode,
+): ProjectionType;
 
 export function getFlatProjectionFromAST(
-    context: GraphQLResolveInfo,
-    fieldNodes?: FieldNode | InlineFragmentNode | FragmentDefinitionNode): { [key: string]: boolean };
+  context: GraphQLResolveInfo,
+  fieldNodes?: FieldNode | InlineFragmentNode | FragmentDefinitionNode,
+): { [key: string]: boolean };
 
 export function extendByFieldProjection(
-    returnType: GraphQLOutputType,
-    projection: ProjectionType): ProjectionType;
+  returnType: GraphQLOutputType,
+  projection: ProjectionType,
+): ProjectionType;

--- a/src/utils/projection.d.ts
+++ b/src/utils/projection.d.ts
@@ -4,7 +4,7 @@ import {
   GraphQLResolveInfo,
   InlineFragmentNode,
   GraphQLOutputType,
-} from '../graphql';
+} from 'graphql';
 
 export type ProjectionNode = { [fieldName: string]: any };
 export type ProjectionType<TSource = any> = {

--- a/src/utils/toDottedObject.d.ts
+++ b/src/utils/toDottedObject.d.ts
@@ -1,1 +1,5 @@
-export default function toDottedObject(obj: object, target?: object, path?: string[]): { [dottedPath: string]: any };
+export default function toDottedObject(
+  obj: object,
+  target?: object,
+  path?: string[],
+): { [dottedPath: string]: any };

--- a/src/utils/toInputObjectType.d.ts
+++ b/src/utils/toInputObjectType.d.ts
@@ -4,24 +4,26 @@ import { TypeComposer } from '../TypeComposer';
 import { SchemaComposer } from '../SchemaComposer';
 
 export interface ToInputObjectTypeOpts {
-    prefix?: string;
-    postfix?: string;
+  prefix?: string;
+  postfix?: string;
 }
 
 export function toInputObjectType(
-    typeComposer: TypeComposer<any, any>,
-    opts?: ToInputObjectTypeOpts,
-    cache?: Map<GraphQLObjectType, InputTypeComposer>): InputTypeComposer;
+  typeComposer: TypeComposer<any, any>,
+  opts?: ToInputObjectTypeOpts,
+  cache?: Map<GraphQLObjectType, InputTypeComposer>,
+): InputTypeComposer;
 
 export interface ConvertInputObjectFieldOpts {
-    prefix?: string;
-    postfix?: string;
-    fieldName?: string;
-    outputTypeName?: string;
+  prefix?: string;
+  postfix?: string;
+  fieldName?: string;
+  outputTypeName?: string;
 }
 
 export function convertInputObjectField(
-    field: GraphQLType,
-    opts: ConvertInputObjectFieldOpts,
-    cache: Map<GraphQLObjectType, InputTypeComposer>,
-    schemaComposer: SchemaComposer<any>): GraphQLInputType;
+  field: GraphQLType,
+  opts: ConvertInputObjectFieldOpts,
+  cache: Map<GraphQLObjectType, InputTypeComposer>,
+  schemaComposer: SchemaComposer<any>,
+): GraphQLInputType;

--- a/src/utils/toInputObjectType.d.ts
+++ b/src/utils/toInputObjectType.d.ts
@@ -9,7 +9,7 @@ export interface ToInputObjectTypeOpts {
 }
 
 export function toInputObjectType(
-    typeComposer: TypeComposer<any>,
+    typeComposer: TypeComposer<any, any>,
     opts?: ToInputObjectTypeOpts,
     cache?: Map<GraphQLObjectType, InputTypeComposer>): InputTypeComposer;
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "strict": true,
     "lib": ["es2017", "esnext.asynciterable"]
   },
-  "include": ["src/**/*.d.ts"],
+  "include": ["src/**/*.d.ts", "src/**/*.spec.ts"],
   "exclude": [
     "./node_modules"
   ]

--- a/tslint.json
+++ b/tslint.json
@@ -1,20 +1,39 @@
 {
-    "defaultSeverity": "error",
-    "extends": [
-        "tslint:recommended"
+  "defaultSeverity": "error",
+  "extends": [
+    "tslint:recommended",
+    "tslint-config-prettier"
+  ],
+  "rulesDirectory": [
+    "tslint-plugin-prettier"
+  ],
+  "jsRules": {},
+  "rules": {
+    "prettier": [
+      true,
+      {
+        "semi": true,
+        "singleQuote": true,
+        "trailingComma": "all",
+        "bracketSpacing": true,
+        "parser": "typescript"
+      }
     ],
-    "jsRules": {},
-    "rules": {
-        "quotemark": [true, "single"],
-        "trailing-comma": [false],
-        "ordered-imports": false,
-        "member-ordering": [true, { "order": "fields-first" }],
-        "variable-name": false,
-        "arrow-parens": false,
-        "interface-name": ["never-prefix"],
-        "no-reference-import": false,
-        "interface-over-type-literal": false,
-        "object-literal-sort-keys": false
-    },
-    "rulesDirectory": []
+    "trailing-comma": [
+      false
+    ],
+    "ordered-imports": false,
+    "member-ordering": [
+      true,
+      {
+        "order": "fields-first"
+      }
+    ],
+    "variable-name": false,
+    "arrow-parens": false,
+    "interface-name": false,
+    "no-reference-import": false,
+    "interface-over-type-literal": false,
+    "object-literal-sort-keys": false
+  }
 }

--- a/tslint.json
+++ b/tslint.json
@@ -12,7 +12,8 @@
         "variable-name": false,
         "interface-name": ["never-prefix"],
         "no-reference-import": false,
-        "interface-over-type-literal": false
+        "interface-over-type-literal": false,
+        "object-literal-sort-keys": false
     },
     "rulesDirectory": []
 }

--- a/tslint.json
+++ b/tslint.json
@@ -10,6 +10,7 @@
         "ordered-imports": false,
         "member-ordering": [true, { "order": "fields-first" }],
         "variable-name": false,
+        "arrow-parens": false,
         "interface-name": ["never-prefix"],
         "no-reference-import": false,
         "interface-over-type-literal": false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1768,6 +1768,13 @@ eslint-plugin-import@^2.13.0:
     read-pkg-up "^2.0.0"
     resolve "^1.6.0"
 
+eslint-plugin-prettier@^2.2.0:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-2.6.2.tgz#71998c60aedfa2141f7bfcbf9d1c459bf98b4fad"
+  dependencies:
+    fast-diff "^1.1.1"
+    jest-docblock "^21.0.0"
+
 eslint-plugin-prettier@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-2.6.1.tgz#de902b4a66b7bca24296429a59a1cc04020ccbbd"
@@ -5120,6 +5127,17 @@ tslib@^1.7.1:
 tslib@^1.8.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.0.tgz#e37a86fda8cbbaf23a057f473c9f4dc64e5fc2e8"
+
+tslint-config-prettier@^1.15.0:
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/tslint-config-prettier/-/tslint-config-prettier-1.15.0.tgz#76b9714399004ab6831fdcf76d89b73691c812cf"
+
+tslint-plugin-prettier@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/tslint-plugin-prettier/-/tslint-plugin-prettier-1.3.0.tgz#7eb65d19ea786a859501a42491b78c5de2031a3f"
+  dependencies:
+    eslint-plugin-prettier "^2.2.0"
+    tslib "^1.7.1"
 
 tslint@^5.10.0:
   version "5.10.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2266,14 +2266,7 @@ eslint-plugin-import@^2.14.0:
     read-pkg-up "^2.0.0"
     resolve "^1.6.0"
 
-eslint-plugin-prettier@^2.2.0:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-2.6.2.tgz#71998c60aedfa2141f7bfcbf9d1c459bf98b4fad"
-  dependencies:
-    fast-diff "^1.1.1"
-    jest-docblock "^21.0.0"
-
-eslint-plugin-prettier@^2.6.2:
+eslint-plugin-prettier@^2.2.0, eslint-plugin-prettier@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-2.6.2.tgz#71998c60aedfa2141f7bfcbf9d1c459bf98b4fad"
   dependencies:
@@ -6874,10 +6867,10 @@ trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
 
-tslib@^1.8.1, tslib@^1.9.0:
+tslib@^1.7.1, tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
-  
+
 tslint-config-prettier@^1.15.0:
   version "1.15.0"
   resolved "https://registry.yarnpkg.com/tslint-config-prettier/-/tslint-config-prettier-1.15.0.tgz#76b9714399004ab6831fdcf76d89b73691c812cf"


### PR DESCRIPTION
Adoptive commit

When using Mongoose plugin, i often get the source interface in the context arg of resolvers so i decided to look into the issue and brought this up. Please review and ask any question.

@nodkz @toverux you might want to check this changes...
This is just a test commit for review to see if i am getting the idea right.

```typescript
import { SchemaComposer } from '../index';
import { TypeComposer } from '../TypeComposer';

interface Person {
    uid: string;
    name: string;
    nickName: string;
    age: number;
}

interface Context {
    req: any;
    res: any;
    uid: string;
}

// works for cases where u create your instance of
const schemaComposer = new SchemaComposer<Context>();

// Person from this schemaComposer gets the context defined for that schemaComposer
const Person = schemaComposer.getOrCreateTC<Person>('Person');

// create from default schemaComposer uses the context type passed in
// or uses `any` as type
const PersonTC = TypeComposer.create<Person, Context>({
    name: 'Person',
    fields: {
        name: 'String',
        nickName: 'String',
        age: 'Int'
    }
});

PersonTC.addResolver({
    resolve: ({ source, context }) => {
        // check availability
        if (source && context) {
            source.age = 2;
            source.name = 'XYZ';
            if (context.uid !== source.uid) {
                // do something if not the current user ...
            }
        }
    }
});

// Changes a driven by the quest for better typing and a better Intelisense experience
// hence boosting productivity
// It passes linting
```

The above passed the `tscheck`. I also noticed that this TContext type implementations is also used at the FlowType end. Well If we are able to come to a consensus concerning this new implementation, then we can go ahead to convert the Flow types.