### PR TITLE
Don't add outputTypeName to InputTypeComposer prefix

### DIFF
--- a/src/utils/__tests__/toInputObjectType-test.js
+++ b/src/utils/__tests__/toInputObjectType-test.js
@@ -58,7 +58,7 @@ describe('toInputObjectType()', () => {
     const itc = toInputObjectType(PersonTC);
     const addrType = itc.getFieldType('address');
     expect(addrType).toBeInstanceOf(GraphQLInputObjectType);
-    expect((addrType: any).name).toBe('PersonAddressInput');
+    expect((addrType: any).name).toBe('AddressInput');
   });
 
   it('should reuse generated input type for recursive types', () => {
@@ -106,7 +106,7 @@ describe('toInputObjectType()', () => {
     expect(itc.getFieldType('age')).toBe(GraphQLInt);
     const ifaceField = itc.getFieldTC('neighbor');
     expect(ifaceField.getType()).toBeInstanceOf(GraphQLInputObjectType);
-    expect(ifaceField.getTypeName()).toBe('ExampleIFaceInput');
+    expect(ifaceField.getTypeName()).toBe('IFaceInput');
     expect(ifaceField.getFieldType('name')).toBe(GraphQLString);
     expect(ifaceField.getFieldType('age')).toBe(GraphQLInt);
     expect(itc.getTypeName()).toBe('ExampleInput');

--- a/src/utils/toInputObjectType.js
+++ b/src/utils/toInputObjectType.js
@@ -16,7 +16,6 @@ import type { InterfaceTypeComposer } from '../InterfaceTypeComposer';
 import type { InputTypeComposer } from '../InputTypeComposer';
 import type { SchemaComposer } from '../SchemaComposer';
 import GenericType from '../type/generic';
-import { upperFirst } from './misc';
 import type { GraphQLType, GraphQLInputType, GraphQLNamedType } from '../graphql';
 
 export type toInputObjectTypeOpts = {
@@ -102,7 +101,7 @@ export function convertInputObjectField(
   if (!isInputType(fieldType)) {
     if (fieldType instanceof GraphQLObjectType || fieldType instanceof GraphQLInterfaceType) {
       const typeOpts = {
-        prefix: `${opts.prefix || ''}${upperFirst(opts.outputTypeName || '')}`,
+        prefix: opts.prefix || '',
         postfix: opts.postfix || 'Input',
       };
       const tc =


### PR DESCRIPTION
Currently in `toInputObjectType` the names of the created ITCs are prefixed with the names of their upper-level TCs. This can lead to very long names for deeper nesting levels, and also seems unnecessary since the TC name should already be unique. But I'm not sure if anyone could rely on this naming scheme?