### PR TITLE
Add support for Date.now() to GraphQLDate

### DIFF
--- a/src/type/__tests__/date-test.js
+++ b/src/type/__tests__/date-test.js
@@ -14,6 +14,12 @@ describe('GraphQLDate', () => {
       );
     });
 
+    it('pass number', () => {
+      expect(GraphQLDate.serialize(new Date(Date.UTC(2018, 10, 1)).getTime())).toBe(
+        '2018-11-01T00:00:00.000Z'
+      );
+    });
+
     it('pass "2016-02-02T00:13:22.000Z"', () => {
       expect(GraphQLDate.serialize('2016-02-02T00:13:22.000Z')).toBe('2016-02-02T00:13:22.000Z');
     });

--- a/src/type/__tests__/date-test.js
+++ b/src/type/__tests__/date-test.js
@@ -52,4 +52,14 @@ describe('GraphQLDate', () => {
       expect(date.toJSON()).toEqual(ast.value);
     });
   });
+
+  it('parse a ast literal of integer kind', async () => {
+    const ast = {
+      kind: Kind.INT,
+      value: '1541030400000',
+    };
+    const date: any = GraphQLDate.parseLiteral(ast);
+    expect(date).toBeInstanceOf(Date);
+    expect(date.toJSON()).toBe('2018-11-01T00:00:00.000Z');
+  });
 });

--- a/src/type/date.js
+++ b/src/type/date.js
@@ -17,6 +17,10 @@ export default new GraphQLScalarType({
       return value;
     }
 
+    if (typeof value === 'number' && isFinite(value)) {
+      return new Date(value).toJSON();
+    }
+
     if (!(value instanceof Date)) {
       throw new TypeError('Field error: value is not an instance of Date');
     }

--- a/src/type/date.js
+++ b/src/type/date.js
@@ -41,9 +41,13 @@ export default new GraphQLScalarType({
     return date;
   },
   parseLiteral(ast) {
+    if (ast.kind === Kind.INT) {
+      return new Date(parseInt(ast.value, 10));
+    }
+
     if (ast.kind !== Kind.STRING) {
       throw new GraphQLError(
-        `Query error: Can only parse strings to buffers but got a: ${ast.kind}`,
+        `Query error: Can only parse strings or integers to buffers but got a: ${ast.kind}`,
         [ast]
       );
     }


### PR DESCRIPTION
Allow timestamps (e.g. the result from `Date.now()`) as GraphQLDate values.