### PR TITLE
Accept more Date formats in parseLiteral

### DIFF
--- a/src/type/date.js
+++ b/src/type/date.js
@@ -57,13 +57,6 @@ export default new GraphQLScalarType({
       throw new GraphQLError('Query error: Invalid date', [ast]);
     }
 
-    if (ast.value !== result.toJSON()) {
-      throw new GraphQLError(
-        'Query error: Invalid date format, only accepts: YYYY-MM-DDTHH:MM:SS.SSSZ',
-        [ast]
-      );
-    }
-
     return result;
   },
 });


### PR DESCRIPTION
It think it would make sense to be less strict in `GraphQLDate.parseLiteral` and accept any ast value that can be transformed into a valid Date.

This is e.g. useful when specifying a Date as a filter arg.

Is there a reason for only allowing YYYY-MM-DDTHH:MM:SS.SSSZ format?