### PR TITLE
Fix import 'find' on typeMapper

### DIFF
--- a/src/TypeMapper.js
+++ b/src/TypeMapper.js
@@ -6,7 +6,7 @@ import { Kind } from 'graphql/language';
 import { getDescription } from 'graphql/utilities/buildASTSchema';
 import keyValMap from 'graphql/jsutils/keyValMap';
 import invariant from 'graphql/jsutils/invariant';
-import find from 'graphql/jsutils/find';
+import find from 'graphql/polyfills/find';
 import { getArgumentValues, getDirectiveValues } from 'graphql/execution/values';
 import type {
   DocumentNode,


### PR DESCRIPTION
Since v14.1.0 graphql moved the find util jsutils > polyfills

The commit is this:
https://github.com/graphql/graphql-js/commit/9e404659a15d59c5ce12aae433dd2a636ea9eb82#diff-29dc0deb58871880ac2e0c670e9518c9

This breaks existing code. The graphql-compose library crashes at start because of that import.