### PR TITLE
Add InputType methods to InterfaceTypeComposer

### DIFF
--- a/src/InterfaceTypeComposer.d.ts
+++ b/src/InterfaceTypeComposer.d.ts
@@ -27,6 +27,7 @@ export type GraphQLInterfaceTypeExtended<
   TContext
 > = GraphQLInterfaceType & {
   _gqcFields?: ComposeFieldConfigMap<TSource, TContext>;
+  _gqcInputTypeComposer?: InputTypeComposer;
   _gqcTypeResolvers?: InterfaceTypeResolversMap<TSource, TContext>;
 };
 

--- a/src/InterfaceTypeComposer.d.ts
+++ b/src/InterfaceTypeComposer.d.ts
@@ -2,6 +2,7 @@ import {
   GraphQLArgumentConfig,
   GraphQLFieldConfig,
   GraphQLFieldConfigArgumentMap,
+  GraphQLInputObjectType,
   GraphQLInputType,
   GraphQLInterfaceType,
   GraphQLList,
@@ -11,6 +12,7 @@ import {
   GraphQLResolveInfo,
   GraphQLTypeResolver,
 } from 'graphql';
+import { InputTypeComposer } from './InputTypeComposer';
 import { SchemaComposer } from './SchemaComposer';
 import {
   ComposeFieldConfig,
@@ -152,6 +154,18 @@ export class InterfaceTypeComposer<TSource = any, TContext = any> {
   public setDescription(description: string): this;
 
   public clone(newTypeName: string): this;
+
+  // -----------------------------------------------
+  // InputType methods
+  // -----------------------------------------------
+
+  public getInputType(): GraphQLInputObjectType;
+
+  public hasInputTypeComposer(): boolean;
+
+  public getInputTypeComposer(): InputTypeComposer;
+
+  public getITC(): InputTypeComposer;
 
   // -----------------------------------------------
   // ResolveType methods

--- a/src/InterfaceTypeComposer.js
+++ b/src/InterfaceTypeComposer.js
@@ -22,6 +22,7 @@ import type {
   GraphQLResolveInfo,
   GraphQLTypeResolver,
 } from './graphql';
+import type { InputTypeComposer } from './InputTypeComposer';
 import type { TypeAsString } from './TypeMapper';
 import type { SchemaComposer } from './SchemaComposer';
 import type {
@@ -31,6 +32,7 @@ import type {
 } from './TypeComposer';
 import type { Thunk } from './utils/definitions';
 import { resolveOutputConfigMapAsThunk, resolveOutputConfigAsThunk } from './utils/configAsThunk';
+import { toInputObjectType } from './utils/toInputObjectType';
 import { typeByPath } from './utils/typeByPath';
 import { getGraphQLType } from './utils/typeHelpers';
 import { defineFieldMap, defineFieldMapToConfig } from './utils/configToDefine';
@@ -447,6 +449,31 @@ export class InterfaceTypeComposer<TContext> {
     cloned.setDescription(this.getDescription());
 
     return cloned;
+  }
+
+  // -----------------------------------------------
+  // InputType methods
+  // -----------------------------------------------
+
+  getInputType(): GraphQLInputObjectType {
+    return this.getInputTypeComposer().getType();
+  }
+
+  hasInputTypeComposer(): boolean {
+    return !!this.gqType._gqcInputTypeComposer;
+  }
+
+  getInputTypeComposer(): InputTypeComposer {
+    if (!this.gqType._gqcInputTypeComposer) {
+      this.gqType._gqcInputTypeComposer = toInputObjectType(this);
+    }
+
+    return this.gqType._gqcInputTypeComposer;
+  }
+
+  // Alias for getInputTypeComposer()
+  getITC(): InputTypeComposer {
+    return this.getInputTypeComposer();
   }
 
   // -----------------------------------------------

--- a/src/InterfaceTypeComposer.js
+++ b/src/InterfaceTypeComposer.js
@@ -16,6 +16,7 @@ import type {
   GraphQLFieldConfig,
   GraphQLFieldConfigMap,
   GraphQLOutputType,
+  GraphQLInputObjectType,
   GraphQLInputType,
   GraphQLFieldConfigArgumentMap,
   GraphQLArgumentConfig,

--- a/src/InterfaceTypeComposer.js
+++ b/src/InterfaceTypeComposer.js
@@ -41,6 +41,7 @@ import { graphqlVersion } from './utils/graphqlVersion';
 
 export type GraphQLInterfaceTypeExtended<TSource, TContext> = GraphQLInterfaceType & {
   _gqcFields?: ComposeFieldConfigMap<TSource, TContext>,
+  _gqcInputTypeComposer?: InputTypeComposer,
   _gqcTypeResolvers?: InterfaceTypeResolversMap<TSource, TContext>,
 };
 

--- a/src/utils/toInputObjectType.js
+++ b/src/utils/toInputObjectType.js
@@ -29,7 +29,7 @@ export function toInputObjectType(
   opts: toInputObjectTypeOpts = {},
   cache: Map<GraphQLNamedType, InputTypeComposer> = new Map()
 ): InputTypeComposer {
-  if (typeComposer instanceof TypeComposer && typeComposer.hasInputTypeComposer()) {
+  if (typeComposer.hasInputTypeComposer()) {
     return typeComposer.getInputTypeComposer();
   }
 


### PR DESCRIPTION
This adds input type methods to `InterfaceTypeComposer`, same as the ones on `TypeComposer`.