### PR TITLE
Allow InterfaceType fields in conversion to InputObjectType

### DIFF
--- a/src/utils/__tests__/toInputObjectType-test.js
+++ b/src/utils/__tests__/toInputObjectType-test.js
@@ -79,11 +79,36 @@ describe('toInputObjectType()', () => {
       interface IFace {
         name: String
         age: Int
-      } 
+      }
     `);
     const itc = toInputObjectType(iftc);
     expect(itc.getFieldType('name')).toBe(GraphQLString);
     expect(itc.getFieldType('age')).toBe(GraphQLInt);
     expect(itc.getTypeName()).toBe('IFaceInput');
+  });
+
+  it('should convert field with InterfaceType to InputType', () => {
+    InterfaceTypeComposer.create(`
+      interface IFace {
+        name: String
+        age: Int
+      }
+    `);
+    const tc = TypeComposer.create(`
+      type Example implements IFace {
+        name: String
+        age: Int
+        neighbor: IFace
+      }
+    `);
+    const itc = toInputObjectType(tc);
+    expect(itc.getFieldType('name')).toBe(GraphQLString);
+    expect(itc.getFieldType('age')).toBe(GraphQLInt);
+    const ifaceField = itc.getFieldTC('neighbor');
+    expect(ifaceField.getType()).toBeInstanceOf(GraphQLInputObjectType);
+    expect(ifaceField.getTypeName()).toBe('ExampleIFaceInput');
+    expect(ifaceField.getFieldType('name')).toBe(GraphQLString);
+    expect(ifaceField.getFieldType('age')).toBe(GraphQLInt);
+    expect(itc.getTypeName()).toBe('ExampleInput');
   });
 });

--- a/src/utils/toInputObjectType.js
+++ b/src/utils/toInputObjectType.js
@@ -5,6 +5,7 @@ import util from 'util';
 import {
   GraphQLInputObjectType,
   GraphQLObjectType,
+  GraphQLInterfaceType,
   isInputType,
   GraphQLUnionType,
   GraphQLList,
@@ -99,19 +100,22 @@ export function convertInputObjectField(
   }
 
   if (!isInputType(fieldType)) {
-    if (fieldType instanceof GraphQLObjectType) {
+    if (fieldType instanceof GraphQLObjectType || fieldType instanceof GraphQLInterfaceType) {
       const typeOpts = {
         prefix: `${opts.prefix || ''}${upperFirst(opts.outputTypeName || '')}`,
         postfix: opts.postfix || 'Input',
       };
-      const tc = new schemaComposer.TypeComposer(fieldType);
+      const tc =
+        fieldType instanceof GraphQLObjectType
+          ? new schemaComposer.TypeComposer(fieldType)
+          : new schemaComposer.InterfaceTypeComposer(fieldType);
       fieldType = toInputObjectType(tc, typeOpts, cache).getType();
     } else {
       // eslint-disable-next-line
       console.error(
         `graphql-compose: can not convert field '${opts.outputTypeName || ''}.${opts.fieldName ||
           ''}' to InputType` +
-          '\nIt should be GraphQLObjectType, but got \n' +
+          '\nIt should be GraphQLObjectType or GraphQLInterfaceType, but got \n' +
           util.inspect(fieldType, { depth: 2, colors: true })
       );
       fieldType = GenericType;


### PR DESCRIPTION
Follow-up to #141.
Make `toInputObjectType` handle InterfaceType fields.