### PR TITLE
fix(TypeScript): update typescript type annotations that were missed (#134)

### DIFF
--- a/src/Resolver.d.ts
+++ b/src/Resolver.d.ts
@@ -60,7 +60,7 @@ export type ResolverSortArgConfig<TSource, TContext> = {
 };
 
 export type ResolverOpts<TSource, TContext, TArgs = any> = {
-  type?: ComposeOutputType<TContext>;
+  type?: ComposeOutputType<TSource, TContext>;
   resolve?: ResolverRpCb<TSource, TContext, TArgs>;
   args?: ComposeFieldConfigArgumentMap;
   name?: string;
@@ -94,7 +94,7 @@ export type ResolverWrapArgsCb = (
 
 export type ResolverWrapTypeCb = (
   prevType: graphql.GraphQLOutputType,
-) => ComposeOutputType<any>;
+) => ComposeOutputType<any, any>;
 
 export type ResolveDebugOpts = {
   showHidden?: boolean;
@@ -106,7 +106,7 @@ export class Resolver<TSource = any, TContext = any, TArgs = any> {
   public static schemaComposer: SchemaComposer<any>;
   public schemaComposer: SchemaComposer<TContext>;
 
-  public type: ComposeOutputType<TContext>;
+  public type: ComposeOutputType<TSource, TContext>;
   public args: ComposeFieldConfigArgumentMap;
   public resolve: ResolverRpCb<TSource, TContext, TArgs>;
   public name: string;
@@ -125,7 +125,7 @@ export class Resolver<TSource = any, TContext = any, TArgs = any> {
 
   public getTypeComposer(): TypeComposer<TSource, TContext>;
 
-  public setType(gqType: ComposeOutputType<TContext>): this;
+  public setType(gqType: ComposeOutputType<TSource, TContext>): this;
 
   // -----------------------------------------------
   // Args methods

--- a/src/TypeComposer.d.ts
+++ b/src/TypeComposer.d.ts
@@ -63,10 +63,11 @@ export type ComposeFieldConfigMap<TSource, TContext> = ObjMap<
 
 export type ComposeFieldConfig<TSource, TContext> =
   | ComposeFieldConfigAsObject<TSource, TContext>
-  | ComposeOutputType<TContext>
-  | (() =>
+  | ComposeOutputType<TSource, TContext>
+  | Thunk<
       | ComposeFieldConfigAsObject<TSource, TContext>
-      | ComposeOutputType<TContext>);
+      | ComposeOutputType<TSource, TContext>
+    >;
 
 // extended GraphQLFieldConfig
 export type GraphqlFieldConfigExtended<TSource, TContext> = GraphQLFieldConfig<
@@ -75,7 +76,7 @@ export type GraphqlFieldConfigExtended<TSource, TContext> = GraphQLFieldConfig<
 > & { projection?: any };
 
 export type ComposeFieldConfigAsObject<TSource, TContext, TArgs = any> = {
-  type: Thunk<ComposeOutputType<TContext>> | GraphQLOutputType;
+  type: Thunk<ComposeOutputType<TSource, TContext>> | GraphQLOutputType;
   args?: ComposeFieldConfigArgumentMap;
   resolve?: GraphQLFieldResolver<TSource, TContext, TArgs>;
   subscribe?: GraphQLFieldResolver<TSource, TContext>;
@@ -86,18 +87,18 @@ export type ComposeFieldConfigAsObject<TSource, TContext, TArgs = any> = {
 } & { $call?: void };
 
 // extended GraphQLOutputType
-export type ComposeOutputType<TContext> =
+export type ComposeOutputType<TSource, TContext> =
   | GraphQLOutputType
-  | TypeComposer<any, TContext>
+  | TypeComposer<TSource, TContext>
   | EnumTypeComposer
   | TypeAsString
-  | Resolver<any, TContext>
+  | Resolver<TSource, TContext>
   | Array<
       | GraphQLOutputType
-      | TypeComposer<any, TContext>
+      | TypeComposer<TSource, TContext>
       | EnumTypeComposer
       | TypeAsString
-      | Resolver<any, TContext>
+      | Resolver<TSource, TContext>
     >;
 
 // Compose Args -----------------------------

--- a/src/__tests__/typedefs/TypeComposer.spec.ts
+++ b/src/__tests__/typedefs/TypeComposer.spec.ts
@@ -166,7 +166,21 @@ PersonTC.getFieldTC('deep') // <-------------- this case should not have errors
 // adding new field to graphql type, its fieldConfig.resolve method should have TSource type
 PersonTC.addFields({
   ageIn2030: {
-    type: 'Int',
+    // test Thunk
+    type: () =>
+      TypeComposer.create({
+        name: 'deepAge',
+        fields: {
+          age: {
+            type: 'Int',
+            // test composeFieldConfig<TSource = Person ...
+            resolve: (source, args, context) => {
+              source.name = 'string';
+              // source.name = 55; <-- errors
+            },
+          },
+        },
+      }),
     resolve: (source, args, context) => {
       // if you don't provide other args, typescript resolves source as any
       return source.age + 12;


### PR DESCRIPTION
* fix(TypeScript): update typescript type annotations that were missed out for (#134)
Actually, Added `TSource` to `ComposeOutputType`.
i.e. changing `ComposeOutputType<TContext>` to `ComposeOutputType<TSource, TContext>`

* refactor(TypeScript): at `ComposeFieldConfig`, swap (() => ...) to Thunk<...>