### PR TITLE
feat(TypeScript): add `TArgsMap` to `ComposeFieldConfig`, `TSource` to `InterfaceTC`

### DIFF
--- a/src/Resolver.d.ts
+++ b/src/Resolver.d.ts
@@ -62,7 +62,7 @@ export type ResolverSortArgConfig<TSource, TContext> = {
 export type ResolverOpts<TSource, TContext, TArgs = any> = {
   type?: ComposeOutputType<TSource, TContext>;
   resolve?: ResolverRpCb<TSource, TContext, TArgs>;
-  args?: ComposeFieldConfigArgumentMap;
+  args?: ComposeFieldConfigArgumentMap<TArgs>;
   name?: string;
   displayName?: string;
   kind?: ResolverKinds;
@@ -107,7 +107,7 @@ export class Resolver<TSource = any, TContext = any, TArgs = any> {
   public schemaComposer: SchemaComposer<TContext>;
 
   public type: ComposeOutputType<TSource, TContext>;
-  public args: ComposeFieldConfigArgumentMap;
+  public args: ComposeFieldConfigArgumentMap<TArgs>;
   public resolve: ResolverRpCb<TSource, TContext, TArgs>;
   public name: string;
   public displayName: string | null;
@@ -141,7 +141,7 @@ export class Resolver<TSource = any, TContext = any, TArgs = any> {
 
   public getArgTC(argName: string): InputTypeComposer;
 
-  public getArgs(): ComposeFieldConfigArgumentMap;
+  public getArgs(): ComposeFieldConfigArgumentMap<TArgs>;
 
   public getArgNames(): string[];
 

--- a/src/__tests__/typedefs/Resolver.spec.ts
+++ b/src/__tests__/typedefs/Resolver.spec.ts
@@ -1,7 +1,15 @@
+import { GraphQLInt, GraphQLString } from 'graphql';
 import { Resolver } from '../../Resolver';
-import { Art, Context, Post } from './mock-typedefs';
+import { Args, Art, Context, Post } from './mock-typedefs';
 
-const findManyPost = new Resolver<Post, Context>({
+const findManyPost = new Resolver<Post, Context, Args>({
+  args: {
+    filter: { type: GraphQLString },
+    limit: { type: GraphQLInt },
+    skip: { type: GraphQLInt },
+    sort: { type: GraphQLString },
+    // unknown: {type: GraphQLInt}, errors
+  },
   resolve: rp => {
     if (rp.source && rp.context) {
       // rp.source.timestamp = 'fails';
@@ -74,6 +82,9 @@ const findManyArt1 = new Resolver<any, any, FindManyArtArgs>({
 
 // all any
 const findManyPost1 = new Resolver({
+  args: {
+    skip: { type: GraphQLInt },
+  },
   resolve: ({ source, context, args }) => {
     source.title = 555; // pass as source is any fails
     source.title = 'A Title';

--- a/src/__tests__/typedefs/TypeComposer.spec.ts
+++ b/src/__tests__/typedefs/TypeComposer.spec.ts
@@ -168,7 +168,10 @@ PersonTC.addFields({
   ageIn2030: {
     // test Thunk
     type: () =>
-      TypeComposer.create({
+      // An error pops up here, this is as TypeScript cannot infer TSource and TContext
+      // So you need to explicitly set it up.
+      // The error actually shows up at the resolve field of ageIn2030
+      TypeComposer.create<Person, Context>({
         name: 'deepAge',
         fields: {
           age: {
@@ -217,6 +220,76 @@ interface GeneralArgs {
   skip: number;
   limit: number;
 }
+
+interface Field1 {
+  arg1: string;
+  arg2: number;
+}
+
+interface FieldsArgsMap {
+  field1: Field1;
+  field2: {
+    arg3: boolean;
+    arg4: any;
+  };
+}
+
+PersonTC.setField('field1', {
+  type: 'Int',
+  resolve: (source, args) => {
+    args.arg1 = 'string';
+    args.arg1 = 3;
+  },
+});
+
+PersonTC.setField<Field1>('field1', {
+  type: 'Int',
+  resolve: (source, args) => {
+    args.arg1 = 'string';
+    // args.arg1 = 3
+  },
+});
+
+PersonTC.addFields({
+  field1: {
+    type: 'Int',
+    resolve: (source, args) => {
+      args.arg1 = 'string';
+      args.arg1 = 44;
+    },
+  },
+  field2: {
+    type: 'String',
+    resolve: (source, args) => {
+      args.arg3 = true;
+      args.arg3 = 'string';
+      args.arg4 = true;
+      args.arg4 = 'string';
+    },
+  },
+});
+
+// if you do not specify all fields, then you will have errors indicating you add.
+PersonTC.addFields<FieldsArgsMap>({
+  field1: {
+    type: 'Int',
+    resolve: (source, args) => {
+      args.arg1 = 'string';
+      // args.arg1 = 44;  errors
+    },
+  },
+  field2: {
+    type: TypeComposer.create({
+      name: 'Hee',
+    }),
+    resolve: (source, args) => {
+      args.arg3 = true;
+      // args.arg3 = 'string';
+      args.arg4 = true;
+      args.arg4 = 'string';
+    },
+  },
+});
 
 // in resolvers
 PersonTC.addResolver<GenericUID, GeneralArgs>({

--- a/src/__tests__/typedefs/mock-typedefs.ts
+++ b/src/__tests__/typedefs/mock-typedefs.ts
@@ -39,5 +39,12 @@ export interface Context {
   uid: string;
 }
 
+export interface Args {
+  filter: any;
+  sort: string;
+  limit: number;
+  skip: number;
+}
+
 // works for cases where u create your instance of
 export const schemaComposerWithContext = new SchemaComposer<Context>();


### PR DESCRIPTION
While working on TypeDefs for #134 this solutions didn't occur to me. I thought we could review. You can see more use cases in the examples
* feat(typedefs): add `TSource` support in `InterfaceTypeComposer`
* feat(typedefs): add `TArgsMap` support to `ComposeFieldConfig`
```typescript
interface Field1 {
  arg1: string;
  arg2: number;
}

interface FieldsArgsMap {
  field1: Field1;
  field2: {
    arg3: boolean;
    arg4: any;
  };
}

PersonTC.setField('field1', {
  type: 'Int',
  resolve: (source, args) => {
    args.arg1 = 'string';
    args.arg1 = 3;
  },
});

PersonTC.setField<Field1>('field1', {
  type: 'Int',
  resolve: (source, args) => {
    args.arg1 = 'string';
    // args.arg1 = 3
  },
});

PersonTC.addFields({
  field1: {
    type: 'Int',
    resolve: (source, args) => {
      args.arg1 = 'string';
      args.arg1 = 44;
    },
  },
  field2: {
    type: 'String',
    resolve: (source, args) => {
      args.arg3 = true;
      args.arg3 = 'string';
      args.arg4 = true;
      args.arg4 = 'string';
    },
  },
});

// if you do not specify all fields, then you will have errors indicating you add.
PersonTC.addFields<FieldsArgsMap>({
  field1: {
    type: 'Int',
    resolve: (source, args) => {
      args.arg1 = 'string';
      // args.arg1 = 44;  errors
    },
  },
  field2: {
    type: TypeComposer.create({
      name: 'Hee',
    }),
    resolve: (source, args) => {
      args.arg3 = true;
      // args.arg3 = 'string';
      args.arg4 = true;
      args.arg4 = 'string';
    },
  },
});
```