### PR TITLE
BUMP 6.0.0, preparation for decorators

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -47,6 +47,7 @@
     "Iterator": true,
     "$Shape": true,
     "$FlowFixMe": true,
-    "$ReadOnlyArray": true
+    "$ReadOnlyArray": true,
+    "$Keys": true
   }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -48,6 +48,7 @@
     "$Shape": true,
     "$FlowFixMe": true,
     "$ReadOnlyArray": true,
-    "$Keys": true
+    "$Keys": true,
+    "$ReadOnly": true
   }
 }

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,10 @@
+{
+  "line-length": false,
+  "no-trailing-punctuation": {
+    "punctuation": ",;"
+  },
+  "no-inline-html": false,
+  "ol-prefix": false,
+  "first-line-h1": false,
+  "first-heading-h1": false
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+  "prettier.eslintIntegration": true,
+  "eslint.validate": [
+    "javascript",
+  ],
+  "javascript.validate.enable": false
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  // moduleNameMapper: {
+  //   '^app(.*)$': '<rootDir>/src$1',
+  // },
+  moduleFileExtensions: ['js'],
+  testMatch: ['**/__tests__/**/*-test.(ts|js)'],
+  roots: ['<rootDir>/src'],
+};

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "eslint-plugin-flowtype": "^3.2.1",
     "eslint-plugin-import": "^2.15.0",
     "eslint-plugin-prettier": "^3.0.1",
-    "flow-bin": "0.91.0",
+    "flow-bin": "0.94.0",
     "graphql": "14.1.1",
     "jest": "^23.6.0",
     "prettier": "^1.16.1",

--- a/package.json
+++ b/package.json
@@ -85,8 +85,6 @@
     "tscheck": "tsc --noEmit",
     "flow": "./node_modules/.bin/flow",
     "test": "npm run coverage && npm run lint && npm run flow && npm run tscheck",
-    "link": "yarn link graphql && yarn link",
-    "unlink": "yarn unlink graphql && yarn add graphql",
     "semantic-release": "semantic-release",
     "test-vers": "yarn add graphql@0.13.0 --dev && jest && yarn add graphql@14.0.0 --dev && jest"
   },

--- a/package.json
+++ b/package.json
@@ -69,11 +69,6 @@
       "path": "./node_modules/cz-conventional-changelog"
     }
   },
-  "jest": {
-    "roots": [
-      "<rootDir>/src"
-    ]
-  },
   "scripts": {
     "build": "npm run build-cjs && npm run build-mjs && npm run build-esm",
     "build-cjs": "rimraf lib && BABEL_ENV=cjs babel src --ignore __tests__,__mocks__ -d lib && COPY_TO_FOLDER=lib npm run build-flow && COPY_TO_FOLDER=lib npm run build-ts",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "build-ts": "find ./src -name '*.d.ts' -not -path '*/__*' | while read filepath; do cp $filepath `echo ./${COPY_TO_FOLDER:-lib}$filepath | sed 's/.\\/src\\//\\//g'`; done",
     "watch": "jest --watch",
     "coverage": "jest --coverage --maxWorkers 4",
-    "lint": "npm run eslint && npm run tslint",
+    "lint": "npm run eslint && npm run tslint && npm run tscheck",
     "eslint": "eslint --ext .js ./src",
     "tslint": "tslint -p . \"src/**/*.d.ts\"",
     "tscheck": "tsc --noEmit",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,6 @@
     "tslint": "tslint -p . \"src/**/*.d.ts\"",
     "tscheck": "tsc --noEmit",
     "flow": "./node_modules/.bin/flow",
-    "glow": "./node_modules/.bin/glow --watch",
     "test": "npm run coverage && npm run lint && npm run flow && npm run tscheck",
     "link": "yarn link graphql && yarn link",
     "unlink": "yarn unlink graphql && yarn add graphql",

--- a/src/EnumTypeComposer.d.ts
+++ b/src/EnumTypeComposer.d.ts
@@ -27,8 +27,8 @@ export type GraphQLEnumTypeExtended = GraphQLEnumType & {
 
 export class EnumTypeComposer {
   public static schemaComposer: SchemaComposer<any>;
-  public schemaComposer: SchemaComposer<any>;
 
+  public schemaComposer: SchemaComposer<any>;
   protected gqType: GraphQLEnumTypeExtended;
 
   public constructor(gqType: GraphQLEnumType);

--- a/src/EnumTypeComposer.d.ts
+++ b/src/EnumTypeComposer.d.ts
@@ -2,14 +2,13 @@
 /* eslint-disable no-use-before-define */
 
 import { GraphQLEnumType, GraphQLList, GraphQLNonNull } from './graphql';
-import { TypeMapper } from './TypeMapper';
 import {
   GraphQLEnumValueConfig,
   GraphQLEnumTypeConfig,
   GraphQLEnumValueConfigMap,
 } from './graphql';
-import { SchemaComposer } from './SchemaComposer';
 import { TypeAsString } from './TypeMapper';
+import { SchemaComposer } from './SchemaComposer';
 import { Extensions } from './utils/definitions';
 
 export type ComposeEnumTypeConfig = GraphQLEnumTypeConfig & {
@@ -25,19 +24,24 @@ export type GraphQLEnumTypeExtended = GraphQLEnumType & {
   _gqcExtensions?: Extensions;
 };
 
-export class EnumTypeComposer {
-  public static schemaComposer: SchemaComposer<any>;
-
-  public schemaComposer: SchemaComposer<any>;
+export class EnumTypeComposer<TContext = any> {
+  public schemaComposer: SchemaComposer<TContext>;
   protected gqType: GraphQLEnumTypeExtended;
 
-  public constructor(gqType: GraphQLEnumType);
+  public constructor(
+    gqType: GraphQLEnumType,
+    schemaComposer: SchemaComposer<TContext>,
+  );
 
-  public static create(typeDef: EnumTypeComposerDefinition): EnumTypeComposer;
-
-  public static createTemp(
+  public static create<TCtx = any>(
     typeDef: EnumTypeComposerDefinition,
-  ): EnumTypeComposer;
+    schemaComposer: SchemaComposer<TCtx>,
+  ): EnumTypeComposer<TCtx>;
+
+  public static createTemp<TCtx = any>(
+    typeDef: EnumTypeComposerDefinition,
+    schemaComposer?: SchemaComposer<TCtx>,
+  ): EnumTypeComposer<TCtx>;
 
   // -----------------------------------------------
   // Value methods
@@ -65,7 +69,7 @@ export class EnumTypeComposer {
 
   public extendField(
     name: string,
-    partialValueConfig: GraphQLEnumValueConfig,
+    partialValueConfig: Partial<GraphQLEnumValueConfig>,
   ): this;
 
   public deprecateFields(
@@ -110,5 +114,5 @@ export class EnumTypeComposer {
 
   public setDescription(description: string): this;
 
-  public clone(newTypeName: string): EnumTypeComposer;
+  public clone(newTypeName: string): EnumTypeComposer<TContext>;
 }

--- a/src/EnumTypeComposer.js
+++ b/src/EnumTypeComposer.js
@@ -28,14 +28,14 @@ export type GraphQLEnumTypeExtended = GraphQLEnumType & {
   _gqcExtensions?: Extensions,
 };
 
-export class EnumTypeComposer {
+export class EnumTypeComposer<TContext> {
   gqType: GraphQLEnumTypeExtended;
-  schemaComposer: SchemaComposer<any>;
+  schemaComposer: SchemaComposer<TContext>;
 
-  static create(
+  static create<TCtx>(
     typeDef: EnumTypeComposerDefinition,
-    schemaComposer: SchemaComposer<any>
-  ): EnumTypeComposer {
+    schemaComposer: SchemaComposer<TCtx>
+  ): EnumTypeComposer<TCtx> {
     if (!(schemaComposer instanceof SchemaComposer)) {
       throw new Error(
         'You must provide SchemaComposer instance as a second argument for `EnumTypeComposer.create(typeDef, schemaComposer)`'
@@ -46,10 +46,10 @@ export class EnumTypeComposer {
     return etc;
   }
 
-  static createTemp(
+  static createTemp<TCtx>(
     typeDef: EnumTypeComposerDefinition,
-    schemaComposer?: SchemaComposer<any>
-  ): EnumTypeComposer {
+    schemaComposer?: SchemaComposer<TCtx>
+  ): EnumTypeComposer<TCtx> {
     const sc = schemaComposer || new SchemaComposer();
 
     let ETC;
@@ -90,7 +90,10 @@ export class EnumTypeComposer {
     return ETC;
   }
 
-  constructor(gqType: GraphQLEnumType, schemaComposer: SchemaComposer<any>) {
+  constructor(
+    gqType: GraphQLEnumType,
+    schemaComposer: SchemaComposer<TContext>
+  ): EnumTypeComposer<TContext> {
     if (!(schemaComposer instanceof SchemaComposer)) {
       throw new Error(
         'You must provide SchemaComposer instance as a second argument for `new EnumTypeComposer(GraphQLEnumType, SchemaComposer)`'
@@ -102,6 +105,9 @@ export class EnumTypeComposer {
       throw new Error('EnumTypeComposer accept only GraphQLEnumType in constructor');
     }
     this.gqType = gqType;
+
+    // alive proper Flow type casting in autosuggestions for class with Generics
+    /* :: return this; */
   }
 
   // -----------------------------------------------
@@ -152,7 +158,7 @@ export class EnumTypeComposer {
    * Completely replace all values in GraphQL enum type
    * WARNING: this method rewrite an internal GraphQL instance properties.
    */
-  setFields(values: GraphQLEnumValueConfigMap): EnumTypeComposer {
+  setFields(values: GraphQLEnumValueConfigMap): EnumTypeComposer<TContext> {
     if (graphqlVersion >= 14) {
       this.gqType._values = defineEnumValues(this.gqType, values);
       this.gqType._valueLookup = new Map(
@@ -180,7 +186,7 @@ export class EnumTypeComposer {
     return this;
   }
 
-  setField(name: string, valueConfig: GraphQLEnumValueConfig): EnumTypeComposer {
+  setField(name: string, valueConfig: GraphQLEnumValueConfig): EnumTypeComposer<TContext> {
     this.addFields({ [name]: valueConfig });
     return this;
   }
@@ -188,12 +194,12 @@ export class EnumTypeComposer {
   /**
    * Add new fields or replace existed in a GraphQL type
    */
-  addFields(newValues: GraphQLEnumValueConfigMap): EnumTypeComposer {
+  addFields(newValues: GraphQLEnumValueConfigMap): EnumTypeComposer<TContext> {
     this.setFields({ ...this.getFields(), ...newValues });
     return this;
   }
 
-  removeField(nameOrArray: string | Array<string>): EnumTypeComposer {
+  removeField(nameOrArray: string | string[]): EnumTypeComposer<TContext> {
     const valueNames = Array.isArray(nameOrArray) ? nameOrArray : [nameOrArray];
     const values = this.getFields();
     valueNames.forEach(valueName => delete values[valueName]);
@@ -201,7 +207,7 @@ export class EnumTypeComposer {
     return this;
   }
 
-  removeOtherFields(fieldNameOrArray: string | Array<string>): EnumTypeComposer {
+  removeOtherFields(fieldNameOrArray: string | string[]): EnumTypeComposer<TContext> {
     const keepFieldNames = Array.isArray(fieldNameOrArray) ? fieldNameOrArray : [fieldNameOrArray];
     const fields = this.getFields();
     Object.keys(fields).forEach(fieldName => {
@@ -213,7 +219,7 @@ export class EnumTypeComposer {
     return this;
   }
 
-  reorderFields(names: string[]): EnumTypeComposer {
+  reorderFields(names: string[]): EnumTypeComposer<TContext> {
     const orderedFields = {};
     const fields = this.getFields();
     names.forEach(name => {
@@ -226,7 +232,10 @@ export class EnumTypeComposer {
     return this;
   }
 
-  extendField(name: string, partialValueConfig: $Shape<GraphQLEnumValueConfig>): EnumTypeComposer {
+  extendField(
+    name: string,
+    partialValueConfig: $Shape<GraphQLEnumValueConfig>
+  ): EnumTypeComposer<TContext> {
     let prevValueConfig;
     try {
       prevValueConfig = this.getField(name);
@@ -291,12 +300,12 @@ export class EnumTypeComposer {
     }
   }
 
-  setExtensions(extensions: Extensions): EnumTypeComposer {
+  setExtensions(extensions: Extensions): EnumTypeComposer<TContext> {
     this.gqType._gqcExtensions = extensions;
     return this;
   }
 
-  extendExtensions(extensions: Extensions): EnumTypeComposer {
+  extendExtensions(extensions: Extensions): EnumTypeComposer<TContext> {
     const current = this.getExtensions();
     this.setExtensions({
       ...current,
@@ -305,7 +314,7 @@ export class EnumTypeComposer {
     return this;
   }
 
-  clearExtensions(): EnumTypeComposer {
+  clearExtensions(): EnumTypeComposer<TContext> {
     this.setExtensions({});
     return this;
   }
@@ -320,14 +329,14 @@ export class EnumTypeComposer {
     return extensionName in extensions;
   }
 
-  setExtension(extensionName: string, value: any): EnumTypeComposer {
+  setExtension(extensionName: string, value: any): EnumTypeComposer<TContext> {
     this.extendExtensions({
       [extensionName]: value,
     });
     return this;
   }
 
-  removeExtension(extensionName: string): EnumTypeComposer {
+  removeExtension(extensionName: string): EnumTypeComposer<TContext> {
     const extensions = { ...this.getExtensions() };
     delete extensions[extensionName];
     this.setExtensions(extensions);
@@ -354,7 +363,7 @@ export class EnumTypeComposer {
     return this.gqType.name;
   }
 
-  setTypeName(name: string): EnumTypeComposer {
+  setTypeName(name: string): EnumTypeComposer<TContext> {
     this.gqType.name = name;
     this.schemaComposer.add(this);
     return this;
@@ -364,12 +373,12 @@ export class EnumTypeComposer {
     return this.gqType.description || '';
   }
 
-  setDescription(description: string): EnumTypeComposer {
+  setDescription(description: string): EnumTypeComposer<TContext> {
     this.gqType.description = description;
     return this;
   }
 
-  clone(newTypeName: string): EnumTypeComposer {
+  clone(newTypeName: string): EnumTypeComposer<TContext> {
     if (!newTypeName) {
       throw new Error('You should provide newTypeName:string for EnumTypeComposer.clone()');
     }

--- a/src/EnumTypeComposer.js
+++ b/src/EnumTypeComposer.js
@@ -30,24 +30,27 @@ export type GraphQLEnumTypeExtended = GraphQLEnumType & {
 
 export class EnumTypeComposer {
   gqType: GraphQLEnumTypeExtended;
-  sc: SchemaComposer<any>;
+  schemaComposer: SchemaComposer<any>;
 
-  static create(typeDef: EnumTypeComposerDefinition, sc: SchemaComposer<any>): EnumTypeComposer {
-    if (!(sc instanceof SchemaComposer)) {
+  static create(
+    typeDef: EnumTypeComposerDefinition,
+    schemaComposer: SchemaComposer<any>
+  ): EnumTypeComposer {
+    if (!(schemaComposer instanceof SchemaComposer)) {
       throw new Error(
         'You must provide SchemaComposer instance as a second argument for `EnumTypeComposer.create(typeDef, schemaComposer)`'
       );
     }
-    const etc = this.createTemp(typeDef, sc);
-    if (sc) sc.add(etc);
+    const etc = this.createTemp(typeDef, schemaComposer);
+    if (schemaComposer) schemaComposer.add(etc);
     return etc;
   }
 
   static createTemp(
     typeDef: EnumTypeComposerDefinition,
-    _sc?: SchemaComposer<any>
+    schemaComposer?: SchemaComposer<any>
   ): EnumTypeComposer {
-    const sc = _sc || new SchemaComposer();
+    const sc = schemaComposer || new SchemaComposer();
 
     let ETC;
 
@@ -87,13 +90,13 @@ export class EnumTypeComposer {
     return ETC;
   }
 
-  constructor(gqType: GraphQLEnumType, sc: SchemaComposer<any>) {
-    if (!(sc instanceof SchemaComposer)) {
+  constructor(gqType: GraphQLEnumType, schemaComposer: SchemaComposer<any>) {
+    if (!(schemaComposer instanceof SchemaComposer)) {
       throw new Error(
         'You must provide SchemaComposer instance as a second argument for `new EnumTypeComposer(GraphQLEnumType, SchemaComposer)`'
       );
     }
-    this.sc = sc;
+    this.schemaComposer = schemaComposer;
 
     if (!(gqType instanceof GraphQLEnumType)) {
       throw new Error('EnumTypeComposer accept only GraphQLEnumType in constructor');
@@ -353,7 +356,7 @@ export class EnumTypeComposer {
 
   setTypeName(name: string): EnumTypeComposer {
     this.gqType.name = name;
-    this.sc.add(this);
+    this.schemaComposer.add(this);
     return this;
   }
 
@@ -383,7 +386,7 @@ export class EnumTypeComposer {
         name: newTypeName,
         values: newValues,
       }),
-      this.sc
+      this.schemaComposer
     );
 
     cloned.setDescription(this.getDescription());

--- a/src/InputTypeComposer.d.ts
+++ b/src/InputTypeComposer.d.ts
@@ -8,10 +8,10 @@ import {
   InputValueDefinitionNode,
 } from './graphql';
 import { Thunk, ObjMap, Extensions } from './utils/definitions';
-import { TypeAsString } from './TypeMapper';
 import { SchemaComposer } from './SchemaComposer';
-import { EnumTypeComposer } from './EnumTypeComposer';
 import { ScalarTypeComposer } from './ScalarTypeComposer';
+import { EnumTypeComposer } from './EnumTypeComposer';
+import { TypeAsString } from './TypeMapper';
 
 export type GraphQLInputObjectTypeExtended = GraphQLInputObjectType & {
   _gqcFields?: ComposeInputFieldConfigMap;
@@ -32,18 +32,18 @@ export type ComposeInputFieldConfigAsObject = {
   astNode?: InputValueDefinitionNode | null;
   extensions?: Extensions;
   [key: string]: any;
-} & { $call?: void };
+};
 
 export type ComposeInputType =
-  | InputTypeComposer
-  | EnumTypeComposer
-  | ScalarTypeComposer
+  | InputTypeComposer<any>
+  | EnumTypeComposer<any>
+  | ScalarTypeComposer<any>
   | GraphQLInputType
   | TypeAsString
   | Array<
-      | InputTypeComposer
-      | EnumTypeComposer
-      | ScalarTypeComposer
+      | InputTypeComposer<any>
+      | EnumTypeComposer<any>
+      | ScalarTypeComposer<any>
       | GraphQLInputType
       | TypeAsString
     >;
@@ -62,20 +62,25 @@ export type InputTypeComposerDefinition =
   | ComposeInputObjectTypeConfig
   | GraphQLInputObjectType;
 
-export class InputTypeComposer {
-  public static schemaComposer: SchemaComposer<any>;
-  public schemaComposer: SchemaComposer<any>;
+export class InputTypeComposer<TContext = any> {
+  public schemaComposer: SchemaComposer<TContext>;
 
-  public gqType: GraphQLInputObjectTypeExtended;
+  protected gqType: GraphQLInputObjectTypeExtended;
 
-  public static create(typeDef: InputTypeComposerDefinition): InputTypeComposer;
+  public constructor(
+    gqType: GraphQLInputObjectType,
+    schemaComposer: SchemaComposer<TContext>,
+  );
 
-  public static createTemp<TContext = any>(
+  public static create<TCtx = any>(
     typeDef: InputTypeComposerDefinition,
-    _sc?: SchemaComposer<TContext>
-  ): InputTypeComposer;
+    schemaComposer: SchemaComposer<TCtx>,
+  ): InputTypeComposer<TCtx>;
 
-  public constructor(gqType: GraphQLInputObjectType);
+  public static createTemp<TCtx = any>(
+    typeDef: InputTypeComposerDefinition,
+    schemaComposer?: SchemaComposer<TCtx>,
+  ): InputTypeComposer<TCtx>;
 
   // -----------------------------------------------
   // Field methods
@@ -102,13 +107,8 @@ export class InputTypeComposer {
   /**
    * Add new fields or replace existed (where field name may have dots)
    */
-  public addNestedFields(
-    newFields: ComposeInputFieldConfigMap,
-  ): InputTypeComposer;
+  public addNestedFields(newFields: ComposeInputFieldConfigMap): this;
 
-  /**
-   * Get fieldConfig by name
-   */
   public getField(fieldName: string): ComposeInputFieldConfig;
 
   public removeField(fieldNameOrArray: string | string[]): this;
@@ -117,7 +117,7 @@ export class InputTypeComposer {
 
   public extendField(
     fieldName: string,
-    parialFieldConfig: ComposeInputFieldConfig,
+    parialFieldConfig: Partial<ComposeInputFieldConfig>,
   ): this;
 
   public reorderFields(names: string[]): this;
@@ -131,7 +131,7 @@ export class InputTypeComposer {
 
   public getFieldType(fieldName: string): GraphQLInputType;
 
-  public getFieldTC(fieldName: string): InputTypeComposer;
+  public getFieldTC(fieldName: string): InputTypeComposer<TContext>;
 
   public makeFieldNonNull(fieldNameOrArray: string | string[]): this;
 
@@ -161,7 +161,7 @@ export class InputTypeComposer {
 
   public setDescription(description: string): this;
 
-  public clone(newTypeName: string): InputTypeComposer;
+  public clone(newTypeName: string): InputTypeComposer<TContext>;
 
   // -----------------------------------------------
   // Extensions methods

--- a/src/InputTypeComposer.js
+++ b/src/InputTypeComposer.js
@@ -398,12 +398,6 @@ export class InputTypeComposer {
     return new GraphQLNonNull(this.gqType);
   }
 
-  /** @deprecated 5.0.0 */
-  getTypeAsRequired(): GraphQLNonNull<GraphQLInputObjectType> {
-    deprecate('Use `InputTypeComposer.getTypeNonNull` method instead of `getTypeAsRequired`');
-    return this.getTypeNonNull();
-  }
-
   getTypeName(): string {
     return this.gqType.name;
   }

--- a/src/InputTypeComposer.js
+++ b/src/InputTypeComposer.js
@@ -9,7 +9,7 @@ import {
   isInputType,
 } from './graphql';
 import { resolveMaybeThunk, upperFirst } from './utils/misc';
-import { deprecate } from './utils/debug';
+// import { deprecate } from './utils/debug';
 import { isObject, isFunction, isString } from './utils/is';
 import { resolveInputConfigMapAsThunk, resolveInputConfigAsThunk } from './utils/configAsThunk';
 import { typeByPath } from './utils/typeByPath';

--- a/src/InputTypeComposer.js
+++ b/src/InputTypeComposer.js
@@ -163,8 +163,7 @@ export class InputTypeComposer {
       if (graphqlVersion >= 14) {
         this.gqType._gqcFields = (defineInputFieldMapToConfig(this.gqType._fields): any);
       } else {
-        // $FlowFixMe
-        const fields: Thunk<GraphQLInputFieldConfigMap> = this.gqType._typeConfig.fields;
+        const fields: Thunk<GraphQLInputFieldConfigMap> = (this.gqType: any)._typeConfig.fields;
         this.gqType._gqcFields = (resolveMaybeThunk(fields) || {}: any);
       }
     }
@@ -196,8 +195,7 @@ export class InputTypeComposer {
         );
       };
     } else {
-      // $FlowFixMe
-      this.gqType._typeConfig.fields = () => {
+      (this.gqType: any)._typeConfig.fields = () => {
         return resolveInputConfigMapAsThunk(this.schemaComposer, fields, this.getTypeName());
       };
       delete this.gqType._fields; // if schema was builded, delete defineFieldMap

--- a/src/InputTypeComposer.js
+++ b/src/InputTypeComposer.js
@@ -9,7 +9,6 @@ import {
   isInputType,
 } from './graphql';
 import { resolveMaybeThunk, upperFirst } from './utils/misc';
-// import { deprecate } from './utils/debug';
 import { isObject, isFunction, isString } from './utils/is';
 import { resolveInputConfigMapAsThunk, resolveInputConfigAsThunk } from './utils/configAsThunk';
 import { typeByPath } from './utils/typeByPath';

--- a/src/InterfaceTypeComposer.d.ts
+++ b/src/InterfaceTypeComposer.d.ts
@@ -17,8 +17,8 @@ import { SchemaComposer } from './SchemaComposer';
 import {
   ComposeFieldConfig,
   ComposeFieldConfigMap,
-  TypeComposer,
-} from './TypeComposer';
+  ObjectTypeComposer,
+} from './ObjectTypeComposer';
 import { TypeAsString } from './TypeMapper';
 import { Thunk, MaybePromise, Extensions } from './utils/definitions';
 
@@ -33,7 +33,7 @@ export type GraphQLInterfaceTypeExtended<
 };
 
 export type InterfaceTypeResolversMap<TSource, TContext> = Map<
-  TypeComposer<any, TContext> | GraphQLObjectType,
+  ObjectTypeComposer<any, TContext> | GraphQLObjectType,
   InterfaceTypeResolverCheckFn<TSource, TContext>
 >;
 
@@ -114,7 +114,7 @@ export class InterfaceTypeComposer<TSource = any, TContext = any> {
 
   public getFieldType(fieldName: string): GraphQLOutputType;
 
-  public getFieldTC(fieldName: string): TypeComposer<any, TContext>;
+  public getFieldTC(fieldName: string): ObjectTypeComposer<any, TContext>;
 
   public makeFieldNonNull(fieldNameOrArray: string | string[]): this;
 
@@ -179,13 +179,13 @@ export class InterfaceTypeComposer<TSource = any, TContext = any> {
   ): this;
 
   public hasTypeResolver(
-    type: TypeComposer<any, TContext> | GraphQLObjectType,
+    type: ObjectTypeComposer<any, TContext> | GraphQLObjectType,
   ): boolean;
 
   public getTypeResolvers(): InterfaceTypeResolversMap<TSource, TContext>;
 
   public getTypeResolverCheckFn(
-    type: TypeComposer<any, TContext> | GraphQLObjectType,
+    type: ObjectTypeComposer<any, TContext> | GraphQLObjectType,
   ): InterfaceTypeResolverCheckFn<TSource, TContext>;
 
   public getTypeResolverNames(): string[];
@@ -197,12 +197,12 @@ export class InterfaceTypeComposer<TSource = any, TContext = any> {
   ): this;
 
   public addTypeResolver(
-    type: TypeComposer<any, TContext> | GraphQLObjectType,
+    type: ObjectTypeComposer<any, TContext> | GraphQLObjectType,
     checkFn: InterfaceTypeResolverCheckFn<TSource, TContext>,
   ): this;
 
   public removeTypeResolver(
-    type: TypeComposer<any, TContext> | GraphQLObjectType,
+    type: ObjectTypeComposer<any, TContext> | GraphQLObjectType,
   ): this;
 
   // -----------------------------------------------

--- a/src/InterfaceTypeComposer.d.ts
+++ b/src/InterfaceTypeComposer.d.ts
@@ -51,24 +51,24 @@ export type ComposeInterfaceTypeConfig<TSource, TContext> = {
   extensions?: Extensions;
 };
 
-export type InterfaceTypeComposerDefinition<TContext> =
+export type InterfaceTypeComposerDefinition<TSource, TContext> =
   | TypeAsString
-  | ComposeInterfaceTypeConfig<any, TContext>;
+  | ComposeInterfaceTypeConfig<TSource, TContext>;
 
 export class InterfaceTypeComposer<TSource = any, TContext = any> {
   public static schemaComposer: SchemaComposer<any>;
-  public schemaComposer: SchemaComposer<TSource>;
+  public schemaComposer: SchemaComposer<TContext>;
 
   protected gqType: GraphQLInterfaceTypeExtended<TSource, TContext>;
 
   public constructor(gqType: GraphQLInterfaceType);
 
   public static create<TSrc = any, TCtx = any>(
-    typeDef: InterfaceTypeComposerDefinition<TCtx>,
+    typeDef: InterfaceTypeComposerDefinition<TSrc, TCtx>,
   ): InterfaceTypeComposer<TSrc, TCtx>;
 
   public static createTemp<TSrc = any, TCtx = any>(
-    typeDef: InterfaceTypeComposerDefinition<TCtx>,
+    typeDef: InterfaceTypeComposerDefinition<TSrc, TCtx>,
   ): InterfaceTypeComposer<TSrc, TCtx>;
 
   // -----------------------------------------------
@@ -77,23 +77,23 @@ export class InterfaceTypeComposer<TSource = any, TContext = any> {
 
   public hasField(name: string): boolean;
 
-  public getFields(): ComposeFieldConfigMap<TSource, TContext>;
+  public getFields(): ComposeFieldConfigMap<any, TContext>;
 
-  public getField(name: string): ComposeFieldConfig<TSource, TContext>;
+  public getField(name: string): ComposeFieldConfig<any, TContext>;
 
   public getFieldNames(): string[];
 
-  public setFields(fields: ComposeFieldConfigMap<TSource, TContext>): this;
+  public setFields(fields: ComposeFieldConfigMap<any, TContext>): this;
 
   public setField(
     name: string,
-    fieldConfig: ComposeFieldConfig<TSource, TContext>,
+    fieldConfig: ComposeFieldConfig<any, TContext>,
   ): this;
 
   /**
    * Add new fields or replace existed in a GraphQL type
    */
-  public addFields(newValues: ComposeFieldConfigMap<TSource, TContext>): this;
+  public addFields(newValues: ComposeFieldConfigMap<any, TContext>): this;
 
   public removeField(nameOrArray: string | string[]): this;
 
@@ -103,7 +103,7 @@ export class InterfaceTypeComposer<TSource = any, TContext = any> {
 
   public extendField(
     fieldName: string,
-    parialFieldConfig: ComposeFieldConfig<TSource, TContext>,
+    parialFieldConfig: ComposeFieldConfig<any, TContext>,
   ): this;
 
   public isFieldNonNull(fieldName: string): boolean;
@@ -114,9 +114,7 @@ export class InterfaceTypeComposer<TSource = any, TContext = any> {
 
   public getFieldType(fieldName: string): GraphQLOutputType;
 
-  public getFieldTC<TSource>(
-    fieldName: string,
-  ): TypeComposer<TSource, TContext>;
+  public getFieldTC(fieldName: string): TypeComposer<any, TContext>;
 
   public makeFieldNonNull(fieldNameOrArray: string | string[]): this;
 
@@ -174,10 +172,10 @@ export class InterfaceTypeComposer<TSource = any, TContext = any> {
   // ResolveType methods
   // -----------------------------------------------
 
-  public getResolveType(): GraphQLTypeResolver<any, TContext> | null | void;
+  public getResolveType(): GraphQLTypeResolver<TSource, TContext> | null | void;
 
   public setResolveType(
-    fn: GraphQLTypeResolver<any, TContext> | null | void,
+    fn: GraphQLTypeResolver<TSource, TContext> | null | void,
   ): this;
 
   public hasTypeResolver(
@@ -188,19 +186,19 @@ export class InterfaceTypeComposer<TSource = any, TContext = any> {
 
   public getTypeResolverCheckFn(
     type: TypeComposer<any, TContext> | GraphQLObjectType,
-  ): InterfaceTypeResolverCheckFn<any, TContext>;
+  ): InterfaceTypeResolverCheckFn<TSource, TContext>;
 
   public getTypeResolverNames(): string[];
 
   public getTypeResolverTypes(): GraphQLObjectType[];
 
   public setTypeResolvers(
-    typeResolversMap: InterfaceTypeResolversMap<any, TContext>,
+    typeResolversMap: InterfaceTypeResolversMap<TSource, TContext>,
   ): this;
 
   public addTypeResolver(
     type: TypeComposer<any, TContext> | GraphQLObjectType,
-    checkFn: InterfaceTypeResolverCheckFn<any, TContext>,
+    checkFn: InterfaceTypeResolverCheckFn<TSource, TContext>,
   ): this;
 
   public removeTypeResolver(

--- a/src/InterfaceTypeComposer.js
+++ b/src/InterfaceTypeComposer.js
@@ -76,10 +76,10 @@ export class InterfaceTypeComposer<TSource, TContext> {
 
   // Also supported `GraphQLInterfaceType` but in such case Flowtype force developers
   // to explicitly write annotations in their code. But it's bad.
-  static create(
-    typeDef: InterfaceTypeComposerDefinition<TSource, TContext>,
-    sc: SchemaComposer<TContext>
-  ): InterfaceTypeComposer<TSource, TContext> {
+  static create<TSrc, TCtx>(
+    typeDef: InterfaceTypeComposerDefinition<TSrc, TCtx>,
+    sc: SchemaComposer<TCtx>
+  ): InterfaceTypeComposer<TSrc, TCtx> {
     if (!(sc instanceof SchemaComposer)) {
       throw new Error(
         'You must provide SchemaComposer instance as a second argument for `InterfaceTypeComposer.create(typeDef, schemaComposer)`'
@@ -91,10 +91,10 @@ export class InterfaceTypeComposer<TSource, TContext> {
     return iftc;
   }
 
-  static createTemp(
-    typeDef: InterfaceTypeComposerDefinition<TSource, TContext>,
-    _sc?: SchemaComposer<TContext>
-  ): InterfaceTypeComposer<TSource, TContext> {
+  static createTemp<TSrc, TCtx>(
+    typeDef: InterfaceTypeComposerDefinition<TSrc, TCtx>,
+    _sc?: SchemaComposer<TCtx>
+  ): InterfaceTypeComposer<TSrc, TCtx> {
     const sc = _sc || new SchemaComposer();
 
     let IFTC;

--- a/src/InterfaceTypeComposer.js
+++ b/src/InterfaceTypeComposer.js
@@ -165,7 +165,7 @@ export class InterfaceTypeComposer<TSource, TContext> {
     return !!fields[name];
   }
 
-  getFields(): ComposeFieldConfigMap<any, TContext> {
+  getFields(): ComposeFieldConfigMap<TSource, TContext> {
     if (!this.gqType._gqcFields) {
       if (graphqlVersion >= 14) {
         this.gqType._gqcFields = (defineFieldMapToConfig(this.gqType._fields): any);
@@ -179,7 +179,7 @@ export class InterfaceTypeComposer<TSource, TContext> {
     return this.gqType._gqcFields;
   }
 
-  getField(name: string): ComposeFieldConfig<any, TContext> {
+  getField(name: string): ComposeFieldConfig<TSource, TContext> {
     const values = this.getFields();
 
     if (!values[name]) {
@@ -196,7 +196,7 @@ export class InterfaceTypeComposer<TSource, TContext> {
   }
 
   setFields(
-    fields: ComposeFieldConfigMap<any, TContext>
+    fields: ComposeFieldConfigMap<TSource, TContext>
   ): InterfaceTypeComposer<TSource, TContext> {
     this.gqType._gqcFields = fields;
 
@@ -218,7 +218,7 @@ export class InterfaceTypeComposer<TSource, TContext> {
 
   setField(
     name: string,
-    fieldConfig: ComposeFieldConfig<any, TContext>
+    fieldConfig: ComposeFieldConfig<TSource, TContext>
   ): InterfaceTypeComposer<TSource, TContext> {
     this.addFields({ [name]: fieldConfig });
     return this;
@@ -228,7 +228,7 @@ export class InterfaceTypeComposer<TSource, TContext> {
    * Add new fields or replace existed in a GraphQL type
    */
   addFields(
-    newValues: ComposeFieldConfigMap<any, TContext>
+    newValues: ComposeFieldConfigMap<TSource, TContext>
   ): InterfaceTypeComposer<TSource, TContext> {
     this.setFields({ ...this.getFields(), ...newValues });
     return this;

--- a/src/InterfaceTypeComposer.js
+++ b/src/InterfaceTypeComposer.js
@@ -72,30 +72,30 @@ export type InterfaceTypeComposerDefinition<TSource, TContext> =
 
 export class InterfaceTypeComposer<TSource, TContext> {
   gqType: GraphQLInterfaceTypeExtended<TSource, TContext>;
-  sc: SchemaComposer<TContext>;
+  schemaComposer: SchemaComposer<TContext>;
 
   // Also supported `GraphQLInterfaceType` but in such case Flowtype force developers
   // to explicitly write annotations in their code. But it's bad.
   static create<TSrc, TCtx>(
     typeDef: InterfaceTypeComposerDefinition<TSrc, TCtx>,
-    sc: SchemaComposer<TCtx>
+    schemaComposer: SchemaComposer<TCtx>
   ): InterfaceTypeComposer<TSrc, TCtx> {
-    if (!(sc instanceof SchemaComposer)) {
+    if (!(schemaComposer instanceof SchemaComposer)) {
       throw new Error(
         'You must provide SchemaComposer instance as a second argument for `InterfaceTypeComposer.create(typeDef, schemaComposer)`'
       );
     }
 
-    const iftc = this.createTemp(typeDef, sc);
-    sc.add(iftc);
+    const iftc = this.createTemp(typeDef, schemaComposer);
+    schemaComposer.add(iftc);
     return iftc;
   }
 
   static createTemp<TSrc, TCtx>(
     typeDef: InterfaceTypeComposerDefinition<TSrc, TCtx>,
-    _sc?: SchemaComposer<TCtx>
+    schemaComposer?: SchemaComposer<TCtx>
   ): InterfaceTypeComposer<TSrc, TCtx> {
-    const sc = _sc || new SchemaComposer();
+    const sc = schemaComposer || new SchemaComposer();
 
     let IFTC;
 
@@ -142,13 +142,13 @@ export class InterfaceTypeComposer<TSource, TContext> {
     return IFTC;
   }
 
-  constructor(gqType: GraphQLInterfaceType, sc: SchemaComposer<TContext>) {
-    if (!(sc instanceof SchemaComposer)) {
+  constructor(gqType: GraphQLInterfaceType, schemaComposer: SchemaComposer<TContext>) {
+    if (!(schemaComposer instanceof SchemaComposer)) {
       throw new Error(
         'You must provide SchemaComposer instance as a second argument for `new InterfaceTypeComposer(GraphQLInterfaceType, SchemaComposer)`'
       );
     }
-    this.sc = sc;
+    this.schemaComposer = schemaComposer;
 
     if (!(gqType instanceof GraphQLInterfaceType)) {
       throw new Error('InterfaceTypeComposer accept only GraphQLInterfaceType in constructor');
@@ -204,12 +204,12 @@ export class InterfaceTypeComposer<TSource, TContext> {
       this.gqType._fields = () => {
         return defineFieldMap(
           this.gqType,
-          resolveOutputConfigMapAsThunk(this.sc, fields, this.getTypeName())
+          resolveOutputConfigMapAsThunk(this.schemaComposer, fields, this.getTypeName())
         );
       };
     } else {
       (this.gqType: any)._typeConfig.fields = () => {
-        return resolveOutputConfigMapAsThunk(this.sc, fields, this.getTypeName());
+        return resolveOutputConfigMapAsThunk(this.schemaComposer, fields, this.getTypeName());
       };
       delete this.gqType._fields; // clear builded fields in type
     }
@@ -299,7 +299,7 @@ export class InterfaceTypeComposer<TSource, TContext> {
       throw new Error(`Type ${this.getTypeName()} does not have field with name '${fieldName}'`);
     }
 
-    return resolveOutputConfigAsThunk(this.sc, fc, fieldName, this.getTypeName());
+    return resolveOutputConfigAsThunk(this.schemaComposer, fc, fieldName, this.getTypeName());
   }
 
   getFieldType(fieldName: string): GraphQLOutputType {
@@ -314,7 +314,7 @@ export class InterfaceTypeComposer<TSource, TContext> {
           `This field should be ObjectType, but it has type '${fieldType.constructor.name}'`
       );
     }
-    return ObjectTypeComposer.createTemp(fieldType, this.sc);
+    return ObjectTypeComposer.createTemp(fieldType, this.schemaComposer);
   }
 
   makeFieldNonNull(
@@ -437,7 +437,7 @@ export class InterfaceTypeComposer<TSource, TContext> {
 
   setTypeName(name: string): InterfaceTypeComposer<TSource, TContext> {
     this.gqType.name = name;
-    this.sc.add(this);
+    this.schemaComposer.add(this);
     return this;
   }
 
@@ -466,7 +466,7 @@ export class InterfaceTypeComposer<TSource, TContext> {
         name: newTypeName,
         fields: newFields,
       }),
-      this.sc
+      this.schemaComposer
     );
 
     cloned.setDescription(this.getDescription());

--- a/src/InterfaceTypeComposer.js
+++ b/src/InterfaceTypeComposer.js
@@ -11,7 +11,7 @@ import {
 } from './graphql';
 import { isObject, isString, isFunction } from './utils/is';
 import { resolveMaybeThunk, inspect } from './utils/misc';
-import { TypeComposer, isComposeOutputType } from './TypeComposer';
+import { ObjectTypeComposer, isComposeOutputType } from './ObjectTypeComposer';
 import type {
   GraphQLFieldConfig,
   GraphQLFieldConfigMap,
@@ -31,7 +31,7 @@ import type {
   ComposeFieldConfig,
   ComposePartialFieldConfigAsObject,
   ComposeObjectTypeConfig,
-} from './TypeComposer';
+} from './ObjectTypeComposer';
 import type { Thunk, Extensions, MaybePromise } from './utils/definitions';
 import { resolveOutputConfigMapAsThunk, resolveOutputConfigAsThunk } from './utils/configAsThunk';
 import { toInputObjectType } from './utils/toInputObjectType';
@@ -48,7 +48,7 @@ export type GraphQLInterfaceTypeExtended<TSource, TContext> = GraphQLInterfaceTy
 };
 
 export type InterfaceTypeResolversMap<TSource, TContext> = Map<
-  TypeComposer<any, TContext> | GraphQLObjectType,
+  ObjectTypeComposer<any, TContext> | GraphQLObjectType,
   InterfaceTypeResolverCheckFn<TSource, TContext>
 >;
 
@@ -306,15 +306,15 @@ export class InterfaceTypeComposer<TSource, TContext> {
     return this.getFieldConfig(fieldName).type;
   }
 
-  getFieldTC(fieldName: string): TypeComposer<any, TContext> {
+  getFieldTC(fieldName: string): ObjectTypeComposer<any, TContext> {
     const fieldType = getNamedType(this.getFieldType(fieldName));
     if (!(fieldType instanceof GraphQLObjectType)) {
       throw new Error(
-        `Cannot get TypeComposer for field '${fieldName}' in type ${this.getTypeName()}. ` +
+        `Cannot get ObjectTypeComposer for field '${fieldName}' in type ${this.getTypeName()}. ` +
           `This field should be ObjectType, but it has type '${fieldType.constructor.name}'`
       );
     }
-    return TypeComposer.createTemp(fieldType, this.sc);
+    return ObjectTypeComposer.createTemp(fieldType, this.sc);
   }
 
   makeFieldNonNull(
@@ -524,7 +524,7 @@ export class InterfaceTypeComposer<TSource, TContext> {
     return this;
   }
 
-  hasTypeResolver(type: TypeComposer<any, TContext> | GraphQLObjectType): boolean {
+  hasTypeResolver(type: ObjectTypeComposer<any, TContext> | GraphQLObjectType): boolean {
     const typeResolversMap = this.getTypeResolvers();
     return typeResolversMap.has(type);
   }
@@ -537,7 +537,7 @@ export class InterfaceTypeComposer<TSource, TContext> {
   }
 
   getTypeResolverCheckFn(
-    type: TypeComposer<any, TContext> | GraphQLObjectType
+    type: ObjectTypeComposer<any, TContext> | GraphQLObjectType
   ): InterfaceTypeResolverCheckFn<TSource, TContext> {
     const typeResolversMap = this.getTypeResolvers();
 
@@ -556,7 +556,7 @@ export class InterfaceTypeComposer<TSource, TContext> {
     const typeResolversMap = this.getTypeResolvers();
     const names = [];
     typeResolversMap.forEach((resolveFn, composeType) => {
-      if (composeType instanceof TypeComposer) {
+      if (composeType instanceof ObjectTypeComposer) {
         names.push(composeType.getTypeName());
       } else if (composeType && composeType.name) {
         names.push(composeType.name);
@@ -581,7 +581,7 @@ export class InterfaceTypeComposer<TSource, TContext> {
 
     this.gqType._gqcTypeResolvers = typeResolversMap;
 
-    // extract GraphQLObjectType from TypeComposer
+    // extract GraphQLObjectType from ObjectTypeComposer
     const fastEntries = [];
     for (const [composeType, checkFn] of typeResolversMap.entries()) {
       fastEntries.push([((getGraphQLType(composeType): any): GraphQLObjectType), checkFn]);
@@ -626,7 +626,7 @@ export class InterfaceTypeComposer<TSource, TContext> {
         if (!(type instanceof GraphQLObjectType)) throw new Error('Must be GraphQLObjectType');
       } catch (e) {
         throw new Error(
-          `For interface type resolver ${this.getTypeName()} you must provide GraphQLObjectType or TypeComposer, but provided ${inspect(
+          `For interface type resolver ${this.getTypeName()} you must provide GraphQLObjectType or ObjectTypeComposer, but provided ${inspect(
             composeType
           )}`
         );
@@ -663,7 +663,7 @@ export class InterfaceTypeComposer<TSource, TContext> {
   }
 
   addTypeResolver(
-    type: TypeComposer<any, TContext> | GraphQLObjectType,
+    type: ObjectTypeComposer<any, TContext> | GraphQLObjectType,
     checkFn: InterfaceTypeResolverCheckFn<TSource, TContext>
   ): InterfaceTypeComposer<TSource, TContext> {
     const typeResolversMap = this.getTypeResolvers();
@@ -673,7 +673,7 @@ export class InterfaceTypeComposer<TSource, TContext> {
   }
 
   removeTypeResolver(
-    type: TypeComposer<any, TContext> | GraphQLObjectType
+    type: ObjectTypeComposer<any, TContext> | GraphQLObjectType
   ): InterfaceTypeComposer<TSource, TContext> {
     const typeResolversMap = this.getTypeResolvers();
     typeResolversMap.delete(type);

--- a/src/ObjectTypeComposer.d.ts
+++ b/src/ObjectTypeComposer.d.ts
@@ -96,7 +96,7 @@ export type ComposeFieldConfigAsObject<TSource, TContext, TArgs = ArgsMap> = {
 // extended GraphQLOutputType
 export type ComposeOutputType<TSource, TContext> =
   | GraphQLOutputType
-  | TypeComposer<TSource, TContext>
+  | ObjectTypeComposer<TSource, TContext>
   | EnumTypeComposer
   | ScalarTypeComposer
   | TypeAsString
@@ -105,7 +105,7 @@ export type ComposeOutputType<TSource, TContext> =
   | UnionTypeComposer<TSource, TContext>
   | Array<
       | GraphQLOutputType
-      | TypeComposer<TSource, TContext>
+      | ObjectTypeComposer<TSource, TContext>
       | EnumTypeComposer
       | ScalarTypeComposer
       | TypeAsString
@@ -196,12 +196,12 @@ export type RelationArgsMapper<TSource, TContext, TArgs = ArgsMap> = {
     | any[];
 };
 
-export type TypeComposerDefinition<TSource, TContext> =
+export type ObjectTypeComposerDefinition<TSource, TContext> =
   | TypeAsString
   | ComposeObjectTypeConfig<TSource, TContext>
   | GraphQLObjectType;
 
-export class TypeComposer<TSource = any, TContext = any> {
+export class ObjectTypeComposer<TSource = any, TContext = any> {
   public static schemaComposer: SchemaComposer<any>;
   public schemaComposer: SchemaComposer<TContext>;
 
@@ -210,12 +210,12 @@ export class TypeComposer<TSource = any, TContext = any> {
   public constructor(gqType: GraphQLObjectType);
 
   public static create<TSrc = any, TCtx = any>(
-    typeDef: TypeComposerDefinition<TSrc, TCtx>,
-  ): TypeComposer<TSrc, TCtx>;
+    typeDef: ObjectTypeComposerDefinition<TSrc, TCtx>,
+  ): ObjectTypeComposer<TSrc, TCtx>;
 
   public static createTemp<TSrc = any, TCtx = any>(
-    typeDef: TypeComposerDefinition<TSrc, TCtx>,
-  ): TypeComposer<TSrc, TCtx>;
+    typeDef: ObjectTypeComposerDefinition<TSrc, TCtx>,
+  ): ObjectTypeComposer<TSrc, TCtx>;
 
   // -----------------------------------------------
   // Field methods
@@ -271,7 +271,7 @@ export class TypeComposer<TSource = any, TContext = any> {
 
   public getFieldType(fieldName: string): GraphQLOutputType;
 
-  public getFieldTC(fieldName: string): TypeComposer<TSource, TContext>;
+  public getFieldTC(fieldName: string): ObjectTypeComposer<TSource, TContext>;
 
   public makeFieldNonNull(fieldNameOrArray: string | string[]): this;
 
@@ -309,7 +309,7 @@ export class TypeComposer<TSource = any, TContext = any> {
 
   public clone<TCloneSource = any>(
     newTypeName: string,
-  ): TypeComposer<TCloneSource, TContext>;
+  ): ObjectTypeComposer<TCloneSource, TContext>;
 
   public getIsTypeOf(): GraphQLIsTypeOfFn<TSource, TContext> | null | void;
 

--- a/src/ObjectTypeComposer.js
+++ b/src/ObjectTypeComposer.js
@@ -221,10 +221,10 @@ export class ObjectTypeComposer<TSource, TContext> {
   gqType: GraphQLObjectTypeExtended<TSource, TContext>;
   sc: SchemaComposer<TContext>;
 
-  static create(
-    typeDef: ObjectTypeComposerDefinition<TSource, TContext>,
-    sc: SchemaComposer<TContext>
-  ): ObjectTypeComposer<TSource, TContext> {
+  static create<TSrc, TCtx>(
+    typeDef: ObjectTypeComposerDefinition<TSrc, TCtx>,
+    sc: SchemaComposer<TCtx>
+  ): ObjectTypeComposer<TSrc, TCtx> {
     if (!(sc instanceof SchemaComposer)) {
       throw new Error(
         'You must provide SchemaComposer instance as a second argument for `ObjectTypeComposer.create(typeDef, schemaComposer)`'
@@ -238,10 +238,10 @@ export class ObjectTypeComposer<TSource, TContext> {
     return tc;
   }
 
-  static createTemp(
-    typeDef: ObjectTypeComposerDefinition<TSource, TContext>,
-    _sc?: SchemaComposer<TContext>
-  ): ObjectTypeComposer<TSource, TContext> {
+  static createTemp<TSrc, TCtx>(
+    typeDef: ObjectTypeComposerDefinition<TSrc, TCtx>,
+    _sc?: SchemaComposer<TCtx>
+  ): ObjectTypeComposer<TSrc, TCtx> {
     const sc = _sc || new SchemaComposer();
     let TC;
 

--- a/src/ObjectTypeComposer.js
+++ b/src/ObjectTypeComposer.js
@@ -105,16 +105,9 @@ export type ComposeFieldConfigAsObject<TSource, TContext, TArgs> = {
   +[key: string]: any,
 };
 
-export type ComposePartialFieldConfigAsObject<TSource, TContext, TArgs = ArgsMap> = {
-  +type?: Thunk<ComposeOutputType<TSource, TContext>> | GraphQLOutputType,
-  +args?: ComposeFieldConfigArgumentMap<TArgs>,
-  +resolve?: GraphQLFieldResolver<TSource, TContext, TArgs>,
-  +subscribe?: GraphQLFieldResolver<TSource, TContext>,
-  +deprecationReason?: ?string,
-  +description?: ?string,
-  +extensions?: Extensions,
-  +[key: string]: any,
-};
+export type ComposePartialFieldConfigAsObject<TSource, TContext, TArgs = ArgsMap> = $Shape<
+  ComposeFieldConfigAsObject<TSource, TContext, TArgs>
+>;
 
 // extended GraphQLOutputType
 export type ComposeOutputType<TSource, TContext> =
@@ -380,7 +373,7 @@ export class ObjectTypeComposer<TSource, TContext> {
    * Add new fields or replace existed (where field name may have dots)
    */
   addNestedFields(
-    newFields: ComposeFieldConfigMap<any, TContext>
+    newFields: ComposeFieldConfigMap<TSource, TContext>
   ): ObjectTypeComposer<TSource, TContext> {
     Object.keys(newFields).forEach(fieldName => {
       const fc = newFields[fieldName];
@@ -811,7 +804,7 @@ export class ObjectTypeComposer<TSource, TContext> {
 
   wrapResolver(
     resolverName: string,
-    cbResolver: ResolverWrapCb<any, TContext, ArgsMap>
+    cbResolver: ResolverWrapCb<TSource, TSource, TContext, ArgsMap, ArgsMap>
   ): ObjectTypeComposer<TSource, TContext> {
     const resolver = this.getResolver(resolverName);
     const newResolver = resolver.wrap(cbResolver);
@@ -822,7 +815,7 @@ export class ObjectTypeComposer<TSource, TContext> {
   wrapResolverAs(
     resolverName: string,
     fromResolverName: string,
-    cbResolver: ResolverWrapCb<any, TContext, ArgsMap>
+    cbResolver: ResolverWrapCb<TSource, TSource, TContext, ArgsMap, ArgsMap>
   ): ObjectTypeComposer<TSource, TContext> {
     const resolver = this.getResolver(fromResolverName);
     const newResolver = resolver.wrap(cbResolver);
@@ -832,7 +825,7 @@ export class ObjectTypeComposer<TSource, TContext> {
 
   wrapResolverResolve(
     resolverName: string,
-    cbNextRp: ResolverNextRpCb<any, TContext, ArgsMap>
+    cbNextRp: ResolverNextRpCb<TSource, TContext, ArgsMap>
   ): ObjectTypeComposer<TSource, TContext> {
     const resolver = this.getResolver(resolverName);
     this.setResolver(resolverName, resolver.wrapResolve(cbNextRp));

--- a/src/Resolver.d.ts
+++ b/src/Resolver.d.ts
@@ -15,9 +15,9 @@ import {
   ComposeArgumentConfigAsObject,
   ComposeFieldConfigArgumentMap,
   ComposeOutputType,
-  TypeComposer,
+  ObjectTypeComposer,
   ArgsMap,
-} from './TypeComposer';
+} from './ObjectTypeComposer';
 import { ProjectionType } from './utils/projection';
 
 export type ResolveParams<TSource, TContext, TArgs = ArgsMap> = {
@@ -141,7 +141,7 @@ export class Resolver<TSource = any, TContext = any, TArgs = ArgsMap> {
 
   public getType(): GraphQLOutputType;
 
-  public getTypeComposer(): TypeComposer<any, TContext>;
+  public getTypeComposer(): ObjectTypeComposer<any, TContext>;
 
   public setType(gqType: ComposeOutputType<any, TContext>): this;
 

--- a/src/Resolver.js
+++ b/src/Resolver.js
@@ -136,7 +136,7 @@ export type ResolverMiddleware<TSource, TContext, TArgs> = (
   info: GraphQLResolveInfo
 ) => any;
 
-export class Resolver<TSource, TContext, TArgs> {
+export class Resolver<TSource, TContext, TArgs = ArgsMap> {
   static schemaComposer: SchemaComposer<TContext>;
 
   get schemaComposer(): SchemaComposer<TContext> {
@@ -145,7 +145,7 @@ export class Resolver<TSource, TContext, TArgs> {
 
   type: ComposeOutputType<TSource, TContext>;
   args: ComposeFieldConfigArgumentMap<any>;
-  resolve: ResolverRpCb<TSource, TContext, TArgs>;
+  resolve: (resolveParams: $Shape<ResolveParams<TSource, TContext, TArgs>>) => Promise<any> | any;
   name: string;
   displayName: ?string;
   kind: ?ResolverKinds;

--- a/src/Resolver.js
+++ b/src/Resolver.js
@@ -19,7 +19,7 @@ import type {
   GraphQLInputType,
   GraphQLResolveInfo,
 } from './graphql';
-import { TypeComposer } from './TypeComposer';
+import { ObjectTypeComposer } from './ObjectTypeComposer';
 import type {
   ComposeOutputType,
   ComposeArgumentConfig,
@@ -27,7 +27,7 @@ import type {
   ComposePartialArgumentConfigAsObject,
   ComposeArgumentType,
   ArgsMap, // eslint-disable-line
-} from './TypeComposer';
+} from './ObjectTypeComposer';
 import { InputTypeComposer, type ComposeInputFieldConfig } from './InputTypeComposer';
 import { EnumTypeComposer } from './EnumTypeComposer';
 import { SchemaComposer } from './SchemaComposer';
@@ -44,7 +44,6 @@ import { getProjectionFromAST } from './utils/projection';
 import type { ProjectionType } from './utils/projection';
 import { typeByPath } from './utils/typeByPath';
 import GraphQLJSON from './type/json';
-// import { deprecate } from './utils/debug';
 
 export type ResolveParams<TSource, TContext, TArgs = ArgsMap> = {
   source: TSource,
@@ -197,15 +196,15 @@ export class Resolver<TSource, TContext, TArgs = ArgsMap> {
     return fc.type;
   }
 
-  getTypeComposer(): TypeComposer<any, TContext> {
+  getTypeComposer(): ObjectTypeComposer<any, TContext> {
     const outputType = getNamedType(this.getType());
     if (!(outputType instanceof GraphQLObjectType)) {
       throw new Error(
-        `Resolver ${this.name} cannot return its output type as TypeComposer instance. ` +
+        `Resolver ${this.name} cannot return its output type as ObjectTypeComposer instance. ` +
           `Cause '${this.type.toString()}' does not instance of GraphQLObjectType.`
       );
     }
-    return new TypeComposer(outputType, this.sc);
+    return new ObjectTypeComposer(outputType, this.sc);
   }
 
   setType(composeType: ComposeOutputType<any, TContext>): Resolver<TSource, TContext, TArgs> {

--- a/src/ScalarTypeComposer.d.ts
+++ b/src/ScalarTypeComposer.d.ts
@@ -28,21 +28,25 @@ export type GraphQLScalarTypeExtended = GraphQLScalarType & {
   _gqcExtensions?: Extensions;
 };
 
-export class ScalarTypeComposer {
-  public static schemaComposer: SchemaComposer<any>;
-  public schemaComposer: SchemaComposer<any>;
+export class ScalarTypeComposer<TContext = any> {
+  public schemaComposer: SchemaComposer<TContext>;
 
   protected gqType: GraphQLScalarTypeExtended;
 
-  public constructor(gqType: GraphQLScalarType);
+  public constructor(
+    gqType: GraphQLScalarType,
+    schemaComposer: SchemaComposer<TContext>,
+  );
 
-  public static create(
+  public static create<TCtx = any>(
     typeDef: ScalarTypeComposerDefinition,
-  ): ScalarTypeComposer;
+    schemaComposer: SchemaComposer<TCtx>,
+  ): ScalarTypeComposer<TCtx>;
 
-  public static createTemp(
+  public static createTemp<TCtx = any>(
     typeDef: ScalarTypeComposerDefinition,
-  ): ScalarTypeComposer;
+    schemaComposer?: SchemaComposer<TCtx>,
+  ): ScalarTypeComposer<TCtx>;
 
   // -----------------------------------------------
   // Serialize methods
@@ -78,7 +82,7 @@ export class ScalarTypeComposer {
 
   public setDescription(description: string): this;
 
-  public clone(newTypeName: string): ScalarTypeComposer;
+  public clone(newTypeName: string): ScalarTypeComposer<TContext>;
 
   // -----------------------------------------------
   // Extensions methods

--- a/src/ScalarTypeComposer.js
+++ b/src/ScalarTypeComposer.js
@@ -28,27 +28,27 @@ export type GraphQLScalarTypeExtended = GraphQLScalarType & {
 
 export class ScalarTypeComposer {
   gqType: GraphQLScalarTypeExtended;
-  sc: SchemaComposer<any>;
+  schemaComposer: SchemaComposer<any>;
 
   static create(
     typeDef: ScalarTypeComposerDefinition,
-    sc: SchemaComposer<any>
+    schemaComposer: SchemaComposer<any>
   ): ScalarTypeComposer {
-    if (!(sc instanceof SchemaComposer)) {
+    if (!(schemaComposer instanceof SchemaComposer)) {
       throw new Error(
         'You must provide SchemaComposer instance as a second argument for `ScalarTypeComposer.create(typeDef, schemaComposer)`'
       );
     }
-    const stc = this.createTemp(typeDef, sc);
-    sc.add(stc);
+    const stc = this.createTemp(typeDef, schemaComposer);
+    schemaComposer.add(stc);
     return stc;
   }
 
   static createTemp(
     typeDef: ScalarTypeComposerDefinition,
-    _sc?: SchemaComposer<any>
+    schemaComposer?: SchemaComposer<any>
   ): ScalarTypeComposer {
-    const sc = _sc || new SchemaComposer();
+    const sc = schemaComposer || new SchemaComposer();
 
     let STC;
 
@@ -89,13 +89,13 @@ export class ScalarTypeComposer {
     return STC;
   }
 
-  constructor(gqType: GraphQLScalarType, sc: SchemaComposer<any>) {
-    if (!(sc instanceof SchemaComposer)) {
+  constructor(gqType: GraphQLScalarType, schemaComposer: SchemaComposer<any>) {
+    if (!(schemaComposer instanceof SchemaComposer)) {
       throw new Error(
         'You must provide SchemaComposer instance as a second argument for `new ScalarTypeComposer(GraphQLScalarType, SchemaComposer)`'
       );
     }
-    this.sc = sc;
+    this.schemaComposer = schemaComposer;
 
     if (!(gqType instanceof GraphQLScalarType)) {
       throw new Error('ScalarTypeComposer accept only GraphQLScalarType in constructor');
@@ -153,7 +153,7 @@ export class ScalarTypeComposer {
 
   setTypeName(name: string): ScalarTypeComposer {
     this.gqType.name = name;
-    this.sc.add(this);
+    this.schemaComposer.add(this);
     return this;
   }
 
@@ -178,7 +178,7 @@ export class ScalarTypeComposer {
         parseValue: this.getParseValue(),
         parseLiteral: this.getParseLiteral(),
       }),
-      this.sc
+      this.schemaComposer
     );
 
     cloned.setDescription(this.getDescription());

--- a/src/ScalarTypeComposer.js
+++ b/src/ScalarTypeComposer.js
@@ -26,14 +26,14 @@ export type GraphQLScalarTypeExtended = GraphQLScalarType & {
   _gqcExtensions?: Extensions,
 };
 
-export class ScalarTypeComposer {
+export class ScalarTypeComposer<TContext> {
   gqType: GraphQLScalarTypeExtended;
-  schemaComposer: SchemaComposer<any>;
+  schemaComposer: SchemaComposer<TContext>;
 
-  static create(
+  static create<TCtx>(
     typeDef: ScalarTypeComposerDefinition,
-    schemaComposer: SchemaComposer<any>
-  ): ScalarTypeComposer {
+    schemaComposer: SchemaComposer<TCtx>
+  ): ScalarTypeComposer<TCtx> {
     if (!(schemaComposer instanceof SchemaComposer)) {
       throw new Error(
         'You must provide SchemaComposer instance as a second argument for `ScalarTypeComposer.create(typeDef, schemaComposer)`'
@@ -44,10 +44,10 @@ export class ScalarTypeComposer {
     return stc;
   }
 
-  static createTemp(
+  static createTemp<TCtx>(
     typeDef: ScalarTypeComposerDefinition,
-    schemaComposer?: SchemaComposer<any>
-  ): ScalarTypeComposer {
+    schemaComposer?: SchemaComposer<TCtx>
+  ): ScalarTypeComposer<TCtx> {
     const sc = schemaComposer || new SchemaComposer();
 
     let STC;
@@ -89,7 +89,10 @@ export class ScalarTypeComposer {
     return STC;
   }
 
-  constructor(gqType: GraphQLScalarType, schemaComposer: SchemaComposer<any>) {
+  constructor(
+    gqType: GraphQLScalarType,
+    schemaComposer: SchemaComposer<TContext>
+  ): ScalarTypeComposer<TContext> {
     if (!(schemaComposer instanceof SchemaComposer)) {
       throw new Error(
         'You must provide SchemaComposer instance as a second argument for `new ScalarTypeComposer(GraphQLScalarType, SchemaComposer)`'
@@ -101,6 +104,9 @@ export class ScalarTypeComposer {
       throw new Error('ScalarTypeComposer accept only GraphQLScalarType in constructor');
     }
     this.gqType = gqType;
+
+    // alive proper Flow type casting in autosuggestions for class with Generics
+    /* :: return this; */
   }
 
   // -----------------------------------------------
@@ -151,7 +157,7 @@ export class ScalarTypeComposer {
     return this.gqType.name;
   }
 
-  setTypeName(name: string): ScalarTypeComposer {
+  setTypeName(name: string): ScalarTypeComposer<TContext> {
     this.gqType.name = name;
     this.schemaComposer.add(this);
     return this;
@@ -161,12 +167,12 @@ export class ScalarTypeComposer {
     return this.gqType.description || '';
   }
 
-  setDescription(description: string): ScalarTypeComposer {
+  setDescription(description: string): ScalarTypeComposer<TContext> {
     this.gqType.description = description;
     return this;
   }
 
-  clone(newTypeName: string): ScalarTypeComposer {
+  clone(newTypeName: string): ScalarTypeComposer<TContext> {
     if (!newTypeName) {
       throw new Error('You should provide newTypeName:string for ScalarTypeComposer.clone()');
     }
@@ -198,12 +204,12 @@ export class ScalarTypeComposer {
     }
   }
 
-  setExtensions(extensions: Extensions): ScalarTypeComposer {
+  setExtensions(extensions: Extensions): ScalarTypeComposer<TContext> {
     this.gqType._gqcExtensions = extensions;
     return this;
   }
 
-  extendExtensions(extensions: Extensions): ScalarTypeComposer {
+  extendExtensions(extensions: Extensions): ScalarTypeComposer<TContext> {
     const current = this.getExtensions();
     this.setExtensions({
       ...current,
@@ -212,7 +218,7 @@ export class ScalarTypeComposer {
     return this;
   }
 
-  clearExtensions(): ScalarTypeComposer {
+  clearExtensions(): ScalarTypeComposer<TContext> {
     this.setExtensions({});
     return this;
   }
@@ -227,14 +233,14 @@ export class ScalarTypeComposer {
     return extensionName in extensions;
   }
 
-  setExtension(extensionName: string, value: any): ScalarTypeComposer {
+  setExtension(extensionName: string, value: any): ScalarTypeComposer<TContext> {
     this.extendExtensions({
       [extensionName]: value,
     });
     return this;
   }
 
-  removeExtension(extensionName: string): ScalarTypeComposer {
+  removeExtension(extensionName: string): ScalarTypeComposer<TContext> {
     const extensions = { ...this.getExtensions() };
     delete extensions[extensionName];
     this.setExtensions(extensions);

--- a/src/SchemaComposer.d.ts
+++ b/src/SchemaComposer.d.ts
@@ -33,6 +33,12 @@ import { TypeStorage } from './TypeStorage';
 import { TypeMapper } from './TypeMapper';
 import { Resolver } from './Resolver';
 
+type ExtraSchemaConfig = {
+  types?: GraphQLNamedType[] | null;
+  directives?: GraphQLDirective[] | null;
+  astNode?: SchemaDefinitionNode | null;
+};
+
 type MustHaveTypes<TContext> =
   | ObjectTypeComposer<any, TContext>
   | InputTypeComposer
@@ -41,12 +47,6 @@ type MustHaveTypes<TContext> =
   | UnionTypeComposer<any, TContext>
   | ScalarTypeComposer
   | GraphQLNamedType;
-
-type ExtraSchemaConfig = {
-  types?: GraphQLNamedType[] | null;
-  directives?: GraphQLDirective[] | null;
-  astNode?: SchemaDefinitionNode | null;
-};
 
 type AddResolveMethods<TContext> = {
   [typeName: string]: {
@@ -60,14 +60,7 @@ type AddResolveMethods<TContext> = {
 };
 
 export class SchemaComposer<TContext> extends TypeStorage<TContext> {
-  public TypeMapper: TypeMapper;
-  public ObjectTypeComposer: typeof ObjectTypeComposer;
-  public InputTypeComposer: typeof InputTypeComposer;
-  public EnumTypeComposer: typeof EnumTypeComposer;
-  public InterfaceTypeComposer: typeof InterfaceTypeComposer;
-  public UnionTypeComposer: typeof UnionTypeComposer;
-  public ScalarTypeComposer: typeof ScalarTypeComposer;
-  public Resolver: typeof Resolver;
+  public typeMapper: TypeMapper;
 
   public Query: ObjectTypeComposer<any, TContext>;
   public Mutation: ObjectTypeComposer<any, TContext>;
@@ -77,19 +70,12 @@ export class SchemaComposer<TContext> extends TypeStorage<TContext> {
   protected _directives: GraphQLDirective[];
 
   public constructor();
+  public rootQuery<TSource = any>(): ObjectTypeComposer<TSource, TContext>;
 
-  public rootQuery<TRootQuery = any>(): ObjectTypeComposer<
-    TRootQuery,
-    TContext
-  >;
+  public rootMutation<TSource = any>(): ObjectTypeComposer<TSource, TContext>;
 
-  public rootMutation<TRootMutation = any>(): ObjectTypeComposer<
-    TRootMutation,
-    TContext
-  >;
-
-  public rootSubscription<TRootSubscription = any>(): ObjectTypeComposer<
-    TRootSubscription,
+  public rootSubscription<TSource = any>(): ObjectTypeComposer<
+    TSource,
     TContext
   >;
 

--- a/src/SchemaComposer.d.ts
+++ b/src/SchemaComposer.d.ts
@@ -8,6 +8,7 @@ import {
 import {
   ObjectTypeComposer,
   ObjectTypeComposerDefinition,
+  ArgsMap,
 } from './ObjectTypeComposer';
 import {
   InputTypeComposer,
@@ -31,7 +32,7 @@ import {
 } from './UnionTypeComposer';
 import { TypeStorage } from './TypeStorage';
 import { TypeMapper } from './TypeMapper';
-import { Resolver } from './Resolver';
+import { Resolver, ResolverOpts } from './Resolver';
 
 type ExtraSchemaConfig = {
   types?: GraphQLNamedType[] | null;
@@ -41,14 +42,14 @@ type ExtraSchemaConfig = {
 
 type MustHaveTypes<TContext> =
   | ObjectTypeComposer<any, TContext>
-  | InputTypeComposer
-  | EnumTypeComposer
+  | InputTypeComposer<TContext>
+  | EnumTypeComposer<TContext>
   | InterfaceTypeComposer<any, TContext>
   | UnionTypeComposer<any, TContext>
-  | ScalarTypeComposer
+  | ScalarTypeComposer<TContext>
   | GraphQLNamedType;
 
-type AddResolveMethods<TContext> = {
+type GraphQLToolsResolveMethods<TContext> = {
   [typeName: string]: {
     [fieldName: string]: (
       source: any,
@@ -59,8 +60,8 @@ type AddResolveMethods<TContext> = {
   };
 };
 
-export class SchemaComposer<TContext> extends TypeStorage<TContext> {
-  public typeMapper: TypeMapper;
+export class SchemaComposer<TContext> extends TypeStorage<any, any> {
+  public typeMapper: TypeMapper<TContext>;
 
   public Query: ObjectTypeComposer<any, TContext>;
   public Mutation: ObjectTypeComposer<any, TContext>;
@@ -70,14 +71,6 @@ export class SchemaComposer<TContext> extends TypeStorage<TContext> {
   protected _directives: GraphQLDirective[];
 
   public constructor();
-  public rootQuery<TSource = any>(): ObjectTypeComposer<TSource, TContext>;
-
-  public rootMutation<TSource = any>(): ObjectTypeComposer<TSource, TContext>;
-
-  public rootSubscription<TSource = any>(): ObjectTypeComposer<
-    TSource,
-    TContext
-  >;
 
   public buildSchema(extraConfig?: ExtraSchemaConfig): GraphQLSchema;
 
@@ -95,13 +88,13 @@ export class SchemaComposer<TContext> extends TypeStorage<TContext> {
 
   public getOrCreateITC(
     typeName: string,
-    onCreate?: (itc: InputTypeComposer) => any,
-  ): InputTypeComposer;
+    onCreate?: (itc: InputTypeComposer<TContext>) => any,
+  ): InputTypeComposer<TContext>;
 
   public getOrCreateETC(
     typeName: string,
-    onCreate?: (etc: EnumTypeComposer) => any,
-  ): EnumTypeComposer;
+    onCreate?: (etc: EnumTypeComposer<TContext>) => any,
+  ): EnumTypeComposer<TContext>;
 
   public getOrCreateIFTC<TSource = any>(
     typeName: string,
@@ -115,16 +108,16 @@ export class SchemaComposer<TContext> extends TypeStorage<TContext> {
 
   public getOrCreateSTC(
     typeName: string,
-    onCreate?: (stc: ScalarTypeComposer) => any,
-  ): ScalarTypeComposer;
+    onCreate?: (stc: ScalarTypeComposer<TContext>) => any,
+  ): ScalarTypeComposer<TContext>;
 
   public getOTC<TSource = any>(
     typeName: any,
   ): ObjectTypeComposer<TSource, TContext>;
 
-  public getITC(typeName: any): InputTypeComposer;
+  public getITC(typeName: any): InputTypeComposer<TContext>;
 
-  public getETC(typeName: any): EnumTypeComposer;
+  public getETC(typeName: any): EnumTypeComposer<TContext>;
 
   public getIFTC<TSource = any>(
     typeName: any,
@@ -134,40 +127,39 @@ export class SchemaComposer<TContext> extends TypeStorage<TContext> {
     typeName: any,
   ): UnionTypeComposer<TSource, TContext>;
 
-  public getSTC(typeName: any): ScalarTypeComposer;
+  public getSTC(typeName: any): ScalarTypeComposer<TContext>;
 
   public getAnyTC(
     typeName: any,
   ):
     | ObjectTypeComposer<any, TContext>
-    | InputTypeComposer
-    | EnumTypeComposer
+    | InputTypeComposer<TContext>
+    | EnumTypeComposer<TContext>
     | InterfaceTypeComposer<any, TContext>
     | UnionTypeComposer<any, TContext>
-    | ScalarTypeComposer;
+    | ScalarTypeComposer<TContext>;
 
   public add(typeOrSDL: any): string | null;
 
   public addAsComposer(typeOrSDL: any): string;
 
-  public addTypeDefs(typeDefs: string): TypeStorage<GraphQLNamedType>;
+  public addTypeDefs(typeDefs: string): TypeStorage<string, GraphQLNamedType>;
 
   public addResolveMethods(
-    typesFieldsResolve: AddResolveMethods<TContext>,
+    typesFieldsResolve: GraphQLToolsResolveMethods<TContext>,
   ): void;
-
-  // alias for createObjectTC
-  public createTC<TSource = any>(
-    typeDef: ObjectTypeComposerDefinition<TSource, TContext>,
-  ): ObjectTypeComposer<TSource, TContext>;
 
   public createObjectTC<TSource = any>(
     typeDef: ObjectTypeComposerDefinition<TSource, TContext>,
   ): ObjectTypeComposer<TSource, TContext>;
 
-  public createInputTC(typeDef: InputTypeComposerDefinition): InputTypeComposer;
+  public createInputTC(
+    typeDef: InputTypeComposerDefinition,
+  ): InputTypeComposer<TContext>;
 
-  public createEnumTC(typeDef: EnumTypeComposerDefinition): EnumTypeComposer;
+  public createEnumTC(
+    typeDef: EnumTypeComposerDefinition,
+  ): EnumTypeComposer<TContext>;
 
   public createInterfaceTC<TSource = any>(
     typeDef: InterfaceTypeComposerDefinition<TSource, TContext>,
@@ -179,7 +171,11 @@ export class SchemaComposer<TContext> extends TypeStorage<TContext> {
 
   public createScalarTC(
     typeDef: ScalarTypeComposerDefinition,
-  ): ScalarTypeComposer;
+  ): ScalarTypeComposer<TContext>;
+
+  public createResolver<TSource = any, TArgs = ArgsMap>(
+    opts: ResolverOpts<TSource, TContext, TArgs>,
+  ): Resolver<TSource, TContext, TArgs>;
 
   public addDirective(directive: GraphQLDirective): this;
 

--- a/src/SchemaComposer.d.ts
+++ b/src/SchemaComposer.d.ts
@@ -5,7 +5,10 @@ import {
   SchemaDefinitionNode,
   GraphQLResolveInfo,
 } from 'graphql';
-import { TypeComposer, TypeComposerDefinition } from './TypeComposer';
+import {
+  ObjectTypeComposer,
+  ObjectTypeComposerDefinition,
+} from './ObjectTypeComposer';
 import {
   InputTypeComposer,
   InputTypeComposerDefinition,
@@ -31,7 +34,7 @@ import { TypeMapper } from './TypeMapper';
 import { Resolver } from './Resolver';
 
 type MustHaveTypes<TContext> =
-  | TypeComposer<any, TContext>
+  | ObjectTypeComposer<any, TContext>
   | InputTypeComposer
   | EnumTypeComposer
   | InterfaceTypeComposer<any, TContext>
@@ -58,7 +61,7 @@ type AddResolveMethods<TContext> = {
 
 export class SchemaComposer<TContext> extends TypeStorage<TContext> {
   public TypeMapper: TypeMapper;
-  public TypeComposer: typeof TypeComposer;
+  public ObjectTypeComposer: typeof ObjectTypeComposer;
   public InputTypeComposer: typeof InputTypeComposer;
   public EnumTypeComposer: typeof EnumTypeComposer;
   public InterfaceTypeComposer: typeof InterfaceTypeComposer;
@@ -66,23 +69,26 @@ export class SchemaComposer<TContext> extends TypeStorage<TContext> {
   public ScalarTypeComposer: typeof ScalarTypeComposer;
   public Resolver: typeof Resolver;
 
-  public Query: TypeComposer<any, TContext>;
-  public Mutation: TypeComposer<any, TContext>;
-  public Subscription: TypeComposer<any, TContext>;
+  public Query: ObjectTypeComposer<any, TContext>;
+  public Mutation: ObjectTypeComposer<any, TContext>;
+  public Subscription: ObjectTypeComposer<any, TContext>;
 
   protected _schemaMustHaveTypes: Array<MustHaveTypes<TContext>>;
   protected _directives: GraphQLDirective[];
 
   public constructor();
 
-  public rootQuery<TRootQuery = any>(): TypeComposer<TRootQuery, TContext>;
+  public rootQuery<TRootQuery = any>(): ObjectTypeComposer<
+    TRootQuery,
+    TContext
+  >;
 
-  public rootMutation<TRootMutation = any>(): TypeComposer<
+  public rootMutation<TRootMutation = any>(): ObjectTypeComposer<
     TRootMutation,
     TContext
   >;
 
-  public rootSubscription<TRootSubscription = any>(): TypeComposer<
+  public rootSubscription<TRootSubscription = any>(): ObjectTypeComposer<
     TRootSubscription,
     TContext
   >;
@@ -92,14 +98,14 @@ export class SchemaComposer<TContext> extends TypeStorage<TContext> {
   public addSchemaMustHaveType(type: MustHaveTypes<TContext>): this;
 
   public removeEmptyTypes(
-    typeComposer: TypeComposer<any, TContext>,
+    tc: ObjectTypeComposer<any, TContext>,
     passedTypes: Set<string>,
   ): void;
 
-  public getOrCreateTC<TSource = any>(
+  public getOrCreateOTC<TSource = any>(
     typeName: string,
-    onCreate?: (tc: TypeComposer<TSource, TContext>) => any,
-  ): TypeComposer<TSource, TContext>;
+    onCreate?: (tc: ObjectTypeComposer<TSource, TContext>) => any,
+  ): ObjectTypeComposer<TSource, TContext>;
 
   public getOrCreateITC(
     typeName: string,
@@ -126,10 +132,28 @@ export class SchemaComposer<TContext> extends TypeStorage<TContext> {
     onCreate?: (stc: ScalarTypeComposer) => any,
   ): ScalarTypeComposer;
 
+  public getOTC<TSource = any>(
+    typeName: any,
+  ): ObjectTypeComposer<TSource, TContext>;
+
+  public getITC(typeName: any): InputTypeComposer;
+
+  public getETC(typeName: any): EnumTypeComposer;
+
+  public getIFTC<TSource = any>(
+    typeName: any,
+  ): InterfaceTypeComposer<TSource, TContext>;
+
+  public getUTC<TSource = any>(
+    typeName: any,
+  ): UnionTypeComposer<TSource, TContext>;
+
+  public getSTC(typeName: any): ScalarTypeComposer;
+
   public getAnyTC(
     typeName: any,
   ):
-    | TypeComposer<any, TContext>
+    | ObjectTypeComposer<any, TContext>
     | InputTypeComposer
     | EnumTypeComposer
     | InterfaceTypeComposer<any, TContext>
@@ -148,12 +172,12 @@ export class SchemaComposer<TContext> extends TypeStorage<TContext> {
 
   // alias for createObjectTC
   public createTC<TSource = any>(
-    typeDef: TypeComposerDefinition<TSource, TContext>,
-  ): TypeComposer<TSource, TContext>;
+    typeDef: ObjectTypeComposerDefinition<TSource, TContext>,
+  ): ObjectTypeComposer<TSource, TContext>;
 
   public createObjectTC<TSource = any>(
-    typeDef: TypeComposerDefinition<TSource, TContext>,
-  ): TypeComposer<TSource, TContext>;
+    typeDef: ObjectTypeComposerDefinition<TSource, TContext>,
+  ): ObjectTypeComposer<TSource, TContext>;
 
   public createInputTC(typeDef: InputTypeComposerDefinition): InputTypeComposer;
 

--- a/src/SchemaComposer.d.ts
+++ b/src/SchemaComposer.d.ts
@@ -34,8 +34,8 @@ type MustHaveTypes<TContext> =
   | TypeComposer<any, TContext>
   | InputTypeComposer
   | EnumTypeComposer
-  | InterfaceTypeComposer<TContext>
-  | UnionTypeComposer<TContext>
+  | InterfaceTypeComposer<any, TContext>
+  | UnionTypeComposer<any, TContext>
   | ScalarTypeComposer
   | GraphQLNamedType;
 
@@ -111,15 +111,15 @@ export class SchemaComposer<TContext> extends TypeStorage<TContext> {
     onCreate?: (etc: EnumTypeComposer) => any,
   ): EnumTypeComposer;
 
-  public getOrCreateIFTC(
+  public getOrCreateIFTC<TSource = any>(
     typeName: string,
-    onCreate?: (iftc: InterfaceTypeComposer<TContext>) => any,
-  ): InterfaceTypeComposer<TContext>;
+    onCreate?: (iftc: InterfaceTypeComposer<TSource, TContext>) => any,
+  ): InterfaceTypeComposer<TSource, TContext>;
 
-  public getOrCreateUTC(
+  public getOrCreateUTC<TSource = any>(
     typeName: string,
-    onCreate?: (utc: UnionTypeComposer<TContext>) => any,
-  ): UnionTypeComposer<TContext>;
+    onCreate?: (utc: UnionTypeComposer<TSource, TContext>) => any,
+  ): UnionTypeComposer<TSource, TContext>;
 
   public getOrCreateSTC(
     typeName: string,
@@ -129,11 +129,11 @@ export class SchemaComposer<TContext> extends TypeStorage<TContext> {
   public getAnyTC(
     typeName: any,
   ):
-    | TypeComposer<TContext>
+    | TypeComposer<any, TContext>
     | InputTypeComposer
     | EnumTypeComposer
-    | InterfaceTypeComposer<TContext>
-    | UnionTypeComposer<TContext>
+    | InterfaceTypeComposer<any, TContext>
+    | UnionTypeComposer<any, TContext>
     | ScalarTypeComposer;
 
   public add(typeOrSDL: any): string | null;
@@ -147,25 +147,25 @@ export class SchemaComposer<TContext> extends TypeStorage<TContext> {
   ): void;
 
   // alias for createObjectTC
-  public createTC(
-    typeDef: TypeComposerDefinition<TContext>,
-  ): TypeComposer<TContext>;
+  public createTC<TSource = any>(
+    typeDef: TypeComposerDefinition<TSource, TContext>,
+  ): TypeComposer<TSource, TContext>;
 
-  public createObjectTC(
-    typeDef: TypeComposerDefinition<TContext>,
-  ): TypeComposer<TContext>;
+  public createObjectTC<TSource = any>(
+    typeDef: TypeComposerDefinition<TSource, TContext>,
+  ): TypeComposer<TSource, TContext>;
 
   public createInputTC(typeDef: InputTypeComposerDefinition): InputTypeComposer;
 
   public createEnumTC(typeDef: EnumTypeComposerDefinition): EnumTypeComposer;
 
-  public createInterfaceTC(
-    typeDef: InterfaceTypeComposerDefinition<TContext>,
-  ): InterfaceTypeComposer<TContext>;
+  public createInterfaceTC<TSource = any>(
+    typeDef: InterfaceTypeComposerDefinition<TSource, TContext>,
+  ): InterfaceTypeComposer<TSource, TContext>;
 
-  public createUnionTC(
-    typeDef: UnionTypeComposerDefinition<TContext>,
-  ): UnionTypeComposer<TContext>;
+  public createUnionTC<TSource = any>(
+    typeDef: UnionTypeComposerDefinition<TSource, TContext>,
+  ): UnionTypeComposer<TSource, TContext>;
 
   public createScalarTC(
     typeDef: ScalarTypeComposerDefinition,

--- a/src/SchemaComposer.js
+++ b/src/SchemaComposer.js
@@ -178,6 +178,7 @@ export class SchemaComposer<TContext> extends TypeStorage<any, any> {
     });
   }
 
+  /* @deprecated 7.0.0 */
   getOrCreateTC(
     typeName: string,
     onCreate?: (ObjectTypeComposer<any, TContext>) => any
@@ -280,6 +281,7 @@ export class SchemaComposer<TContext> extends TypeStorage<any, any> {
     this._directives = BUILT_IN_DIRECTIVES;
   }
 
+  /* @deprecated 7.0.0 */
   getTC(typeName: any): ObjectTypeComposer<any, TContext> {
     deprecate(`Use SchemaComposer.getOTC() method instead`);
     return this.getOTC(typeName);
@@ -479,9 +481,11 @@ export class SchemaComposer<TContext> extends TypeStorage<any, any> {
   }
 
   // alias for createObjectTC
+  /* @deprecated 7.0.0 */
   createTC(
     typeDef: ObjectTypeComposerDefinition<any, TContext>
   ): ObjectTypeComposer<any, TContext> {
+    deprecate(`Use SchemaComposer.getOTC() method instead`);
     return this.createObjectTC(typeDef);
   }
 

--- a/src/SchemaComposer.js
+++ b/src/SchemaComposer.js
@@ -24,7 +24,7 @@ import {
   UnionTypeComposer as _UnionTypeComposer,
   type UnionTypeComposerDefinition,
 } from './UnionTypeComposer';
-import { Resolver as _Resolver } from './Resolver';
+import { Resolver as _Resolver, type ResolverOpts } from './Resolver';
 import { isFunction } from './utils/is';
 import { inspect } from './utils/misc';
 import { getGraphQLType } from './utils/typeHelpers';
@@ -534,6 +534,10 @@ export class SchemaComposer<TContext> extends TypeStorage<TContext> {
 
   createScalarTC(typeDef: ScalarTypeComposerDefinition): _ScalarTypeComposer {
     return this.ScalarTypeComposer.create(typeDef);
+  }
+
+  createResolver(opts: ResolverOpts<any, any, any>): _Resolver<any, TContext, any> {
+    return new _Resolver<any, TContext, any>(opts, this);
   }
 
   addDirective(directive: GraphQLDirective): SchemaComposer<TContext> {

--- a/src/TypeComposer.js
+++ b/src/TypeComposer.js
@@ -106,7 +106,7 @@ export type ComposeFieldConfigAsObject<TSource, TContext, TArgs> = {
   +[key: string]: any,
 };
 
-export type ComposePartialFieldConfigAsObject<TSource, TContext, TArgs> = {
+export type ComposePartialFieldConfigAsObject<TSource, TContext, TArgs = ArgsMap> = {
   +type?: Thunk<ComposeOutputType<TSource, TContext>> | GraphQLOutputType,
   +args?: ComposeFieldConfigArgumentMap<TArgs>,
   +resolve?: GraphQLFieldResolver<TSource, TContext, TArgs>,

--- a/src/TypeMapper.d.ts
+++ b/src/TypeMapper.d.ts
@@ -36,7 +36,7 @@ export type TypeAsString =
   | TypeWrappedString
   | TypeNameString;
 export type ComposeObjectType =
-  | TypeComposer<any>
+  | TypeComposer<any, any>
   | GraphQLObjectType
   | TypeDefinitionString
   | TypeAsString;
@@ -87,7 +87,7 @@ declare class TypeMapper {
   ): GraphQLArgumentConfig;
 
   public convertArgConfigMap(
-    composeArgsConfigMap: ComposeFieldConfigArgumentMap,
+    composeArgsConfigMap: ComposeFieldConfigArgumentMap<any>,
     fieldName?: string,
     typeName?: string,
   ): GraphQLFieldConfigArgumentMap;

--- a/src/TypeMapper.d.ts
+++ b/src/TypeMapper.d.ts
@@ -10,6 +10,7 @@ import {
   GraphQLType,
   GraphQLObjectType,
 } from 'graphql';
+import { SchemaComposer } from './SchemaComposer';
 import {
   ComposeInputFieldConfig,
   ComposeInputFieldConfigMap,
@@ -41,12 +42,13 @@ export type ComposeObjectType =
   | TypeDefinitionString
   | TypeAsString;
 
-declare class TypeMapper {
-  public basicScalars: Map<string, GraphQLNamedType>;
+declare class TypeMapper<TContext> {
+  public schemaComposer: SchemaComposer<TContext>;
+  protected basicScalars: Map<string, GraphQLNamedType>;
 
-  public constructor();
+  public constructor(schemaComposer: SchemaComposer<TContext>);
 
-  public get(name: string): GraphQLNamedType | null;
+  public get(name: string): GraphQLNamedType | void;
 
   public set(name: string, type: GraphQLNamedType): void;
 
@@ -56,13 +58,15 @@ declare class TypeMapper {
     str: TypeWrappedString | TypeNameString,
   ): GraphQLType | null;
 
-  public createType(str: TypeDefinitionString): GraphQLNamedType | null;
+  public createType(str: TypeDefinitionString): GraphQLNamedType | void;
 
-  public parseTypesFromString(str: string): TypeStorage<GraphQLNamedType>;
+  public parseTypesFromString(
+    str: string,
+  ): TypeStorage<string, GraphQLNamedType>;
 
   public parseTypesFromAst(
     astDocument: DocumentNode,
-  ): TypeStorage<GraphQLNamedType>;
+  ): TypeStorage<string, GraphQLNamedType>;
 
   public convertOutputType(composeType: ComposeObjectType): GraphQLObjectType;
 

--- a/src/TypeMapper.d.ts
+++ b/src/TypeMapper.d.ts
@@ -15,12 +15,12 @@ import {
   ComposeInputFieldConfigMap,
 } from './InputTypeComposer';
 import {
-  TypeComposer,
+  ObjectTypeComposer,
   ComposeArgumentConfig,
   ComposeFieldConfig,
   ComposeFieldConfigArgumentMap,
   ComposeFieldConfigMap,
-} from './TypeComposer';
+} from './ObjectTypeComposer';
 import {
   TypeDefinitionString,
   TypeNameString,
@@ -36,7 +36,7 @@ export type TypeAsString =
   | TypeWrappedString
   | TypeNameString;
 export type ComposeObjectType =
-  | TypeComposer<any, any>
+  | ObjectTypeComposer<any, any>
   | GraphQLObjectType
   | TypeDefinitionString
   | TypeAsString;

--- a/src/TypeMapper.js
+++ b/src/TypeMapper.js
@@ -91,7 +91,7 @@ export type TypeWrappedString = string; // eg. Int, Int!, [Int]
 export type TypeNameString = string; // eg. Int, Float
 export type TypeAsString = TypeDefinitionString | TypeWrappedString | TypeNameString;
 export type ComposeObjectType =
-  | TypeComposer<any>
+  | TypeComposer<any, any>
   | GraphQLObjectType
   | TypeDefinitionString
   | TypeAsString;
@@ -525,7 +525,7 @@ export class TypeMapper<TContext> {
   }
 
   convertArgConfigMap(
-    composeArgsConfigMap: ComposeFieldConfigArgumentMap,
+    composeArgsConfigMap: ComposeFieldConfigArgumentMap<any>,
     fieldName?: string = '',
     typeName?: string = ''
   ): GraphQLFieldConfigArgumentMap {

--- a/src/TypeMapper.js
+++ b/src/TypeMapper.js
@@ -72,8 +72,8 @@ import type {
   ComposeFieldConfig,
   ComposeArgumentConfig,
   ComposeFieldConfigArgumentMap,
-} from './TypeComposer';
-import { TypeComposer } from './TypeComposer';
+} from './ObjectTypeComposer';
+import { ObjectTypeComposer } from './ObjectTypeComposer';
 import type { SchemaComposer } from './SchemaComposer';
 import { InputTypeComposer } from './InputTypeComposer';
 import { ScalarTypeComposer } from './ScalarTypeComposer';
@@ -91,7 +91,7 @@ export type TypeWrappedString = string; // eg. Int, Int!, [Int]
 export type TypeNameString = string; // eg. Int, Float
 export type TypeAsString = TypeDefinitionString | TypeWrappedString | TypeNameString;
 export type ComposeObjectType =
-  | TypeComposer<any, any>
+  | ObjectTypeComposer<any, any>
   | GraphQLObjectType
   | TypeDefinitionString
   | TypeAsString;
@@ -231,8 +231,8 @@ export class TypeMapper<TContext> {
   }
 
   convertOutputType(composeType: ComposeObjectType): GraphQLObjectType {
-    if (this.schemaComposer.hasInstance(composeType, TypeComposer)) {
-      return this.schemaComposer.getTC(composeType).getType();
+    if (this.schemaComposer.hasInstance(composeType, ObjectTypeComposer)) {
+      return this.schemaComposer.getOTC(composeType).getType();
     } else if (typeof composeType === 'string') {
       const type = RegexpOutputTypeDefinition.test(composeType)
         ? this.createType(composeType)
@@ -249,7 +249,7 @@ export class TypeMapper<TContext> {
       return type;
     } else if (composeType instanceof GraphQLObjectType) {
       return composeType;
-    } else if (composeType instanceof TypeComposer) {
+    } else if (composeType instanceof ObjectTypeComposer) {
       return composeType.getType();
     }
 
@@ -274,7 +274,7 @@ export class TypeMapper<TContext> {
     } else if (composeFC instanceof Resolver) {
       return composeFC.getFieldConfig();
     } else if (
-      composeFC instanceof TypeComposer ||
+      composeFC instanceof ObjectTypeComposer ||
       composeFC instanceof EnumTypeComposer ||
       composeFC instanceof InterfaceTypeComposer ||
       composeFC instanceof UnionTypeComposer ||
@@ -320,8 +320,8 @@ export class TypeMapper<TContext> {
         );
       }
 
-      if (this.schemaComposer.hasInstance(composeType, TypeComposer)) {
-        fieldConfig.type = this.schemaComposer.getTC(composeType).getType();
+      if (this.schemaComposer.hasInstance(composeType, ObjectTypeComposer)) {
+        fieldConfig.type = this.schemaComposer.getOTC(composeType).getType();
       } else {
         const type =
           RegexpOutputTypeDefinition.test(composeType) ||
@@ -338,7 +338,7 @@ export class TypeMapper<TContext> {
         fieldConfig.type = (type: any);
       }
     } else if (
-      composeType instanceof TypeComposer ||
+      composeType instanceof ObjectTypeComposer ||
       composeType instanceof EnumTypeComposer ||
       composeType instanceof InterfaceTypeComposer ||
       composeType instanceof UnionTypeComposer ||
@@ -450,9 +450,9 @@ export class TypeMapper<TContext> {
       composeType = composeType[0];
     }
 
-    if (composeType instanceof TypeComposer) {
+    if (composeType instanceof ObjectTypeComposer) {
       throw new Error(
-        `You cannot provide TypeComposer to the arg '${typeName}.${fieldName}.@${argName}'. It should be InputType.`
+        `You cannot provide ObjectTypeComposer to the arg '${typeName}.${fieldName}.@${argName}'. It should be InputType.`
       );
     }
 
@@ -588,9 +588,9 @@ export class TypeMapper<TContext> {
       composeType = composeType[0];
     }
 
-    if (composeType instanceof TypeComposer) {
+    if (composeType instanceof ObjectTypeComposer) {
       throw new Error(
-        `You cannot provide TypeComposer to the field '${typeName}.${fieldName}'. It should be InputType.`
+        `You cannot provide ObjectTypeComposer to the field '${typeName}.${fieldName}'. It should be InputType.`
       );
     }
 

--- a/src/TypeMapper.js
+++ b/src/TypeMapper.js
@@ -208,7 +208,7 @@ export class TypeMapper<TContext> {
     return undefined;
   }
 
-  parseTypesFromString(str: string): TypeStorage<GraphQLNamedType> {
+  parseTypesFromString(str: string): TypeStorage<string, GraphQLNamedType> {
     const astDocument: DocumentNode = parse(str);
 
     if (!astDocument || astDocument.kind !== 'Document') {
@@ -218,7 +218,7 @@ export class TypeMapper<TContext> {
     return this.parseTypesFromAst(astDocument);
   }
 
-  parseTypesFromAst(astDocument: DocumentNode): TypeStorage<GraphQLNamedType> {
+  parseTypesFromAst(astDocument: DocumentNode): TypeStorage<string, GraphQLNamedType> {
     const typeStorage = new TypeStorage();
     for (let i = 0; i < astDocument.definitions.length; i++) {
       const def = astDocument.definitions[i];
@@ -708,7 +708,7 @@ function typeFromAST(inputTypeAST: TypeNode, schema: SchemaComposer<any>): ?Grap
 function typeDefNamed(
   typeName: string,
   schema: SchemaComposer<any>,
-  typeStorage: ?TypeStorage<any>
+  typeStorage: ?TypeStorage<any, any>
 ): GraphQLNamedType {
   const type = schema.typeMapper.get(typeName);
   if (type) {
@@ -729,7 +729,7 @@ function typeDefNamed(
   throw new Error(`Cannot find type with name '${typeName}' in SchemaComposer.`);
 }
 
-function makeSchemaDef(def, schema: SchemaComposer<any>, typeStorage: ?TypeStorage<any>) {
+function makeSchemaDef(def, schema: SchemaComposer<any>, typeStorage: ?TypeStorage<any, any>) {
   if (!def) {
     throw new Error('def must be defined');
   }
@@ -772,7 +772,7 @@ function getInputDefaultValue(value: InputValueDefinitionNode, type: GraphQLInpu
 function makeInputValues(
   values: ?$ReadOnlyArray<InputValueDefinitionNode>,
   schema: SchemaComposer<any>,
-  typeStorage: ?TypeStorage<any>
+  typeStorage: ?TypeStorage<any, any>
 ) {
   if (!values) return {};
   return keyValMap(
@@ -792,7 +792,7 @@ function makeInputValues(
 function makeFieldDefMap(
   def: ObjectTypeDefinitionNode | InterfaceTypeDefinitionNode,
   schema: SchemaComposer<any>,
-  typeStorage: ?TypeStorage<any>
+  typeStorage: ?TypeStorage<any, any>
 ) {
   if (!def.fields) return {};
   return keyValMap(
@@ -831,7 +831,7 @@ function makeEnumDef(def: EnumTypeDefinitionNode) {
 function makeInputObjectDef(
   def: InputObjectTypeDefinitionNode,
   schema: SchemaComposer<any>,
-  typeStorage: ?TypeStorage<any>
+  typeStorage: ?TypeStorage<any, any>
 ) {
   return new GraphQLInputObjectType({
     name: def.name.value,
@@ -844,7 +844,7 @@ function makeInputObjectDef(
 function makeDirectiveDef(
   def: DirectiveDefinitionNode,
   schema: SchemaComposer<any>,
-  typeStorage: ?TypeStorage<any>
+  typeStorage: ?TypeStorage<any, any>
 ): GraphQLDirective {
   const locations = def.locations.map(({ value }) => (value: any));
 
@@ -911,7 +911,7 @@ function buildWrappedType(innerType: GraphQLType, inputTypeAST: TypeNode): Graph
 function produceOutputType(
   typeAST: TypeNode,
   schema: SchemaComposer<any>,
-  typeStorage: ?TypeStorage<any>
+  typeStorage: ?TypeStorage<any, any>
 ): GraphQLOutputType {
   const type = produceType(typeAST, schema, typeStorage);
   invariant(isOutputType(type), 'Expected Output type.');
@@ -921,7 +921,7 @@ function produceOutputType(
 function produceType(
   typeAST: TypeNode,
   schema: SchemaComposer<any>,
-  typeStorage: ?TypeStorage<any>
+  typeStorage: ?TypeStorage<any, any>
 ): GraphQLType {
   const typeName = getNamedTypeAST(typeAST).name.value;
   const typeDef = typeDefNamed(typeName, schema, typeStorage);
@@ -931,7 +931,7 @@ function produceType(
 function produceInputType(
   typeAST: TypeNode,
   schema: SchemaComposer<any>,
-  typeStorage: ?TypeStorage<any>
+  typeStorage: ?TypeStorage<any, any>
 ): GraphQLInputType {
   const type = produceType(typeAST, schema, typeStorage);
   invariant(isInputType(type), 'Expected Input type.');
@@ -941,7 +941,7 @@ function produceInputType(
 function produceInterfaceType(
   typeAST: TypeNode,
   schema: SchemaComposer<any>,
-  typeStorage: ?TypeStorage<any>
+  typeStorage: ?TypeStorage<any, any>
 ): GraphQLInterfaceType {
   const type = produceType(typeAST, schema, typeStorage);
   invariant(type instanceof GraphQLInterfaceType, 'Expected Object type.');
@@ -951,7 +951,7 @@ function produceInterfaceType(
 function makeImplementedInterfaces(
   def: ObjectTypeDefinitionNode,
   schema: SchemaComposer<any>,
-  typeStorage: ?TypeStorage<any>
+  typeStorage: ?TypeStorage<any, any>
 ) {
   return (
     def.interfaces && def.interfaces.map(iface => produceInterfaceType(iface, schema, typeStorage))
@@ -961,7 +961,7 @@ function makeImplementedInterfaces(
 function makeTypeDef(
   def: ObjectTypeDefinitionNode,
   schema: SchemaComposer<any>,
-  typeStorage: ?TypeStorage<any>
+  typeStorage: ?TypeStorage<any, any>
 ) {
   return new GraphQLObjectType({
     name: def.name.value,
@@ -975,7 +975,7 @@ function makeTypeDef(
 function makeInterfaceDef(
   def: InterfaceTypeDefinitionNode,
   schema: SchemaComposer<any>,
-  typeStorage: ?TypeStorage<any>
+  typeStorage: ?TypeStorage<any, any>
 ) {
   return new GraphQLInterfaceType({
     name: def.name.value,
@@ -988,7 +988,7 @@ function makeInterfaceDef(
 function makeUnionDef(
   def: UnionTypeDefinitionNode,
   schema: SchemaComposer<any>,
-  typeStorage: ?TypeStorage<any>
+  typeStorage: ?TypeStorage<any, any>
 ) {
   const types: ?$ReadOnlyArray<NamedTypeNode> = def.types;
   return new GraphQLUnionType({

--- a/src/TypeStorage.d.ts
+++ b/src/TypeStorage.d.ts
@@ -6,19 +6,8 @@ import { EnumTypeComposer } from './EnumTypeComposer';
 import { InterfaceTypeComposer } from './InterfaceTypeComposer';
 import { UnionTypeComposer } from './UnionTypeComposer';
 
-type K = any;
-type V<TContext> =
-  | ObjectTypeComposer<any, TContext>
-  | InputTypeComposer
-  | EnumTypeComposer
-  | InterfaceTypeComposer<any, TContext>
-  | UnionTypeComposer<any, TContext>
-  | ScalarTypeComposer
-  | GraphQLNamedType
-  | GraphQLScalarType;
-
-export class TypeStorage<TContext> {
-  public types: Map<K, V<TContext>>;
+export class TypeStorage<K, V> {
+  public types: Map<K, V>;
   public readonly size: number;
 
   public constructor();
@@ -27,29 +16,26 @@ export class TypeStorage<TContext> {
 
   public delete(key: K): boolean;
 
-  public entries(): Iterator<[K, V<TContext>]>;
+  public entries(): Iterator<[K, V]>;
 
   public forEach(
-    callbackfn: (value: V<TContext>, index: K, map: Map<K, V<TContext>>) => any,
+    callbackfn: (value: V, index: K, map: Map<K, V>) => any,
     thisArg?: any,
   ): void;
 
-  public get(key: K): V<TContext>;
+  public get(key: K): V;
 
   public has(key: K): boolean;
 
   public keys(): Iterator<K>;
 
-  public set(key: K, value: V<TContext>): this;
+  public set(key: K, value: V): this;
 
-  public values(): Iterator<V<TContext>>;
+  public values(): Iterator<V>;
 
-  public add(value: V<TContext>): string | null;
+  public add(value: V): string | null;
 
   public hasInstance(key: K, ClassObj: any): boolean;
 
-  public getOrSet(
-    key: K,
-    typeOrThunk: V<TContext> | (() => V<TContext>),
-  ): V<TContext>;
+  public getOrSet(key: K, typeOrThunk: V | (() => V)): V;
 }

--- a/src/TypeStorage.d.ts
+++ b/src/TypeStorage.d.ts
@@ -11,8 +11,8 @@ type V<TContext> =
   | TypeComposer<any, TContext>
   | InputTypeComposer
   | EnumTypeComposer
-  | InterfaceTypeComposer<TContext>
-  | UnionTypeComposer<TContext>
+  | InterfaceTypeComposer<any, TContext>
+  | UnionTypeComposer<any, TContext>
   | ScalarTypeComposer
   | GraphQLNamedType
   | GraphQLScalarType;
@@ -53,17 +53,19 @@ export class TypeStorage<TContext> {
     typeOrThunk: V<TContext> | (() => V<TContext>),
   ): V<TContext>;
 
-  public getTC(typeName: K): TypeComposer<any, TContext>;
-
   public getTC<TSource = any>(typeName: K): TypeComposer<TSource, TContext>;
 
   public getITC(typeName: K): InputTypeComposer;
 
   public getETC(typeName: K): EnumTypeComposer;
 
-  public getIFTC(typeName: K): InterfaceTypeComposer<TContext>;
+  public getIFTC<TSource = any>(
+    typeName: K,
+  ): InterfaceTypeComposer<TSource, TContext>;
 
-  public getUTC(typeName: K): UnionTypeComposer<TContext>;
+  public getUTC<TSource = any>(
+    typeName: K,
+  ): UnionTypeComposer<TSource, TContext>;
 
   public getSTC(typeName: K): ScalarTypeComposer;
 }

--- a/src/TypeStorage.d.ts
+++ b/src/TypeStorage.d.ts
@@ -1,5 +1,5 @@
 import { GraphQLNamedType, GraphQLScalarType } from 'graphql';
-import { TypeComposer } from './TypeComposer';
+import { ObjectTypeComposer } from './ObjectTypeComposer';
 import { InputTypeComposer } from './InputTypeComposer';
 import { ScalarTypeComposer } from './ScalarTypeComposer';
 import { EnumTypeComposer } from './EnumTypeComposer';
@@ -8,7 +8,7 @@ import { UnionTypeComposer } from './UnionTypeComposer';
 
 type K = any;
 type V<TContext> =
-  | TypeComposer<any, TContext>
+  | ObjectTypeComposer<any, TContext>
   | InputTypeComposer
   | EnumTypeComposer
   | InterfaceTypeComposer<any, TContext>
@@ -52,20 +52,4 @@ export class TypeStorage<TContext> {
     key: K,
     typeOrThunk: V<TContext> | (() => V<TContext>),
   ): V<TContext>;
-
-  public getTC<TSource = any>(typeName: K): TypeComposer<TSource, TContext>;
-
-  public getITC(typeName: K): InputTypeComposer;
-
-  public getETC(typeName: K): EnumTypeComposer;
-
-  public getIFTC<TSource = any>(
-    typeName: K,
-  ): InterfaceTypeComposer<TSource, TContext>;
-
-  public getUTC<TSource = any>(
-    typeName: K,
-  ): UnionTypeComposer<TSource, TContext>;
-
-  public getSTC(typeName: K): ScalarTypeComposer;
 }

--- a/src/TypeStorage.js
+++ b/src/TypeStorage.js
@@ -9,7 +9,7 @@ export class TypeStorage<K, V> {
   constructor(): TypeStorage<K, V> {
     this.types = new Map();
 
-    // alive proper Flow type casting in autosuggestions
+    // alive proper Flow type casting in autosuggestions for class with Generics
     /* :: return this; */
   }
 

--- a/src/TypeStorage.js
+++ b/src/TypeStorage.js
@@ -11,11 +11,11 @@ import type { GraphQLNamedType } from './graphql';
 
 type K = any;
 type V<TContext> =
-  | TypeComposer<TContext>
+  | TypeComposer<any, TContext>
   | InputTypeComposer
   | EnumTypeComposer
-  | InterfaceTypeComposer<TContext>
-  | UnionTypeComposer<TContext>
+  | InterfaceTypeComposer<any, TContext>
+  | UnionTypeComposer<any, TContext>
   | ScalarTypeComposer
   | GraphQLNamedType;
 
@@ -119,7 +119,7 @@ export class TypeStorage<TContext> {
     return gqType;
   }
 
-  getTC(typeName: K): TypeComposer<TContext> {
+  getTC(typeName: K): TypeComposer<any, TContext> {
     if (!this.hasInstance(typeName, TypeComposer)) {
       throw new Error(`Cannot find TypeComposer with name ${typeName}`);
     }
@@ -140,14 +140,14 @@ export class TypeStorage<TContext> {
     return (this.get(typeName): any);
   }
 
-  getIFTC(typeName: K): InterfaceTypeComposer<TContext> {
+  getIFTC(typeName: K): InterfaceTypeComposer<any, TContext> {
     if (!this.hasInstance(typeName, InterfaceTypeComposer)) {
       throw new Error(`Cannot find InterfaceTypeComposer with name ${typeName}`);
     }
     return (this.get(typeName): any);
   }
 
-  getUTC(typeName: K): UnionTypeComposer<TContext> {
+  getUTC(typeName: K): UnionTypeComposer<any, TContext> {
     if (!this.hasInstance(typeName, UnionTypeComposer)) {
       throw new Error(`Cannot find UnionTypeComposer with name ${typeName}`);
     }

--- a/src/UnionTypeComposer.d.ts
+++ b/src/UnionTypeComposer.d.ts
@@ -28,8 +28,6 @@ export type GraphQLUnionTypeExtended<TSource, TContext> = GraphQLUnionType & {
   _gqcExtensions?: Extensions;
 };
 
-export type ComposeTypesArray = ComposeObjectType[];
-
 export type UnionTypeResolversMap<TSource, TContext> = Map<
   ComposeObjectType,
   UnionTypeResolverCheckFn<TSource, TContext>
@@ -39,11 +37,11 @@ export type UnionTypeResolverCheckFn<TSource, TContext> = (
   value: TSource,
   context: TContext,
   info: GraphQLResolveInfo,
-) => MaybePromise<boolean | null | undefined>;
+) => MaybePromise<boolean | null | void>;
 
 export type ComposeUnionTypeConfig<TSource, TContext> = {
   name: string;
-  types?: Thunk<ComposeTypesArray>;
+  types?: Thunk<ComposeObjectType[]>;
   resolveType?: GraphQLTypeResolver<TSource, TContext> | null;
   description?: string | null;
   extensions?: Extensions;
@@ -54,19 +52,23 @@ export type UnionTypeComposerDefinition<TSource, TContext> =
   | ComposeUnionTypeConfig<TSource, TContext>;
 
 export class UnionTypeComposer<TSource = any, TContext = any> {
-  public static schemaComposer: SchemaComposer<any>;
-  public schemaComposer: SchemaComposer<TSource>;
+  public schemaComposer: SchemaComposer<TContext>;
 
   protected gqType: GraphQLUnionTypeExtended<TSource, TContext>;
 
-  public constructor(gqType: GraphQLUnionType);
+  public constructor(
+    gqType: GraphQLUnionType,
+    schemaComposer: SchemaComposer<TContext>,
+  );
 
   public static create<TSrc = any, TCtx = any>(
     typeDef: UnionTypeComposerDefinition<TSrc, TCtx>,
+    schemaComposer: SchemaComposer<TCtx>,
   ): UnionTypeComposer<TSrc, TCtx>;
 
   public static createTemp<TSrc = any, TCtx = any>(
     typeDef: UnionTypeComposerDefinition<TSrc, TCtx>,
+    schemaComposer?: SchemaComposer<TCtx>,
   ): UnionTypeComposer<TSrc, TCtx>;
 
   // -----------------------------------------------
@@ -77,11 +79,13 @@ export class UnionTypeComposer<TSource = any, TContext = any> {
     name: string | GraphQLObjectType | ObjectTypeComposer<any, TContext>,
   ): boolean;
 
-  public getTypes(): ComposeTypesArray;
+  public getTypes(): ComposeObjectType[];
 
   public getTypeNames(): string[];
 
-  public setTypes(types: ComposeTypesArray): this;
+  public clearTypes(): UnionTypeComposer<TSource, TContext>;
+
+  public setTypes(types: ComposeObjectType[]): this;
 
   public addType(type: ComposeObjectType): this;
 
@@ -107,7 +111,7 @@ export class UnionTypeComposer<TSource = any, TContext = any> {
 
   public setDescription(description: string): this;
 
-  public clone(newTypeName: string): this;
+  public clone(newTypeName: string): UnionTypeComposer<TSource, TContext>;
 
   // -----------------------------------------------
   // ResolveType methods

--- a/src/UnionTypeComposer.d.ts
+++ b/src/UnionTypeComposer.d.ts
@@ -17,8 +17,8 @@ import { SchemaComposer } from './SchemaComposer';
 import {
   ComposeFieldConfig,
   ComposeFieldConfigMap,
-  TypeComposer,
-} from './TypeComposer';
+  ObjectTypeComposer,
+} from './ObjectTypeComposer';
 import { TypeAsString, ComposeObjectType } from './TypeMapper';
 import { Thunk, Extensions, MaybePromise } from './utils/definitions';
 
@@ -74,7 +74,7 @@ export class UnionTypeComposer<TSource = any, TContext = any> {
   // -----------------------------------------------
 
   public hasType(
-    name: string | GraphQLObjectType | TypeComposer<any, TContext>,
+    name: string | GraphQLObjectType | ObjectTypeComposer<any, TContext>,
   ): boolean;
 
   public getTypes(): ComposeTypesArray;
@@ -120,13 +120,13 @@ export class UnionTypeComposer<TSource = any, TContext = any> {
   ): this;
 
   public hasTypeResolver(
-    type: TypeComposer<any, TContext> | GraphQLObjectType,
+    type: ObjectTypeComposer<any, TContext> | GraphQLObjectType,
   ): boolean;
 
   public getTypeResolvers(): UnionTypeResolversMap<TSource, TContext>;
 
   public getTypeResolverCheckFn(
-    type: TypeComposer<any, TContext> | GraphQLObjectType,
+    type: ObjectTypeComposer<any, TContext> | GraphQLObjectType,
   ): UnionTypeResolverCheckFn<any, TContext>;
 
   public getTypeResolverNames(): string[];
@@ -138,12 +138,12 @@ export class UnionTypeComposer<TSource = any, TContext = any> {
   ): this;
 
   public addTypeResolver(
-    type: TypeComposer<any, TContext> | GraphQLObjectType,
+    type: ObjectTypeComposer<any, TContext> | GraphQLObjectType,
     checkFn: UnionTypeResolverCheckFn<TSource, TContext>,
   ): this;
 
   public removeTypeResolver(
-    type: TypeComposer<any, TContext> | GraphQLObjectType,
+    type: ObjectTypeComposer<any, TContext> | GraphQLObjectType,
   ): this;
 
   // -----------------------------------------------

--- a/src/UnionTypeComposer.d.ts
+++ b/src/UnionTypeComposer.d.ts
@@ -49,9 +49,9 @@ export type ComposeUnionTypeConfig<TSource, TContext> = {
   extensions?: Extensions;
 };
 
-export type UnionTypeComposerDefinition<TContext> =
+export type UnionTypeComposerDefinition<TSource, TContext> =
   | TypeAsString
-  | ComposeUnionTypeConfig<any, TContext>;
+  | ComposeUnionTypeConfig<TSource, TContext>;
 
 export class UnionTypeComposer<TSource = any, TContext = any> {
   public static schemaComposer: SchemaComposer<any>;
@@ -62,11 +62,11 @@ export class UnionTypeComposer<TSource = any, TContext = any> {
   public constructor(gqType: GraphQLUnionType);
 
   public static create<TSrc = any, TCtx = any>(
-    typeDef: UnionTypeComposerDefinition<TCtx>,
+    typeDef: UnionTypeComposerDefinition<TSrc, TCtx>,
   ): UnionTypeComposer<TSrc, TCtx>;
 
   public static createTemp<TSrc = any, TCtx = any>(
-    typeDef: UnionTypeComposerDefinition<TCtx>,
+    typeDef: UnionTypeComposerDefinition<TSrc, TCtx>,
   ): UnionTypeComposer<TSrc, TCtx>;
 
   // -----------------------------------------------
@@ -74,7 +74,7 @@ export class UnionTypeComposer<TSource = any, TContext = any> {
   // -----------------------------------------------
 
   public hasType(
-    name: string | GraphQLObjectType | TypeComposer<TContext>,
+    name: string | GraphQLObjectType | TypeComposer<any, TContext>,
   ): boolean;
 
   public getTypes(): ComposeTypesArray;
@@ -113,10 +113,10 @@ export class UnionTypeComposer<TSource = any, TContext = any> {
   // ResolveType methods
   // -----------------------------------------------
 
-  public getResolveType(): GraphQLTypeResolver<any, TContext> | null | void;
+  public getResolveType(): GraphQLTypeResolver<TSource, TContext> | null | void;
 
   public setResolveType(
-    fn: GraphQLTypeResolver<any, TContext> | null | void,
+    fn: GraphQLTypeResolver<TSource, TContext> | null | void,
   ): this;
 
   public hasTypeResolver(
@@ -134,12 +134,12 @@ export class UnionTypeComposer<TSource = any, TContext = any> {
   public getTypeResolverTypes(): GraphQLObjectType[];
 
   public setTypeResolvers(
-    typeResolversMap: UnionTypeResolversMap<any, TContext>,
+    typeResolversMap: UnionTypeResolversMap<TSource, TContext>,
   ): this;
 
   public addTypeResolver(
     type: TypeComposer<any, TContext> | GraphQLObjectType,
-    checkFn: UnionTypeResolverCheckFn<any, TContext>,
+    checkFn: UnionTypeResolverCheckFn<TSource, TContext>,
   ): this;
 
   public removeTypeResolver(

--- a/src/UnionTypeComposer.js
+++ b/src/UnionTypeComposer.js
@@ -51,10 +51,10 @@ export class UnionTypeComposer<TSource, TContext> {
 
   // Also supported `GraphQLUnionType` but in such case Flowtype force developers
   // to explicitly write annotations in their code. But it's bad.
-  static create(
-    typeDef: UnionTypeComposerDefinition<TSource, TContext>,
-    sc: SchemaComposer<TContext>
-  ): UnionTypeComposer<TSource, TContext> {
+  static create<TSrc, TCtx>(
+    typeDef: UnionTypeComposerDefinition<TSrc, TCtx>,
+    sc: SchemaComposer<TCtx>
+  ): UnionTypeComposer<TSrc, TCtx> {
     if (!(sc instanceof SchemaComposer)) {
       throw new Error(
         'You must provide SchemaComposer instance as a second argument for `UnionTypeComposer.create(typeDef, schemaComposer)`'
@@ -65,10 +65,10 @@ export class UnionTypeComposer<TSource, TContext> {
     return utc;
   }
 
-  static createTemp(
-    typeDef: UnionTypeComposerDefinition<TSource, TContext>,
-    _sc?: SchemaComposer<TContext>
-  ): UnionTypeComposer<TSource, TContext> {
+  static createTemp<TSrc, TCtx>(
+    typeDef: UnionTypeComposerDefinition<TSrc, TCtx>,
+    _sc?: SchemaComposer<TCtx>
+  ): UnionTypeComposer<TSrc, TCtx> {
     const sc = _sc || new SchemaComposer();
     let UTC;
 

--- a/src/UnionTypeComposer.js
+++ b/src/UnionTypeComposer.js
@@ -5,7 +5,7 @@
 import { GraphQLUnionType, GraphQLObjectType, GraphQLList, GraphQLNonNull } from './graphql';
 import { isObject, isString, isFunction } from './utils/is';
 import { inspect } from './utils/misc';
-import { TypeComposer } from './TypeComposer';
+import { ObjectTypeComposer } from './ObjectTypeComposer';
 import type { GraphQLResolveInfo, GraphQLTypeResolver } from './graphql';
 import type { TypeAsString, ComposeObjectType } from './TypeMapper';
 import { SchemaComposer } from './SchemaComposer';
@@ -135,7 +135,7 @@ export class UnionTypeComposer<TSource, TContext> {
   // Union Types methods
   // -----------------------------------------------
 
-  hasType(name: string | GraphQLObjectType | TypeComposer<any, TContext>): boolean {
+  hasType(name: string | GraphQLObjectType | ObjectTypeComposer<any, TContext>): boolean {
     const nameAsString = getComposeTypeName(name);
     return this.getTypeNames().includes(nameAsString);
   }
@@ -270,7 +270,7 @@ export class UnionTypeComposer<TSource, TContext> {
     return this;
   }
 
-  hasTypeResolver(type: TypeComposer<any, TContext> | GraphQLObjectType): boolean {
+  hasTypeResolver(type: ObjectTypeComposer<any, TContext> | GraphQLObjectType): boolean {
     const typeResolversMap = this.getTypeResolvers();
     return typeResolversMap.has(type);
   }
@@ -283,7 +283,7 @@ export class UnionTypeComposer<TSource, TContext> {
   }
 
   getTypeResolverCheckFn(
-    type: TypeComposer<any, TContext> | GraphQLObjectType
+    type: ObjectTypeComposer<any, TContext> | GraphQLObjectType
   ): UnionTypeResolverCheckFn<any, TContext> {
     const typeResolversMap = this.getTypeResolvers();
 
@@ -302,7 +302,7 @@ export class UnionTypeComposer<TSource, TContext> {
     const typeResolversMap = this.getTypeResolvers();
     const names = [];
     typeResolversMap.forEach((resolveFn, composeType) => {
-      if (composeType instanceof TypeComposer) {
+      if (composeType instanceof ObjectTypeComposer) {
         names.push(composeType.getTypeName());
       } else if (composeType && typeof composeType.name === 'string') {
         names.push(composeType.name);
@@ -327,7 +327,7 @@ export class UnionTypeComposer<TSource, TContext> {
 
     this.gqType._gqcTypeResolvers = typeResolversMap;
 
-    // extract GraphQLObjectType from TypeComposer
+    // extract GraphQLObjectType from ObjectTypeComposer
     const fastEntries = [];
     for (const [composeType, checkFn] of typeResolversMap.entries()) {
       fastEntries.push([((getGraphQLType(composeType): any): GraphQLObjectType), checkFn]);
@@ -373,7 +373,7 @@ export class UnionTypeComposer<TSource, TContext> {
         if (!(type instanceof GraphQLObjectType)) throw new Error('Must be GraphQLObjectType');
       } catch (e) {
         throw new Error(
-          `For union type resolver ${this.getTypeName()} you must provide GraphQLObjectType or TypeComposer, but provided ${inspect(
+          `For union type resolver ${this.getTypeName()} you must provide GraphQLObjectType or ObjectTypeComposer, but provided ${inspect(
             composeType
           )}`
         );
@@ -408,7 +408,7 @@ export class UnionTypeComposer<TSource, TContext> {
   }
 
   addTypeResolver(
-    type: TypeComposer<any, TContext> | GraphQLObjectType,
+    type: ObjectTypeComposer<any, TContext> | GraphQLObjectType,
     checkFn: UnionTypeResolverCheckFn<TSource, TContext>
   ): UnionTypeComposer<TSource, TContext> {
     const typeResolversMap = this.getTypeResolvers();
@@ -418,7 +418,7 @@ export class UnionTypeComposer<TSource, TContext> {
   }
 
   removeTypeResolver(
-    type: TypeComposer<any, TContext> | GraphQLObjectType
+    type: ObjectTypeComposer<any, TContext> | GraphQLObjectType
   ): UnionTypeComposer<TSource, TContext> {
     const typeResolversMap = this.getTypeResolvers();
     typeResolversMap.delete(type);

--- a/src/UnionTypeComposer.js
+++ b/src/UnionTypeComposer.js
@@ -46,7 +46,7 @@ export type UnionTypeComposerDefinition<TSource, TContext> =
   | ComposeUnionTypeConfig<TSource, TContext>;
 
 export class UnionTypeComposer<TSource, TContext> {
-  gqType: GraphQLUnionTypeExtended<any, TContext>;
+  gqType: GraphQLUnionTypeExtended<TSource, TContext>;
   sc: SchemaComposer<TContext>;
 
   // Also supported `GraphQLUnionType` but in such case Flowtype force developers

--- a/src/UnionTypeComposer.js
+++ b/src/UnionTypeComposer.js
@@ -47,29 +47,29 @@ export type UnionTypeComposerDefinition<TSource, TContext> =
 
 export class UnionTypeComposer<TSource, TContext> {
   gqType: GraphQLUnionTypeExtended<TSource, TContext>;
-  sc: SchemaComposer<TContext>;
+  schemaComposer: SchemaComposer<TContext>;
 
   // Also supported `GraphQLUnionType` but in such case Flowtype force developers
   // to explicitly write annotations in their code. But it's bad.
   static create<TSrc, TCtx>(
     typeDef: UnionTypeComposerDefinition<TSrc, TCtx>,
-    sc: SchemaComposer<TCtx>
+    schemaComposer: SchemaComposer<TCtx>
   ): UnionTypeComposer<TSrc, TCtx> {
-    if (!(sc instanceof SchemaComposer)) {
+    if (!(schemaComposer instanceof SchemaComposer)) {
       throw new Error(
         'You must provide SchemaComposer instance as a second argument for `UnionTypeComposer.create(typeDef, schemaComposer)`'
       );
     }
-    const utc = this.createTemp(typeDef, sc);
-    sc.add(utc);
+    const utc = this.createTemp(typeDef, schemaComposer);
+    schemaComposer.add(utc);
     return utc;
   }
 
   static createTemp<TSrc, TCtx>(
     typeDef: UnionTypeComposerDefinition<TSrc, TCtx>,
-    _sc?: SchemaComposer<TCtx>
+    schemaComposer?: SchemaComposer<TCtx>
   ): UnionTypeComposer<TSrc, TCtx> {
-    const sc = _sc || new SchemaComposer();
+    const sc = schemaComposer || new SchemaComposer();
     let UTC;
 
     if (isString(typeDef)) {
@@ -115,13 +115,13 @@ export class UnionTypeComposer<TSource, TContext> {
     return UTC;
   }
 
-  constructor(gqType: GraphQLUnionType, sc: SchemaComposer<TContext>) {
-    if (!(sc instanceof SchemaComposer)) {
+  constructor(gqType: GraphQLUnionType, schemaComposer: SchemaComposer<TContext>) {
+    if (!(schemaComposer instanceof SchemaComposer)) {
       throw new Error(
         'You must provide SchemaComposer instance as a second argument for `new UnionTypeComposer(GraphQLUnionType, SchemaComposer)`'
       );
     }
-    this.sc = sc;
+    this.schemaComposer = schemaComposer;
 
     if (!(gqType instanceof GraphQLUnionType)) {
       throw new Error(
@@ -151,12 +151,12 @@ export class UnionTypeComposer<TSource, TContext> {
 
       if (graphqlVersion >= 14) {
         this.gqType._types = () => {
-          return resolveTypeArrayAsThunk(this.sc, this.getTypes(), this.getTypeName());
+          return resolveTypeArrayAsThunk(this.schemaComposer, this.getTypes(), this.getTypeName());
         };
       } else {
         (this.gqType: any)._types = null;
         (this.gqType: any)._typeConfig.types = () => {
-          return resolveTypeArrayAsThunk(this.sc, this.getTypes(), this.getTypeName());
+          return resolveTypeArrayAsThunk(this.schemaComposer, this.getTypes(), this.getTypeName());
         };
       }
     }
@@ -230,7 +230,7 @@ export class UnionTypeComposer<TSource, TContext> {
 
   setTypeName(name: string): UnionTypeComposer<TSource, TContext> {
     this.gqType.name = name;
-    this.sc.add(this);
+    this.schemaComposer.add(this);
     return this;
   }
 
@@ -248,7 +248,7 @@ export class UnionTypeComposer<TSource, TContext> {
       throw new Error('You should provide newTypeName:string for UnionTypeComposer.clone()');
     }
 
-    const cloned = UnionTypeComposer.create(newTypeName, this.sc);
+    const cloned = UnionTypeComposer.create(newTypeName, this.schemaComposer);
     cloned.setTypes(this.getTypes());
     cloned.setDescription(this.getDescription());
 

--- a/src/__mocks__/schemaComposer.js
+++ b/src/__mocks__/schemaComposer.js
@@ -3,16 +3,18 @@
 import { GraphQLInt, GraphQLString } from '../graphql';
 import { schemaComposer } from '..';
 
-schemaComposer.getOrCreateTC('User').addFields({
-  name: {
-    type: GraphQLString,
-  },
-  nickname: {
-    type: GraphQLString,
-  },
-  age: {
-    type: GraphQLInt,
-  },
-});
+schemaComposer.getOrCreateTC('User', tc =>
+  tc.addFields({
+    name: {
+      type: GraphQLString,
+    },
+    nickname: {
+      type: GraphQLString,
+    },
+    age: {
+      type: GraphQLInt,
+    },
+  })
+);
 
 export default schemaComposer;

--- a/src/__mocks__/schemaComposer.js
+++ b/src/__mocks__/schemaComposer.js
@@ -3,7 +3,7 @@
 import { GraphQLInt, GraphQLString } from '../graphql';
 import { schemaComposer } from '..';
 
-schemaComposer.getOrCreateTC('User', tc =>
+schemaComposer.getOrCreateOTC('User', tc =>
   tc.addFields({
     name: {
       type: GraphQLString,

--- a/src/__tests__/EnumTypeComposer-test.js
+++ b/src/__tests__/EnumTypeComposer-test.js
@@ -1,6 +1,7 @@
 /* @flow strict */
 
-import { EnumTypeComposer, schemaComposer } from '..';
+import { schemaComposer } from '..';
+import { EnumTypeComposer } from '../EnumTypeComposer';
 import { GraphQLList, GraphQLNonNull, GraphQLEnumType } from '../graphql';
 import { graphqlVersion } from '../utils/graphqlVersion';
 
@@ -21,7 +22,7 @@ describe('EnumTypeComposer', () => {
       },
     });
 
-    etc = new EnumTypeComposer(enumType);
+    etc = new EnumTypeComposer(enumType, schemaComposer);
   });
 
   describe('values manipulation', () => {
@@ -32,7 +33,7 @@ describe('EnumTypeComposer', () => {
 
     if (graphqlVersion >= 13) {
       it('getFields() from empty Enum', () => {
-        const etc2 = EnumTypeComposer.create('SomeType');
+        const etc2 = EnumTypeComposer.create('SomeType', schemaComposer);
         expect(etc2.getFields()).toEqual({});
       });
     }
@@ -150,7 +151,7 @@ describe('EnumTypeComposer', () => {
   describe('create() [static method]', () => {
     if (graphqlVersion >= 13) {
       it('should create ETC by typeName as a string', () => {
-        const myTC = EnumTypeComposer.create('TypeStub');
+        const myTC = EnumTypeComposer.create('TypeStub', schemaComposer);
         expect(myTC).toBeInstanceOf(EnumTypeComposer);
         expect(myTC.getType()).toBeInstanceOf(GraphQLEnumType);
         expect(myTC.getFields()).toEqual({});
@@ -158,20 +159,23 @@ describe('EnumTypeComposer', () => {
     }
 
     it('should create ETC by type template string', () => {
-      const myTC = EnumTypeComposer.create('enum SDLEnum { V1 V2 V3 }');
+      const myTC = EnumTypeComposer.create('enum SDLEnum { V1 V2 V3 }', schemaComposer);
       expect(myTC).toBeInstanceOf(EnumTypeComposer);
       expect(myTC.getTypeName()).toBe('SDLEnum');
       expect(myTC.getFieldNames()).toEqual(['V1', 'V2', 'V3']);
     });
 
     it('should create ETC by GraphQLEnumTypeConfig', () => {
-      const myTC = EnumTypeComposer.create({
-        name: 'TestType',
-        values: {
-          v1: {},
-          v2: {},
+      const myTC = EnumTypeComposer.create(
+        {
+          name: 'TestType',
+          values: {
+            v1: {},
+            v2: {},
+          },
         },
-      });
+        schemaComposer
+      );
       expect(myTC).toBeInstanceOf(EnumTypeComposer);
       expect(myTC.getTypeName()).toBe('TestType');
       expect(myTC.getFieldNames()).toEqual(['v1', 'v2']);
@@ -185,19 +189,19 @@ describe('EnumTypeComposer', () => {
           v2: {},
         },
       });
-      const myTC = EnumTypeComposer.create(objType);
+      const myTC = EnumTypeComposer.create(objType, schemaComposer);
       expect(myTC).toBeInstanceOf(EnumTypeComposer);
       expect(myTC.getType()).toBe(objType);
       expect(myTC.getFieldNames()).toEqual(['v1', 'v2']);
     });
 
     it('should create TC without values from string', () => {
-      const myTC = EnumTypeComposer.create('MyEnum');
+      const myTC = EnumTypeComposer.create('MyEnum', schemaComposer);
       expect(myTC.getFieldNames()).toEqual([]);
     });
 
     it('should create type and store it in schemaComposer', () => {
-      const SomeUserETC = EnumTypeComposer.create('SomeUserEnum');
+      const SomeUserETC = EnumTypeComposer.create('SomeUserEnum', schemaComposer);
       expect(schemaComposer.getETC('SomeUserEnum')).toBe(SomeUserETC);
     });
 

--- a/src/__tests__/EnumTypeComposer-test.js
+++ b/src/__tests__/EnumTypeComposer-test.js
@@ -11,7 +11,7 @@ beforeEach(() => {
 
 describe('EnumTypeComposer', () => {
   let enumType: GraphQLEnumType;
-  let etc: EnumTypeComposer;
+  let etc: EnumTypeComposer<any>;
 
   beforeEach(() => {
     enumType = new GraphQLEnumType({

--- a/src/__tests__/Extensions-test.js
+++ b/src/__tests__/Extensions-test.js
@@ -1,66 +1,78 @@
-import {
-  EnumTypeComposer,
-  InputTypeComposer,
-  InterfaceTypeComposer,
-  ScalarTypeComposer,
-  TypeComposer,
-  UnionTypeComposer,
-  schemaComposer,
-} from '..';
+/* @flow */
+
+import { schemaComposer as sc } from '..';
+import { EnumTypeComposer } from '../EnumTypeComposer';
+import { InputTypeComposer } from '../InputTypeComposer';
+import { InterfaceTypeComposer } from '../InterfaceTypeComposer';
+import { ScalarTypeComposer } from '../ScalarTypeComposer';
+import { TypeComposer } from '../TypeComposer';
+import { UnionTypeComposer } from '../UnionTypeComposer';
 
 beforeEach(() => {
-  schemaComposer.clear();
+  sc.clear();
 });
 
 describe('Extensions', () => {
   describe('TypeComposer', () => {
     it('has type Extensions methods', () => {
-      const typeComposer = TypeComposer.create({
-        name: 'Foo',
-        fields: {
-          id: 'ID!',
-          name: 'String',
+      const typeComposer = TypeComposer.create(
+        {
+          name: 'Foo',
+          fields: {
+            id: 'ID!',
+            name: 'String',
+          },
         },
-      });
+        sc
+      );
       testTypeExtensions(typeComposer);
     });
 
     it('has field Extensions methods', () => {
-      const typeComposer = TypeComposer.create({
-        name: 'Foo',
-        fields: {
-          id: 'ID!',
-          name: 'String',
+      const typeComposer = TypeComposer.create(
+        {
+          name: 'Foo',
+          fields: {
+            id: 'ID!',
+            name: 'String',
+          },
         },
-      });
+        sc
+      );
       testFieldExtensions(typeComposer);
     });
 
     it('has type extension initializers', () => {
-      const typeComposer = TypeComposer.create({
-        name: 'Foo',
-        fields: {
-          id: 'ID!',
-          name: 'String',
+      const typeComposer = TypeComposer.create(
+        {
+          name: 'Foo',
+          fields: {
+            id: 'ID!',
+            name: 'String',
+          },
+          extensions: { tags: ['generated'] },
         },
-        extensions: { tags: ['generated'] },
-      });
+        sc
+      );
       expect(typeComposer.getExtensions()).toEqual({ tags: ['generated'] });
     });
 
     it('has field extension initializers', () => {
-      const typeComposer = TypeComposer.create({
-        name: 'Foo',
-        fields: {
-          id: 'ID!',
-          name: {
-            type: 'String',
-            extensions: {
-              noFilter: true,
+      const typeComposer = TypeComposer.create(
+        {
+          name: 'Foo',
+          fields: {
+            id: 'ID!',
+            name: {
+              type: 'String',
+              extensions: {
+                noFilter: true,
+              },
             },
           },
         },
-      });
+        sc
+      );
       expect(typeComposer.getFieldExtensions('name')).toEqual({
         noFilter: true,
       });
@@ -69,52 +81,64 @@ describe('Extensions', () => {
 
   describe('InputTypeComposer', () => {
     it('has type Extensions methods', () => {
-      const typeComposer = InputTypeComposer.create({
-        name: 'Foo',
-        fields: {
-          id: 'ID!',
-          name: 'String',
+      const typeComposer = InputTypeComposer.create(
+        {
+          name: 'Foo',
+          fields: {
+            id: 'ID!',
+            name: 'String',
+          },
         },
-      });
+        sc
+      );
       testTypeExtensions(typeComposer);
     });
 
     it('has field Extensions methods', () => {
-      const typeComposer = InputTypeComposer.create({
-        name: 'Foo',
-        fields: {
-          id: 'ID!',
-          name: 'String',
+      const typeComposer = InputTypeComposer.create(
+        {
+          name: 'Foo',
+          fields: {
+            id: 'ID!',
+            name: 'String',
+          },
         },
-      });
+        sc
+      );
       testFieldExtensions(typeComposer);
     });
 
     it('has type extension initializers', () => {
-      const typeComposer = InputTypeComposer.create({
-        name: 'Foo',
-        fields: {
-          id: 'ID!',
-          name: 'String',
+      const typeComposer = InputTypeComposer.create(
+        {
+          name: 'Foo',
+          fields: {
+            id: 'ID!',
+            name: 'String',
+          },
+          extensions: { tags: ['generated'] },
         },
-        extensions: { tags: ['generated'] },
-      });
+        sc
+      );
       expect(typeComposer.getExtensions()).toEqual({ tags: ['generated'] });
     });
 
     it('has field extension initializers', () => {
-      const typeComposer = InputTypeComposer.create({
-        name: 'Foo',
-        fields: {
-          id: 'ID!',
-          name: {
-            type: 'String',
-            extensions: {
-              noFilter: true,
+      const typeComposer = InputTypeComposer.create(
+        {
+          name: 'Foo',
+          fields: {
+            id: 'ID!',
+            name: {
+              type: 'String',
+              extensions: {
+                noFilter: true,
+              },
             },
           },
         },
-      });
+        sc
+      );
       expect(typeComposer.getFieldExtensions('name')).toEqual({
         noFilter: true,
       });
@@ -123,52 +147,64 @@ describe('Extensions', () => {
 
   describe('InterfaceTypeComposer', () => {
     it('has type Extensions methods', () => {
-      const typeComposer = InterfaceTypeComposer.create({
-        name: 'Foo',
-        fields: {
-          id: 'ID!',
-          name: 'String',
+      const typeComposer = InterfaceTypeComposer.create(
+        {
+          name: 'Foo',
+          fields: {
+            id: 'ID!',
+            name: 'String',
+          },
         },
-      });
+        sc
+      );
       testTypeExtensions(typeComposer);
     });
 
     it('has field Extensions methods', () => {
-      const typeComposer = InterfaceTypeComposer.create({
-        name: 'Foo',
-        fields: {
-          id: 'ID!',
-          name: 'String',
+      const typeComposer = InterfaceTypeComposer.create(
+        {
+          name: 'Foo',
+          fields: {
+            id: 'ID!',
+            name: 'String',
+          },
         },
-      });
+        sc
+      );
       testFieldExtensions(typeComposer);
     });
 
     it('has type extension initializers', () => {
-      const typeComposer = InterfaceTypeComposer.create({
-        name: 'Foo',
-        fields: {
-          id: 'ID!',
-          name: 'String',
+      const typeComposer = InterfaceTypeComposer.create(
+        {
+          name: 'Foo',
+          fields: {
+            id: 'ID!',
+            name: 'String',
+          },
+          extensions: { tags: ['generated'] },
         },
-        extensions: { tags: ['generated'] },
-      });
+        sc
+      );
       expect(typeComposer.getExtensions()).toEqual({ tags: ['generated'] });
     });
 
     it('has field extension initializers', () => {
-      const typeComposer = InterfaceTypeComposer.create({
-        name: 'Foo',
-        fields: {
-          id: 'ID!',
-          name: {
-            type: 'String',
-            extensions: {
-              noFilter: true,
+      const typeComposer = InterfaceTypeComposer.create(
+        {
+          name: 'Foo',
+          fields: {
+            id: 'ID!',
+            name: {
+              type: 'String',
+              extensions: {
+                noFilter: true,
+              },
             },
           },
         },
-      });
+        sc
+      );
       expect(typeComposer.getFieldExtensions('name')).toEqual({
         noFilter: true,
       });
@@ -177,77 +213,101 @@ describe('Extensions', () => {
 
   describe('EnumTypeComposer', () => {
     it('has type Extensions methods', () => {
-      const typeComposer = EnumTypeComposer.create({
-        name: 'Foo',
-        values: {
-          FOO: { value: 'FOO' },
-          BAR: { value: 'BAR' },
+      const typeComposer = EnumTypeComposer.create(
+        {
+          name: 'Foo',
+          values: {
+            FOO: { value: 'FOO' },
+            BAR: { value: 'BAR' },
+          },
         },
-      });
+        sc
+      );
       testTypeExtensions(typeComposer);
     });
 
     it('has type extension initializers', () => {
-      const typeComposer = EnumTypeComposer.create({
-        name: 'Foo',
-        values: {
-          FOO: { value: 'FOO' },
-          BAR: { value: 'BAR' },
+      const typeComposer = EnumTypeComposer.create(
+        {
+          name: 'Foo',
+          values: {
+            FOO: { value: 'FOO' },
+            BAR: { value: 'BAR' },
+          },
+          extensions: { tags: ['generated'] },
         },
-        extensions: { tags: ['generated'] },
-      });
+        sc
+      );
       expect(typeComposer.getExtensions()).toEqual({ tags: ['generated'] });
     });
   });
 
   describe('UnionTypeComposer', () => {
     it('has type Extensions methods', () => {
-      const foo = TypeComposer.create({
-        name: 'Foo',
-        fields: {
-          id: 'ID!',
-          name: 'String',
+      const foo = TypeComposer.create(
+        {
+          name: 'Foo',
+          fields: {
+            id: 'ID!',
+            name: 'String',
+          },
         },
-      });
-      const typeComposer = UnionTypeComposer.create({
-        name: 'FooUnion',
-        types: [foo],
-      });
+        sc
+      );
+      const typeComposer = UnionTypeComposer.create(
+        {
+          name: 'FooUnion',
+          types: [foo],
+        },
+        sc
+      );
       testTypeExtensions(typeComposer);
     });
 
     it('has type extension initializers', () => {
-      const foo = TypeComposer.create({
-        name: 'Foo',
-        fields: {
-          id: 'ID!',
-          name: 'String',
+      const foo = TypeComposer.create(
+        {
+          name: 'Foo',
+          fields: {
+            id: 'ID!',
+            name: 'String',
+          },
         },
-      });
-      const typeComposer = UnionTypeComposer.create({
-        name: 'FooUnion',
-        types: [foo],
-        extensions: { tags: ['generated'] },
-      });
+        sc
+      );
+      const typeComposer = UnionTypeComposer.create(
+        {
+          name: 'FooUnion',
+          types: [foo],
+          extensions: { tags: ['generated'] },
+        },
+        sc
+      );
       expect(typeComposer.getExtensions()).toEqual({ tags: ['generated'] });
     });
   });
 
   describe('ScalarTypeComposer', () => {
     it('has type Extensions methods', () => {
-      const typeComposer = ScalarTypeComposer.create({
-        name: 'Foo',
-        serialize() {},
-      });
+      const typeComposer = ScalarTypeComposer.create(
+        {
+          name: 'Foo',
+          serialize() {},
+        },
+        sc
+      );
       testTypeExtensions(typeComposer);
     });
 
     it('has type extension initializers', () => {
-      const typeComposer = ScalarTypeComposer.create({
-        name: 'Foo',
-        serialize() {},
-        extensions: { tags: ['generated'] },
-      });
+      const typeComposer = ScalarTypeComposer.create(
+        {
+          name: 'Foo',
+          serialize: () => {},
+          extensions: { tags: ['generated'] },
+        },
+        sc
+      );
       expect(typeComposer.getExtensions()).toEqual({ tags: ['generated'] });
     });
   });

--- a/src/__tests__/Extensions-test.js
+++ b/src/__tests__/Extensions-test.js
@@ -5,7 +5,7 @@ import { EnumTypeComposer } from '../EnumTypeComposer';
 import { InputTypeComposer } from '../InputTypeComposer';
 import { InterfaceTypeComposer } from '../InterfaceTypeComposer';
 import { ScalarTypeComposer } from '../ScalarTypeComposer';
-import { TypeComposer } from '../TypeComposer';
+import { ObjectTypeComposer } from '../ObjectTypeComposer';
 import { UnionTypeComposer } from '../UnionTypeComposer';
 
 beforeEach(() => {
@@ -13,9 +13,9 @@ beforeEach(() => {
 });
 
 describe('Extensions', () => {
-  describe('TypeComposer', () => {
+  describe('ObjectTypeComposer', () => {
     it('has type Extensions methods', () => {
-      const typeComposer = TypeComposer.create(
+      const tc = ObjectTypeComposer.create(
         {
           name: 'Foo',
           fields: {
@@ -25,11 +25,11 @@ describe('Extensions', () => {
         },
         sc
       );
-      testTypeExtensions(typeComposer);
+      testTypeExtensions(tc);
     });
 
     it('has field Extensions methods', () => {
-      const typeComposer = TypeComposer.create(
+      const tc = ObjectTypeComposer.create(
         {
           name: 'Foo',
           fields: {
@@ -39,11 +39,11 @@ describe('Extensions', () => {
         },
         sc
       );
-      testFieldExtensions(typeComposer);
+      testFieldExtensions(tc);
     });
 
     it('has type extension initializers', () => {
-      const typeComposer = TypeComposer.create(
+      const tc = ObjectTypeComposer.create(
         {
           name: 'Foo',
           fields: {
@@ -54,11 +54,11 @@ describe('Extensions', () => {
         },
         sc
       );
-      expect(typeComposer.getExtensions()).toEqual({ tags: ['generated'] });
+      expect(tc.getExtensions()).toEqual({ tags: ['generated'] });
     });
 
     it('has field extension initializers', () => {
-      const typeComposer = TypeComposer.create(
+      const tc = ObjectTypeComposer.create(
         {
           name: 'Foo',
           fields: {
@@ -73,7 +73,7 @@ describe('Extensions', () => {
         },
         sc
       );
-      expect(typeComposer.getFieldExtensions('name')).toEqual({
+      expect(tc.getFieldExtensions('name')).toEqual({
         noFilter: true,
       });
     });
@@ -81,7 +81,7 @@ describe('Extensions', () => {
 
   describe('InputTypeComposer', () => {
     it('has type Extensions methods', () => {
-      const typeComposer = InputTypeComposer.create(
+      const tc = InputTypeComposer.create(
         {
           name: 'Foo',
           fields: {
@@ -91,11 +91,11 @@ describe('Extensions', () => {
         },
         sc
       );
-      testTypeExtensions(typeComposer);
+      testTypeExtensions(tc);
     });
 
     it('has field Extensions methods', () => {
-      const typeComposer = InputTypeComposer.create(
+      const tc = InputTypeComposer.create(
         {
           name: 'Foo',
           fields: {
@@ -105,11 +105,11 @@ describe('Extensions', () => {
         },
         sc
       );
-      testFieldExtensions(typeComposer);
+      testFieldExtensions(tc);
     });
 
     it('has type extension initializers', () => {
-      const typeComposer = InputTypeComposer.create(
+      const tc = InputTypeComposer.create(
         {
           name: 'Foo',
           fields: {
@@ -120,11 +120,11 @@ describe('Extensions', () => {
         },
         sc
       );
-      expect(typeComposer.getExtensions()).toEqual({ tags: ['generated'] });
+      expect(tc.getExtensions()).toEqual({ tags: ['generated'] });
     });
 
     it('has field extension initializers', () => {
-      const typeComposer = InputTypeComposer.create(
+      const tc = InputTypeComposer.create(
         {
           name: 'Foo',
           fields: {
@@ -139,7 +139,7 @@ describe('Extensions', () => {
         },
         sc
       );
-      expect(typeComposer.getFieldExtensions('name')).toEqual({
+      expect(tc.getFieldExtensions('name')).toEqual({
         noFilter: true,
       });
     });
@@ -147,7 +147,7 @@ describe('Extensions', () => {
 
   describe('InterfaceTypeComposer', () => {
     it('has type Extensions methods', () => {
-      const typeComposer = InterfaceTypeComposer.create(
+      const tc = InterfaceTypeComposer.create(
         {
           name: 'Foo',
           fields: {
@@ -157,11 +157,11 @@ describe('Extensions', () => {
         },
         sc
       );
-      testTypeExtensions(typeComposer);
+      testTypeExtensions(tc);
     });
 
     it('has field Extensions methods', () => {
-      const typeComposer = InterfaceTypeComposer.create(
+      const tc = InterfaceTypeComposer.create(
         {
           name: 'Foo',
           fields: {
@@ -171,11 +171,11 @@ describe('Extensions', () => {
         },
         sc
       );
-      testFieldExtensions(typeComposer);
+      testFieldExtensions(tc);
     });
 
     it('has type extension initializers', () => {
-      const typeComposer = InterfaceTypeComposer.create(
+      const tc = InterfaceTypeComposer.create(
         {
           name: 'Foo',
           fields: {
@@ -186,11 +186,11 @@ describe('Extensions', () => {
         },
         sc
       );
-      expect(typeComposer.getExtensions()).toEqual({ tags: ['generated'] });
+      expect(tc.getExtensions()).toEqual({ tags: ['generated'] });
     });
 
     it('has field extension initializers', () => {
-      const typeComposer = InterfaceTypeComposer.create(
+      const tc = InterfaceTypeComposer.create(
         {
           name: 'Foo',
           fields: {
@@ -205,7 +205,7 @@ describe('Extensions', () => {
         },
         sc
       );
-      expect(typeComposer.getFieldExtensions('name')).toEqual({
+      expect(tc.getFieldExtensions('name')).toEqual({
         noFilter: true,
       });
     });
@@ -213,7 +213,7 @@ describe('Extensions', () => {
 
   describe('EnumTypeComposer', () => {
     it('has type Extensions methods', () => {
-      const typeComposer = EnumTypeComposer.create(
+      const tc = EnumTypeComposer.create(
         {
           name: 'Foo',
           values: {
@@ -223,11 +223,11 @@ describe('Extensions', () => {
         },
         sc
       );
-      testTypeExtensions(typeComposer);
+      testTypeExtensions(tc);
     });
 
     it('has type extension initializers', () => {
-      const typeComposer = EnumTypeComposer.create(
+      const tc = EnumTypeComposer.create(
         {
           name: 'Foo',
           values: {
@@ -238,13 +238,13 @@ describe('Extensions', () => {
         },
         sc
       );
-      expect(typeComposer.getExtensions()).toEqual({ tags: ['generated'] });
+      expect(tc.getExtensions()).toEqual({ tags: ['generated'] });
     });
   });
 
   describe('UnionTypeComposer', () => {
     it('has type Extensions methods', () => {
-      const foo = TypeComposer.create(
+      const foo = ObjectTypeComposer.create(
         {
           name: 'Foo',
           fields: {
@@ -254,18 +254,18 @@ describe('Extensions', () => {
         },
         sc
       );
-      const typeComposer = UnionTypeComposer.create(
+      const tc = UnionTypeComposer.create(
         {
           name: 'FooUnion',
           types: [foo],
         },
         sc
       );
-      testTypeExtensions(typeComposer);
+      testTypeExtensions(tc);
     });
 
     it('has type extension initializers', () => {
-      const foo = TypeComposer.create(
+      const foo = ObjectTypeComposer.create(
         {
           name: 'Foo',
           fields: {
@@ -275,7 +275,7 @@ describe('Extensions', () => {
         },
         sc
       );
-      const typeComposer = UnionTypeComposer.create(
+      const tc = UnionTypeComposer.create(
         {
           name: 'FooUnion',
           types: [foo],
@@ -283,24 +283,24 @@ describe('Extensions', () => {
         },
         sc
       );
-      expect(typeComposer.getExtensions()).toEqual({ tags: ['generated'] });
+      expect(tc.getExtensions()).toEqual({ tags: ['generated'] });
     });
   });
 
   describe('ScalarTypeComposer', () => {
     it('has type Extensions methods', () => {
-      const typeComposer = ScalarTypeComposer.create(
+      const tc = ScalarTypeComposer.create(
         {
           name: 'Foo',
           serialize() {},
         },
         sc
       );
-      testTypeExtensions(typeComposer);
+      testTypeExtensions(tc);
     });
 
     it('has type extension initializers', () => {
-      const typeComposer = ScalarTypeComposer.create(
+      const tc = ScalarTypeComposer.create(
         {
           name: 'Foo',
           serialize: () => {},
@@ -308,7 +308,7 @@ describe('Extensions', () => {
         },
         sc
       );
-      expect(typeComposer.getExtensions()).toEqual({ tags: ['generated'] });
+      expect(tc.getExtensions()).toEqual({ tags: ['generated'] });
     });
   });
 

--- a/src/__tests__/InputTypeComposer-test.js
+++ b/src/__tests__/InputTypeComposer-test.js
@@ -18,7 +18,7 @@ beforeEach(() => {
 
 describe('InputTypeComposer', () => {
   let objectType: GraphQLInputObjectType;
-  let itc: InputTypeComposer;
+  let itc: InputTypeComposer<any>;
 
   beforeEach(() => {
     objectType = new GraphQLInputObjectType({

--- a/src/__tests__/InputTypeComposer-test.js
+++ b/src/__tests__/InputTypeComposer-test.js
@@ -8,7 +8,8 @@ import {
   GraphQLInt,
   GraphQLBoolean,
 } from '../graphql';
-import { InputTypeComposer, schemaComposer } from '..';
+import { schemaComposer } from '..';
+import { InputTypeComposer } from '../InputTypeComposer';
 import { graphqlVersion } from '../utils/graphqlVersion';
 
 beforeEach(() => {
@@ -28,7 +29,7 @@ describe('InputTypeComposer', () => {
         input2: { type: GraphQLString },
       },
     });
-    itc = new InputTypeComposer(objectType);
+    itc = new InputTypeComposer(objectType, schemaComposer);
   });
 
   describe('field manipulation methods', () => {
@@ -145,12 +146,12 @@ describe('InputTypeComposer', () => {
           input3: 'String',
         },
       };
-      const itc1 = InputTypeComposer.create(cfg);
+      const itc1 = schemaComposer.createInputTC(cfg);
       itc1.removeOtherFields('input1');
       expect(itc1.getFieldNames()).toEqual(expect.arrayContaining(['input1']));
       expect(itc1.getFieldNames()).not.toEqual(expect.arrayContaining(['input2', 'input3']));
 
-      const itc2 = InputTypeComposer.create(cfg);
+      const itc2 = schemaComposer.createInputTC(cfg);
       itc2.removeOtherFields(['input1', 'input2']);
       expect(itc2.getFieldNames()).toEqual(expect.arrayContaining(['input1', 'input2']));
       expect(itc2.getFieldNames()).not.toEqual(expect.arrayContaining(['input3']));
@@ -158,7 +159,7 @@ describe('InputTypeComposer', () => {
 
     describe('reorderFields()', () => {
       it('should change fields order', () => {
-        const itcOrder = InputTypeComposer.create({
+        const itcOrder = schemaComposer.createInputTC({
           name: 'Type',
           fields: { f1: 'Int', f2: 'Int', f3: 'Int ' },
         });
@@ -168,7 +169,7 @@ describe('InputTypeComposer', () => {
       });
 
       it('should append not listed fields', () => {
-        const itcOrder = InputTypeComposer.create({
+        const itcOrder = schemaComposer.createInputTC({
           name: 'Type',
           fields: { f1: 'Int', f2: 'Int', f3: 'Int ' },
         });
@@ -178,7 +179,7 @@ describe('InputTypeComposer', () => {
       });
 
       it('should skip non existed fields', () => {
-        const itcOrder = InputTypeComposer.create({
+        const itcOrder = schemaComposer.createInputTC({
           name: 'Type',
           fields: { f1: 'Int', f2: 'Int', f3: 'Int ' },
         });
@@ -318,14 +319,14 @@ describe('InputTypeComposer', () => {
 
   describe('static method create()', () => {
     it('should create ITC by typeName as a string', () => {
-      const itc1 = InputTypeComposer.create('TypeStub');
+      const itc1 = schemaComposer.createInputTC('TypeStub');
       expect(itc1).toBeInstanceOf(InputTypeComposer);
       expect(itc1.getType()).toBeInstanceOf(GraphQLInputObjectType);
       expect(itc1.getFields()).toEqual({});
     });
 
     it('should create ITC by type template string', () => {
-      const itc1 = InputTypeComposer.create(
+      const itc1 = schemaComposer.createInputTC(
         `
         input TestTypeTplInput {
           f1: String @default(value: "new")
@@ -343,7 +344,7 @@ describe('InputTypeComposer', () => {
     });
 
     it('should create ITC by GraphQLObjectTypeConfig', () => {
-      const itc1 = InputTypeComposer.create({
+      const itc1 = schemaComposer.createInputTC({
         name: 'TestTypeInput',
         fields: {
           f1: {
@@ -359,7 +360,7 @@ describe('InputTypeComposer', () => {
     });
 
     it('should create ITC by GraphQLObjectTypeConfig with fields as Thunk', () => {
-      const itc1 = InputTypeComposer.create({
+      const itc1 = schemaComposer.createInputTC({
         name: 'TestTypeInput',
         fields: (): any => ({
           f1: {
@@ -383,14 +384,14 @@ describe('InputTypeComposer', () => {
           },
         },
       });
-      const itc1 = InputTypeComposer.create(objType);
+      const itc1 = schemaComposer.createInputTC(objType);
       expect(itc1).toBeInstanceOf(InputTypeComposer);
       expect(itc1.getType()).toBe(objType);
       expect(itc1.getFieldType('f1')).toBe(GraphQLString);
     });
 
     it('should create type and store it in schemaComposer', () => {
-      const SomeUserITC = InputTypeComposer.create('SomeUserInput');
+      const SomeUserITC = schemaComposer.createInputTC('SomeUserInput');
       expect(schemaComposer.getITC('SomeUserInput')).toBe(SomeUserITC);
     });
 
@@ -409,14 +410,15 @@ describe('InputTypeComposer', () => {
             type: GraphQLString,
           },
         },
-      })
+      }),
+      schemaComposer
     );
 
     expect(itc1.get('field1')).toBe(GraphQLString);
   });
 
   it('should have chainable methods', () => {
-    const itc1 = InputTypeComposer.create('InputType');
+    const itc1 = schemaComposer.createInputTC('InputType');
     expect(itc1.setFields({})).toBe(itc1);
     expect(itc1.setField('f1', 'String')).toBe(itc1);
     expect(itc1.extendField('f1', {})).toBe(itc1);
@@ -431,12 +433,12 @@ describe('InputTypeComposer', () => {
   });
 
   describe('getFieldTC()', () => {
-    const myITC = InputTypeComposer.create('MyCustomInputType');
+    const myITC = schemaComposer.createInputTC('MyCustomInputType');
     myITC.addFields({
       scalar: 'String',
       list: '[Int]',
-      obj: InputTypeComposer.create(`input ICustomObjInputType { name: String }`),
-      objArr: [InputTypeComposer.create(`input ICustomObjInputType2 { name: String }`)],
+      obj: schemaComposer.createInputTC(`input ICustomObjInputType { name: String }`),
+      objArr: [schemaComposer.createInputTC(`input ICustomObjInputType2 { name: String }`)],
     });
 
     it('should return InputTypeComposer for object field', () => {

--- a/src/__tests__/InterfaceTypeComposer-test.js
+++ b/src/__tests__/InterfaceTypeComposer-test.js
@@ -649,8 +649,8 @@ describe('InterfaceTypeComposer', () => {
 
       it('integration test', async () => {
         const iftc1 = schemaComposer.createInterfaceTC(`interface F { f: Int }`);
-        const aTC = schemaComposer.createTC('type A implements F { a: Int, f: Int }');
-        const bTC = schemaComposer.createTC('type B implements F { b: Int, f: Int }');
+        const aTC = schemaComposer.createObjectTC('type A implements F { a: Int, f: Int }');
+        const bTC = schemaComposer.createObjectTC('type B implements F { b: Int, f: Int }');
         const resolveType = value => {
           if (value) {
             if (value.a) return 'A';

--- a/src/__tests__/InterfaceTypeComposer-test.js
+++ b/src/__tests__/InterfaceTypeComposer-test.js
@@ -14,7 +14,7 @@ import {
 import { schemaComposer } from '..';
 import { InterfaceTypeComposer } from '../InterfaceTypeComposer';
 import { InputTypeComposer } from '../InputTypeComposer';
-// , InputTypeComposer, TypeComposer
+// , InputTypeComposer, ObjectTypeComposer
 import { graphqlVersion } from '../utils/graphqlVersion';
 
 beforeEach(() => {

--- a/src/__tests__/ObjectTypeComposer-test.js
+++ b/src/__tests__/ObjectTypeComposer-test.js
@@ -971,7 +971,7 @@ describe('ObjectTypeComposer', () => {
 
   describe('check isTypeOf methods', () => {
     it('check methods setIstypeOf() getIstypeOf()', () => {
-      const tc1 = schemaComposer.createTC('type A { f: Int }');
+      const tc1 = schemaComposer.createObjectTC('type A { f: Int }');
       expect(tc1.getIsTypeOf()).toBeUndefined();
       const isTypeOf = () => true;
       tc1.setIsTypeOf(isTypeOf);
@@ -979,11 +979,11 @@ describe('ObjectTypeComposer', () => {
     });
 
     it('integration test', async () => {
-      const tc1 = schemaComposer.createTC('type A { a: Int }');
+      const tc1 = schemaComposer.createObjectTC('type A { a: Int }');
       tc1.setIsTypeOf(source => {
         return source && source.kind === 'A';
       });
-      const tc2 = schemaComposer.createTC('type B { b: Int }');
+      const tc2 = schemaComposer.createObjectTC('type B { b: Int }');
       tc2.setIsTypeOf(source => {
         return source && source.kind === 'B';
       });

--- a/src/__tests__/ObjectTypeComposer-test.js
+++ b/src/__tests__/ObjectTypeComposer-test.js
@@ -14,7 +14,7 @@ import {
 } from '../graphql';
 import { schemaComposer } from '..';
 import { Resolver } from '../Resolver';
-import { TypeComposer } from '../TypeComposer';
+import { ObjectTypeComposer } from '../ObjectTypeComposer';
 import { InputTypeComposer } from '../InputTypeComposer';
 import { InterfaceTypeComposer } from '../InterfaceTypeComposer';
 import { graphqlVersion } from '../utils/graphqlVersion';
@@ -23,9 +23,9 @@ beforeEach(() => {
   schemaComposer.clear();
 });
 
-describe('TypeComposer', () => {
+describe('ObjectTypeComposer', () => {
   let objectType: GraphQLObjectType;
-  let tc: TypeComposer<any, any>;
+  let tc: ObjectTypeComposer<any, any>;
 
   beforeEach(() => {
     objectType = new GraphQLObjectType({
@@ -35,7 +35,7 @@ describe('TypeComposer', () => {
         field2: { type: GraphQLString },
       },
     });
-    tc = new TypeComposer(objectType, schemaComposer);
+    tc = new ObjectTypeComposer(objectType, schemaComposer);
   });
 
   describe('fields manipulation', () => {
@@ -43,7 +43,7 @@ describe('TypeComposer', () => {
       const fieldNames = Object.keys(tc.getFields());
       expect(fieldNames).toEqual(expect.arrayContaining(['field1', 'field2']));
 
-      const tc2 = TypeComposer.create('SomeType', schemaComposer);
+      const tc2 = ObjectTypeComposer.create('SomeType', schemaComposer);
       expect(tc2.getFields()).toEqual({});
     });
 
@@ -420,14 +420,14 @@ describe('TypeComposer', () => {
 
   describe('create() [static method]', () => {
     it('should create TC by typeName as a string', () => {
-      const myTC = TypeComposer.create('TypeStub', schemaComposer);
-      expect(myTC).toBeInstanceOf(TypeComposer);
+      const myTC = ObjectTypeComposer.create('TypeStub', schemaComposer);
+      expect(myTC).toBeInstanceOf(ObjectTypeComposer);
       expect(myTC.getType()).toBeInstanceOf(GraphQLObjectType);
       expect(myTC.getFields()).toEqual({});
     });
 
     it('should create TC by type template string', () => {
-      const myTC = TypeComposer.create(
+      const myTC = ObjectTypeComposer.create(
         `
         type TestTypeTpl {
           f1: String
@@ -437,7 +437,7 @@ describe('TypeComposer', () => {
       `,
         schemaComposer
       );
-      expect(myTC).toBeInstanceOf(TypeComposer);
+      expect(myTC).toBeInstanceOf(ObjectTypeComposer);
       expect(myTC.getTypeName()).toBe('TestTypeTpl');
       expect(myTC.getFieldType('f1')).toBe(GraphQLString);
       expect(myTC.getFieldType('f2')).toBeInstanceOf(GraphQLNonNull);
@@ -445,7 +445,7 @@ describe('TypeComposer', () => {
     });
 
     it('should create TC by GraphQLObjectTypeConfig', () => {
-      const myTC = TypeComposer.create(
+      const myTC = ObjectTypeComposer.create(
         {
           name: 'TestType',
           fields: {
@@ -457,14 +457,14 @@ describe('TypeComposer', () => {
         },
         schemaComposer
       );
-      expect(myTC).toBeInstanceOf(TypeComposer);
+      expect(myTC).toBeInstanceOf(ObjectTypeComposer);
       expect(myTC.getFieldType('f1')).toBe(GraphQLString);
       expect(myTC.getFieldType('f2')).toBeInstanceOf(GraphQLNonNull);
       expect((myTC.getFieldType('f2'): any).ofType).toBe(GraphQLInt);
     });
 
     it('should create TC by GraphQLObjectTypeConfig with fields as Thunk', () => {
-      const myTC = TypeComposer.create(
+      const myTC = ObjectTypeComposer.create(
         {
           name: 'TestType',
           fields: (): any => ({
@@ -476,7 +476,7 @@ describe('TypeComposer', () => {
         },
         schemaComposer
       );
-      expect(myTC).toBeInstanceOf(TypeComposer);
+      expect(myTC).toBeInstanceOf(ObjectTypeComposer);
       expect(myTC.getFieldType('f1')).toBe(GraphQLString);
       expect(myTC.getFieldType('f2')).toBeInstanceOf(GraphQLNonNull);
       expect((myTC.getFieldType('f2'): any).ofType).toBe(GraphQLInt);
@@ -491,30 +491,30 @@ describe('TypeComposer', () => {
           },
         },
       });
-      const myTC = TypeComposer.create(objType, schemaComposer);
-      expect(myTC).toBeInstanceOf(TypeComposer);
+      const myTC = ObjectTypeComposer.create(objType, schemaComposer);
+      expect(myTC).toBeInstanceOf(ObjectTypeComposer);
       expect(myTC.getType()).toBe(objType);
       expect(myTC.getFieldType('f1')).toBe(GraphQLString);
     });
 
     it('should create type and store it in schemaComposer', () => {
-      const SomeUserTC = TypeComposer.create('SomeUser', schemaComposer);
-      expect(schemaComposer.getTC('SomeUser')).toBe(SomeUserTC);
+      const SomeUserTC = ObjectTypeComposer.create('SomeUser', schemaComposer);
+      expect(schemaComposer.getOTC('SomeUser')).toBe(SomeUserTC);
     });
 
     it('should create type and NOTE store root types in schemaComposer', () => {
-      TypeComposer.create('Query', schemaComposer);
+      ObjectTypeComposer.create('Query', schemaComposer);
       expect(schemaComposer.has('Query')).toBeFalsy();
 
-      TypeComposer.create('Mutation', schemaComposer);
+      ObjectTypeComposer.create('Mutation', schemaComposer);
       expect(schemaComposer.has('Query')).toBeFalsy();
 
-      TypeComposer.create('Subscription', schemaComposer);
+      ObjectTypeComposer.create('Subscription', schemaComposer);
       expect(schemaComposer.has('Query')).toBeFalsy();
     });
 
     it('createTemp() should not store type in schemaComposer', () => {
-      TypeComposer.createTemp('SomeUser');
+      ObjectTypeComposer.createTemp('SomeUser');
       expect(schemaComposer.has('SomeUser')).toBeFalsy();
     });
   });
@@ -538,7 +538,7 @@ describe('TypeComposer', () => {
 
   describe('get()', () => {
     it('should return type by path', () => {
-      const myTC = new TypeComposer(
+      const myTC = new ObjectTypeComposer(
         new GraphQLObjectType({
           name: 'Readable',
           fields: {
@@ -709,11 +709,11 @@ describe('TypeComposer', () => {
   });
 
   describe('addRelation()', () => {
-    let UserTC: TypeComposer<any, any>;
-    let ArticleTC: TypeComposer<any, any>;
+    let UserTC: ObjectTypeComposer<any, any>;
+    let ArticleTC: ObjectTypeComposer<any, any>;
 
     beforeEach(() => {
-      UserTC = TypeComposer.create(
+      UserTC = ObjectTypeComposer.create(
         `
         type User {
           id: Int,
@@ -728,7 +728,7 @@ describe('TypeComposer', () => {
         resolve: () => null,
       });
 
-      ArticleTC = TypeComposer.create(
+      ArticleTC = ObjectTypeComposer.create(
         `
         type Article {
           id: Int,
@@ -884,10 +884,10 @@ describe('TypeComposer', () => {
   });
 
   describe('deprecateFields()', () => {
-    let tc1: TypeComposer<any, any>;
+    let tc1: ObjectTypeComposer<any, any>;
 
     beforeEach(() => {
-      tc1 = TypeComposer.create(
+      tc1 = ObjectTypeComposer.create(
         {
           name: 'MyType',
           fields: {
@@ -940,20 +940,20 @@ describe('TypeComposer', () => {
   });
 
   describe('getFieldTC()', () => {
-    const myTC = TypeComposer.create('MyCustomType', schemaComposer);
+    const myTC = ObjectTypeComposer.create('MyCustomType', schemaComposer);
     myTC.addFields({
       scalar: 'String',
       list: '[Int]',
-      obj: TypeComposer.create(`type MyCustomObjType { name: String }`, schemaComposer),
-      objArr: [TypeComposer.create(`type MyCustomObjType2 { name: String }`, schemaComposer)],
+      obj: ObjectTypeComposer.create(`type MyCustomObjType { name: String }`, schemaComposer),
+      objArr: [ObjectTypeComposer.create(`type MyCustomObjType2 { name: String }`, schemaComposer)],
     });
 
-    it('should return TypeComposer for object field', () => {
+    it('should return ObjectTypeComposer for object field', () => {
       const objTC = myTC.getFieldTC('obj');
       expect(objTC.getTypeName()).toBe('MyCustomObjType');
     });
 
-    it('should return TypeComposer for wrapped object field', () => {
+    it('should return ObjectTypeComposer for wrapped object field', () => {
       const objTC = myTC.getFieldTC('objArr');
       expect(objTC.getTypeName()).toBe('MyCustomObjType2');
     });

--- a/src/__tests__/Resolver-test.js
+++ b/src/__tests__/Resolver-test.js
@@ -534,7 +534,7 @@ describe('Resolver', () => {
       schemaComposer
     );
 
-    schemaComposer.rootQuery().addRelation('resolveUser', {
+    schemaComposer.Query.addRelation('resolveUser', {
       resolver: () => myResolver,
       projection: { _id: true },
     });

--- a/src/__tests__/Resolver-test.js
+++ b/src/__tests__/Resolver-test.js
@@ -578,10 +578,12 @@ describe('Resolver', () => {
           filterTypeNameFallback: 'FilterOtherUniqueNameInput',
         });
 
-      await newResolver.resolve({
-        args: { filter: { age: 15, isActive: false } },
-        someKey: 16,
-      });
+      await newResolver.resolve(
+        ({
+          args: { filter: { age: 15, isActive: false } },
+          someKey: 16,
+        }: any)
+      );
 
       expect((rpSnap: any).rawQuery).toEqual({
         age: { $gt: 15 },
@@ -717,7 +719,7 @@ describe('Resolver', () => {
         sortTypeNameFallback: 'SortEnum',
       });
 
-      newResolver.resolve({ args: { sort: 'PRICE_ASC' }, query });
+      newResolver.resolve(({ args: { sort: 'PRICE_ASC' }, query }: any));
       expect((rpSnap: any).args.sort).toEqual({ price: 1 });
       expect(whereSnap).toEqual({ price: { $gt: 0 } });
     });
@@ -841,10 +843,12 @@ describe('Resolver', () => {
           displayName: 'User.find()',
           resolve: () => {},
         });
-        r1.debugParams('args, args.sort, source.name').resolve({
-          source: { id: 1, name: 'Pavel' },
-          args: { limit: 1, sort: 'id' },
-        });
+        r1.debugParams('args, args.sort, source.name').resolve(
+          ({
+            source: { id: 1, name: 'Pavel' },
+            args: { limit: 1, sort: 'id' },
+          }: any)
+        );
 
         expect(console.log.mock.calls[0]).toEqual(['ResolveParams for User.find():']);
         expect(console.dir.mock.calls[0]).toEqual([
@@ -918,10 +922,12 @@ describe('Resolver', () => {
             params: 'args.sort source.name',
             payload: 'b, c.3',
           })
-          .resolve({
-            source: { id: 1, name: 'Pavel' },
-            args: { limit: 1, sort: 'id' },
-          });
+          .resolve(
+            ({
+              source: { id: 1, name: 'Pavel' },
+              args: { limit: 1, sort: 'id' },
+            }: any)
+          );
 
         expect(console.time.mock.calls[0]).toEqual(['Execution time for User.find()']);
         expect(console.timeEnd.mock.calls[0]).toEqual(['Execution time for User.find()']);
@@ -1055,7 +1061,7 @@ describe('Resolver', () => {
         return res;
       };
 
-      const res = await r.withMiddlewares([mw1, mw2]).resolve({});
+      const res = await r.withMiddlewares([mw1, mw2]).resolve(({}: any));
       expect(res).toBe('users result');
       expect(log).toEqual(['m1.before', 'm2.before', 'call User.find()', 'm2.after', 'm1.after']);
     });

--- a/src/__tests__/Resolver-test.js
+++ b/src/__tests__/Resolver-test.js
@@ -14,9 +14,9 @@ import {
 } from '../graphql';
 import schemaComposer from '../__mocks__/schemaComposer';
 import { Resolver } from '../Resolver';
-import { TypeComposer } from '../TypeComposer';
+import { ObjectTypeComposer } from '../ObjectTypeComposer';
 import { InputTypeComposer } from '../InputTypeComposer';
-// import { Resolver, TypeComposer, InputTypeComposer, EnumTypeComposer } from '..';
+// import { Resolver, ObjectTypeComposer, InputTypeComposer, EnumTypeComposer } from '..';
 
 describe('Resolver', () => {
   let resolver: Resolver<any, any, any>;
@@ -91,7 +91,7 @@ describe('Resolver', () => {
       expect(type.name).toBe('SomeType');
     });
 
-    it('should accept TypeComposer for `type` option', () => {
+    it('should accept ObjectTypeComposer for `type` option', () => {
       const typeTC = schemaComposer.createObjectTC('type SomeType22 { test: String }');
       const myResolver = new Resolver(
         {
@@ -1042,7 +1042,7 @@ describe('Resolver', () => {
   });
 
   describe('getTypeComposer()', () => {
-    it('should return TypeComposer for GraphQLObjectType', () => {
+    it('should return ObjectTypeComposer for GraphQLObjectType', () => {
       const r = new Resolver(
         {
           name: 'find',
@@ -1053,7 +1053,7 @@ describe('Resolver', () => {
         schemaComposer
       );
       expect(r.getType()).toBeInstanceOf(GraphQLObjectType);
-      expect(r.getTypeComposer()).toBeInstanceOf(TypeComposer);
+      expect(r.getTypeComposer()).toBeInstanceOf(ObjectTypeComposer);
       expect(r.getTypeComposer().getTypeName()).toBe('MyOutputType');
     });
 
@@ -1074,7 +1074,7 @@ describe('Resolver', () => {
       const type: any = r.getType();
       expect(type).toBeInstanceOf(GraphQLNonNull);
       expect(type.ofType).toBeInstanceOf(GraphQLList);
-      expect(r.getTypeComposer()).toBeInstanceOf(TypeComposer);
+      expect(r.getTypeComposer()).toBeInstanceOf(ObjectTypeComposer);
       expect(r.getTypeComposer().getTypeName()).toBe('MyOutputType');
     });
 

--- a/src/__tests__/ScalarTypeComposer-test.js
+++ b/src/__tests__/ScalarTypeComposer-test.js
@@ -10,7 +10,7 @@ beforeEach(() => {
 
 describe('ScalarTypeComposer', () => {
   let scalarType: GraphQLScalarType;
-  let stc: ScalarTypeComposer;
+  let stc: ScalarTypeComposer<any>;
 
   beforeEach(() => {
     scalarType = new GraphQLScalarType({

--- a/src/__tests__/ScalarTypeComposer-test.js
+++ b/src/__tests__/ScalarTypeComposer-test.js
@@ -1,7 +1,8 @@
 /* @flow strict */
 
-import { ScalarTypeComposer, schemaComposer } from '..';
+import { schemaComposer } from '..';
 import { GraphQLList, GraphQLNonNull, GraphQLScalarType } from '../graphql';
+import { ScalarTypeComposer } from '../ScalarTypeComposer';
 
 beforeEach(() => {
   schemaComposer.clear();
@@ -17,21 +18,24 @@ describe('ScalarTypeComposer', () => {
       serialize: () => {},
     });
 
-    stc = new ScalarTypeComposer(scalarType);
+    stc = new ScalarTypeComposer(scalarType, schemaComposer);
   });
 
   describe('create() [static method]', () => {
     it('should create STC by type template string', () => {
-      const myTC = ScalarTypeComposer.create('scalar SDLScalar');
+      const myTC = ScalarTypeComposer.create('scalar SDLScalar', schemaComposer);
       expect(myTC).toBeInstanceOf(ScalarTypeComposer);
       expect(myTC.getTypeName()).toBe('SDLScalar');
     });
 
     it('should create STC by GraphQLScalarTypeConfig', () => {
-      const myTC = ScalarTypeComposer.create({
-        name: 'TestType',
-        serialize: () => {},
-      });
+      const myTC = ScalarTypeComposer.create(
+        {
+          name: 'TestType',
+          serialize: () => {},
+        },
+        schemaComposer
+      );
       expect(myTC).toBeInstanceOf(ScalarTypeComposer);
       expect(myTC.getTypeName()).toBe('TestType');
     });
@@ -41,18 +45,18 @@ describe('ScalarTypeComposer', () => {
         name: 'TestTypeObj',
         serialize: () => {},
       });
-      const myTC = ScalarTypeComposer.create(objType);
+      const myTC = ScalarTypeComposer.create(objType, schemaComposer);
       expect(myTC).toBeInstanceOf(ScalarTypeComposer);
       expect(myTC.getType()).toBe(objType);
     });
 
     it('should create STC from string', () => {
-      const myTC = ScalarTypeComposer.create('MySSS');
+      const myTC = ScalarTypeComposer.create('MySSS', schemaComposer);
       expect(myTC.getTypeName()).toEqual('MySSS');
     });
 
     it('should create type and store it in schemaComposer', () => {
-      const SomeUserSTC = ScalarTypeComposer.create('SomeUserScalar');
+      const SomeUserSTC = ScalarTypeComposer.create('SomeUserScalar', schemaComposer);
       expect(schemaComposer.getSTC('SomeUserScalar')).toBe(SomeUserSTC);
     });
 

--- a/src/__tests__/SchemaComposer-test.js
+++ b/src/__tests__/SchemaComposer-test.js
@@ -286,19 +286,19 @@ describe('SchemaComposer', () => {
   describe('root type getters', () => {
     it('Query', () => {
       const sc = new SchemaComposer();
-      expect(sc.Query).toBe(sc.rootQuery());
+      expect(sc.Query).toBe(sc.Query);
       expect(sc.Query.getTypeName()).toBe('Query');
     });
 
     it('Mutation', () => {
       const sc = new SchemaComposer();
-      expect(sc.Mutation).toBe(sc.rootMutation());
+      expect(sc.Mutation).toBe(sc.Mutation);
       expect(sc.Mutation.getTypeName()).toBe('Mutation');
     });
 
     it('Subscription', () => {
       const sc = new SchemaComposer();
-      expect(sc.Subscription).toBe(sc.rootSubscription());
+      expect(sc.Subscription).toBe(sc.Subscription);
       expect(sc.Subscription.getTypeName()).toBe('Subscription');
     });
   });
@@ -929,10 +929,6 @@ describe('SchemaComposer', () => {
       const tc2 = sc.createObjectTC(`type B { f: Int }`);
       expect(tc2).toBeInstanceOf(ObjectTypeComposer);
       expect(tc2.hasField('f')).toBeTruthy();
-
-      const tc3 = sc.createOutputTC(`type C { f: Int }`);
-      expect(tc3).toBeInstanceOf(ObjectTypeComposer);
-      expect(tc3.hasField('f')).toBeTruthy();
     });
 
     it('createInputTC()', () => {

--- a/src/__tests__/SchemaComposer-test.js
+++ b/src/__tests__/SchemaComposer-test.js
@@ -926,7 +926,7 @@ describe('SchemaComposer', () => {
       expect(tc).toBeInstanceOf(ObjectTypeComposer);
       expect(tc.hasField('f')).toBeTruthy();
 
-      const tc2 = sc.createTC(`type B { f: Int }`);
+      const tc2 = sc.createObjectTC(`type B { f: Int }`);
       expect(tc2).toBeInstanceOf(ObjectTypeComposer);
       expect(tc2.hasField('f')).toBeTruthy();
 

--- a/src/__tests__/SchemaComposer-test.js
+++ b/src/__tests__/SchemaComposer-test.js
@@ -1,7 +1,7 @@
 /* @flow strict */
 
 import { SchemaComposer } from '..';
-import { TypeComposer } from '../TypeComposer';
+import { ObjectTypeComposer } from '../ObjectTypeComposer';
 import { InputTypeComposer } from '../InputTypeComposer';
 import { ScalarTypeComposer } from '../ScalarTypeComposer';
 import { EnumTypeComposer } from '../EnumTypeComposer';
@@ -46,19 +46,19 @@ describe('SchemaComposer', () => {
     expect(sc.has('unexistedType')).toBe(false);
   });
 
-  describe('getOrCreateTC()', () => {
+  describe('getOrCreateOTC()', () => {
     it('should create TC if not exists', () => {
       const sc = new SchemaComposer();
-      const UserTC = sc.getOrCreateTC('User');
-      expect(UserTC).toBeInstanceOf(TypeComposer);
+      const UserTC = sc.getOrCreateOTC('User');
+      expect(UserTC).toBeInstanceOf(ObjectTypeComposer);
       expect(sc.has('User')).toBeTruthy();
-      expect(sc.hasInstance('User', TypeComposer)).toBeTruthy();
-      expect(sc.getTC('User')).toBe(UserTC);
+      expect(sc.hasInstance('User', ObjectTypeComposer)).toBeTruthy();
+      expect(sc.getOTC('User')).toBe(UserTC);
     });
 
     it('should create TC if not exists with onCreate', () => {
       const sc = new SchemaComposer();
-      const UserTC = sc.getOrCreateTC('User', tc => {
+      const UserTC = sc.getOrCreateOTC('User', tc => {
         tc.setDescription('User model');
       });
       expect(UserTC.getDescription()).toBe('User model');
@@ -66,10 +66,10 @@ describe('SchemaComposer', () => {
 
     it('should return already created TC without onCreate', () => {
       const sc = new SchemaComposer();
-      const UserTC = sc.getOrCreateTC('User', tc => {
+      const UserTC = sc.getOrCreateOTC('User', tc => {
         tc.setDescription('User model');
       });
-      const UserTC2 = sc.getOrCreateTC('User', tc => {
+      const UserTC2 = sc.getOrCreateOTC('User', tc => {
         tc.setDescription('updated description');
       });
       expect(UserTC).toBe(UserTC2);
@@ -250,10 +250,10 @@ describe('SchemaComposer', () => {
   describe('removeEmptyTypes()', () => {
     it('should remove fields with Types which have no fields', () => {
       const sc = new SchemaComposer();
-      const TypeWithoutFieldsTC = sc.getOrCreateTC('Stub');
+      const TypeWithoutFieldsTC = sc.getOrCreateOTC('Stub');
       TypeWithoutFieldsTC.setFields({});
 
-      const ViewerTC = sc.getOrCreateTC('Viewer');
+      const ViewerTC = sc.getOrCreateOTC('Viewer');
       ViewerTC.setFields({
         name: 'String',
         stub: TypeWithoutFieldsTC,
@@ -276,7 +276,7 @@ describe('SchemaComposer', () => {
 
     it('should not produce Maximum call stack size exceeded', () => {
       const sc = new SchemaComposer();
-      const UserTC = sc.getOrCreateTC('User');
+      const UserTC = sc.getOrCreateOTC('User');
       UserTC.setField('friend', UserTC);
 
       sc.removeEmptyTypes(UserTC);
@@ -319,18 +319,18 @@ describe('SchemaComposer', () => {
     expect(schema._typeMap.Me).toEqual(tc.getType());
   });
 
-  describe('getTC', () => {
-    it('should return TypeComposer', () => {
+  describe('getOTC', () => {
+    it('should return ObjectTypeComposer', () => {
       const sc = new SchemaComposer();
       sc.createObjectTC(`
           type Author {
             name: String
           }
         `);
-      expect(sc.getTC('Author')).toBeInstanceOf(TypeComposer);
+      expect(sc.getOTC('Author')).toBeInstanceOf(ObjectTypeComposer);
     });
 
-    it('should return GraphQLObjectType as TypeComposer', () => {
+    it('should return GraphQLObjectType as ObjectTypeComposer', () => {
       const sc = new SchemaComposer();
       sc.add(
         new GraphQLObjectType({
@@ -338,7 +338,7 @@ describe('SchemaComposer', () => {
           fields: { name: { type: GraphQLString } },
         })
       );
-      expect(sc.getTC('Author')).toBeInstanceOf(TypeComposer);
+      expect(sc.getOTC('Author')).toBeInstanceOf(ObjectTypeComposer);
     });
 
     it('should throw error for incorrect type', () => {
@@ -348,7 +348,9 @@ describe('SchemaComposer', () => {
           name: String
         }
       `);
-      expect(() => sc.getTC('Author')).toThrowError('Cannot find TypeComposer with name Author');
+      expect(() => sc.getOTC('Author')).toThrowError(
+        'Cannot find ObjectTypeComposer with name Author'
+      );
     });
   });
 
@@ -485,17 +487,17 @@ describe('SchemaComposer', () => {
   });
 
   describe('getAnyTC()', () => {
-    it('should return TypeComposer', () => {
+    it('should return ObjectTypeComposer', () => {
       const sc = new SchemaComposer();
       sc.createObjectTC(`type Object1 { name: String }`);
-      expect(sc.getAnyTC('Object1')).toBeInstanceOf(TypeComposer);
+      expect(sc.getAnyTC('Object1')).toBeInstanceOf(ObjectTypeComposer);
       sc.add(
         new GraphQLObjectType({
           name: 'Object2',
           fields: () => ({}),
         })
       );
-      expect(sc.getAnyTC('Object2')).toBeInstanceOf(TypeComposer);
+      expect(sc.getAnyTC('Object2')).toBeInstanceOf(ObjectTypeComposer);
     });
 
     it('should return InputTypeComposer', () => {
@@ -566,15 +568,15 @@ describe('SchemaComposer', () => {
   });
 
   describe('add()', () => {
-    it('should add TypeComposer', () => {
+    it('should add ObjectTypeComposer', () => {
       const sc = new SchemaComposer();
-      const tc = TypeComposer.createTemp('User');
+      const tc = ObjectTypeComposer.createTemp('User');
       const typeName = sc.add(tc);
       expect(typeName).toBe('User');
       expect(sc.get('User')).toBe(tc);
-      expect(sc.getTC('User')).toBe(tc);
+      expect(sc.getOTC('User')).toBe(tc);
       sc.add(`type Object { a: Int }`);
-      expect(sc.get('Object')).toBeInstanceOf(TypeComposer);
+      expect(sc.get('Object')).toBeInstanceOf(ObjectTypeComposer);
     });
 
     it('should add InputTypeComposer', () => {
@@ -646,10 +648,10 @@ describe('SchemaComposer', () => {
   });
 
   describe('addAsComposer()', () => {
-    it('should add TypeComposer', () => {
+    it('should add ObjectTypeComposer', () => {
       const sc = new SchemaComposer();
       sc.addAsComposer(`type Object1 { name: String }`);
-      sc.addAsComposer(TypeComposer.createTemp(`type Object2 { name: String }`));
+      sc.addAsComposer(ObjectTypeComposer.createTemp(`type Object2 { name: String }`));
       sc.addAsComposer(
         new GraphQLObjectType({
           name: 'Object3',
@@ -657,9 +659,9 @@ describe('SchemaComposer', () => {
         })
       );
 
-      expect(sc.get('Object1')).toBeInstanceOf(TypeComposer);
-      expect(sc.get('Object2')).toBeInstanceOf(TypeComposer);
-      expect(sc.get('Object3')).toBeInstanceOf(TypeComposer);
+      expect(sc.get('Object1')).toBeInstanceOf(ObjectTypeComposer);
+      expect(sc.get('Object2')).toBeInstanceOf(ObjectTypeComposer);
+      expect(sc.get('Object3')).toBeInstanceOf(ObjectTypeComposer);
     });
 
     it('should return InputTypeComposer', () => {
@@ -788,14 +790,14 @@ describe('SchemaComposer', () => {
 
       // Post type should be the same instance
       const Post = sc.get('Post');
-      const PostInAuthor = TypeComposer.createTemp((sc.get('Author'): any))
+      const PostInAuthor = ObjectTypeComposer.createTemp((sc.get('Author'): any))
         .getFieldTC('posts')
         .getType();
       expect(Post).toBe(PostInAuthor);
 
       // Author type should be the same instance
       const Author = sc.get('Author');
-      const AuthorInPost = TypeComposer.createTemp((sc.get('Post'): any))
+      const AuthorInPost = ObjectTypeComposer.createTemp((sc.get('Post'): any))
         .getFieldTC('author')
         .getType();
       expect(Author).toBe(AuthorInPost);
@@ -811,14 +813,14 @@ describe('SchemaComposer', () => {
           some(arg: Int): String
         }
       `);
-      expect(sc.getTC('Author').hasFieldArg('some', 'arg')).toBeTruthy();
+      expect(sc.getOTC('Author').hasFieldArg('some', 'arg')).toBeTruthy();
 
       sc.addTypeDefs(`
         type Author {
           name: String
         }
       `);
-      expect(sc.getTC('Author').hasFieldArg('some', 'arg')).toBeFalsy();
+      expect(sc.getOTC('Author').hasFieldArg('some', 'arg')).toBeFalsy();
     });
 
     it('should merge Root types', () => {
@@ -921,15 +923,15 @@ describe('SchemaComposer', () => {
     it('createObjectTC()', () => {
       const sc = new SchemaComposer();
       const tc = sc.createObjectTC(`type A { f: Int }`);
-      expect(tc).toBeInstanceOf(TypeComposer);
+      expect(tc).toBeInstanceOf(ObjectTypeComposer);
       expect(tc.hasField('f')).toBeTruthy();
 
       const tc2 = sc.createTC(`type B { f: Int }`);
-      expect(tc2).toBeInstanceOf(TypeComposer);
+      expect(tc2).toBeInstanceOf(ObjectTypeComposer);
       expect(tc2.hasField('f')).toBeTruthy();
 
       const tc3 = sc.createOutputTC(`type C { f: Int }`);
-      expect(tc3).toBeInstanceOf(TypeComposer);
+      expect(tc3).toBeInstanceOf(ObjectTypeComposer);
       expect(tc3.hasField('f')).toBeTruthy();
     });
 

--- a/src/__tests__/SchemaComposer-test.js
+++ b/src/__tests__/SchemaComposer-test.js
@@ -26,21 +26,21 @@ import {
 describe('SchemaComposer', () => {
   it('should implements `add` method', () => {
     const sc = new SchemaComposer();
-    const SomeTC = sc.TypeComposer.create({ name: 'validType' });
+    const SomeTC = sc.createObjectTC({ name: 'validType' });
     sc.add(SomeTC);
     expect(sc.get('validType')).toBe(SomeTC);
   });
 
   it('should implements `get` method', () => {
     const sc = new SchemaComposer();
-    const SomeTC = sc.TypeComposer.create({ name: 'validType' });
+    const SomeTC = sc.createObjectTC({ name: 'validType' });
     sc.add(SomeTC);
     expect(sc.get('validType')).toBe(SomeTC);
   });
 
   it('should implements `has` method`', () => {
     const sc = new SchemaComposer();
-    const SomeTC = sc.TypeComposer.create({ name: 'validType' });
+    const SomeTC = sc.createObjectTC({ name: 'validType' });
     sc.add(SomeTC);
     expect(sc.has('validType')).toBe(true);
     expect(sc.has('unexistedType')).toBe(false);
@@ -214,8 +214,8 @@ describe('SchemaComposer', () => {
     it('should accept additional types', () => {
       const sc = new SchemaComposer();
       sc.Query.addFields({ time: 'Int' });
-      const me1 = sc.TypeComposer.create('type Me1 { a: Int }').getType();
-      const me2 = sc.TypeComposer.create('type Me2 { a: Int }').getType();
+      const me1 = sc.createObjectTC('type Me1 { a: Int }').getType();
+      const me2 = sc.createObjectTC('type Me2 { a: Int }').getType();
       const schema = sc.buildSchema({ types: [me1, me1, me2] });
 
       expect(schema._typeMap.Me1).toEqual(me1);
@@ -305,7 +305,7 @@ describe('SchemaComposer', () => {
 
   describe('SchemaMustHaveType', () => {
     const sc = new SchemaComposer();
-    const tc = sc.TypeComposer.create(`type Me { name: String }`);
+    const tc = sc.createObjectTC(`type Me { name: String }`);
 
     sc.addSchemaMustHaveType(tc);
     expect(sc._schemaMustHaveTypes).toContain(tc);
@@ -322,7 +322,7 @@ describe('SchemaComposer', () => {
   describe('getTC', () => {
     it('should return TypeComposer', () => {
       const sc = new SchemaComposer();
-      sc.TypeComposer.create(`
+      sc.createObjectTC(`
           type Author {
             name: String
           }
@@ -343,7 +343,7 @@ describe('SchemaComposer', () => {
 
     it('should throw error for incorrect type', () => {
       const sc = new SchemaComposer();
-      sc.InputTypeComposer.create(`
+      sc.createInputTC(`
         input Author {
           name: String
         }
@@ -355,7 +355,7 @@ describe('SchemaComposer', () => {
   describe('getITC', () => {
     it('should return InputTypeComposer', () => {
       const sc = new SchemaComposer();
-      sc.InputTypeComposer.create(`
+      sc.createInputTC(`
           input Author {
             name: String
           }
@@ -376,7 +376,7 @@ describe('SchemaComposer', () => {
 
     it('should throw error for incorrect type', () => {
       const sc = new SchemaComposer();
-      sc.TypeComposer.create(`
+      sc.createObjectTC(`
         type Author {
           name: String
         }
@@ -390,7 +390,7 @@ describe('SchemaComposer', () => {
   describe('getSTC', () => {
     it('should return ScalarTypeComposer', () => {
       const sc = new SchemaComposer();
-      sc.ScalarTypeComposer.create(`scalar UInt`);
+      sc.createScalarTC(`scalar UInt`);
       expect(sc.getSTC('UInt')).toBeInstanceOf(ScalarTypeComposer);
     });
 
@@ -407,7 +407,7 @@ describe('SchemaComposer', () => {
 
     it('should throw error for incorrect type', () => {
       const sc = new SchemaComposer();
-      sc.TypeComposer.create(`
+      sc.createObjectTC(`
         type Sort {
           name: String
         }
@@ -419,7 +419,7 @@ describe('SchemaComposer', () => {
   describe('getETC', () => {
     it('should return EnumTypeComposer', () => {
       const sc = new SchemaComposer();
-      sc.EnumTypeComposer.create(`
+      sc.createEnumTC(`
           enum Sort {
             ASC DESC
           }
@@ -440,7 +440,7 @@ describe('SchemaComposer', () => {
 
     it('should throw error for incorrect type', () => {
       const sc = new SchemaComposer();
-      sc.TypeComposer.create(`
+      sc.createObjectTC(`
         type Sort {
           name: String
         }
@@ -452,7 +452,7 @@ describe('SchemaComposer', () => {
   describe('getIFTC', () => {
     it('should return InterfaceTypeComposer', () => {
       const sc = new SchemaComposer();
-      sc.InterfaceTypeComposer.create(`
+      sc.createInterfaceTC(`
           interface IFace {
             name: String
           }
@@ -473,7 +473,7 @@ describe('SchemaComposer', () => {
 
     it('should throw error for incorrect type', () => {
       const sc = new SchemaComposer();
-      sc.TypeComposer.create(`
+      sc.createObjectTC(`
         type IFace {
           name: String
         }
@@ -487,7 +487,7 @@ describe('SchemaComposer', () => {
   describe('getAnyTC()', () => {
     it('should return TypeComposer', () => {
       const sc = new SchemaComposer();
-      sc.TypeComposer.create(`type Object1 { name: String }`);
+      sc.createObjectTC(`type Object1 { name: String }`);
       expect(sc.getAnyTC('Object1')).toBeInstanceOf(TypeComposer);
       sc.add(
         new GraphQLObjectType({
@@ -500,7 +500,7 @@ describe('SchemaComposer', () => {
 
     it('should return InputTypeComposer', () => {
       const sc = new SchemaComposer();
-      sc.InputTypeComposer.create(`input Input1 { name: String }`);
+      sc.createInputTC(`input Input1 { name: String }`);
       expect(sc.getAnyTC('Input1')).toBeInstanceOf(InputTypeComposer);
       sc.add(
         new GraphQLInputObjectType({
@@ -513,7 +513,7 @@ describe('SchemaComposer', () => {
 
     it('should return ScalarTypeComposer', () => {
       const sc = new SchemaComposer();
-      sc.ScalarTypeComposer.create(`scalar Scalar1`);
+      sc.createScalarTC(`scalar Scalar1`);
       expect(sc.getAnyTC('Scalar1')).toBeInstanceOf(ScalarTypeComposer);
       sc.add(
         new GraphQLScalarType({
@@ -526,7 +526,7 @@ describe('SchemaComposer', () => {
 
     it('should return EnumTypeComposer', () => {
       const sc = new SchemaComposer();
-      sc.EnumTypeComposer.create(`enum Enum1 { A B }`);
+      sc.createEnumTC(`enum Enum1 { A B }`);
       expect(sc.getAnyTC('Enum1')).toBeInstanceOf(EnumTypeComposer);
       sc.add(
         new GraphQLEnumType({
@@ -539,7 +539,7 @@ describe('SchemaComposer', () => {
 
     it('should return InterfaceTypeComposer', () => {
       const sc = new SchemaComposer();
-      sc.InterfaceTypeComposer.create(`interface Iface1 { f1: Int }`);
+      sc.createInterfaceTC(`interface Iface1 { f1: Int }`);
       expect(sc.getAnyTC('Iface1')).toBeInstanceOf(InterfaceTypeComposer);
       sc.add(
         new GraphQLInterfaceType({
@@ -553,7 +553,7 @@ describe('SchemaComposer', () => {
     it('should return UnionTypeComposer', () => {
       const sc = new SchemaComposer();
       const a = sc.createObjectTC(`type A { f: Int }`);
-      sc.UnionTypeComposer.create(`union Union1 = A`);
+      sc.createUnionTC(`union Union1 = A`);
       expect(sc.getAnyTC('Union1')).toBeInstanceOf(UnionTypeComposer);
       sc.add(
         new GraphQLUnionType({
@@ -568,7 +568,7 @@ describe('SchemaComposer', () => {
   describe('add()', () => {
     it('should add TypeComposer', () => {
       const sc = new SchemaComposer();
-      const tc = sc.TypeComposer.createTemp('User');
+      const tc = TypeComposer.createTemp('User');
       const typeName = sc.add(tc);
       expect(typeName).toBe('User');
       expect(sc.get('User')).toBe(tc);
@@ -579,7 +579,7 @@ describe('SchemaComposer', () => {
 
     it('should add InputTypeComposer', () => {
       const sc = new SchemaComposer();
-      const itc = sc.InputTypeComposer.createTemp('UserInput');
+      const itc = InputTypeComposer.createTemp('UserInput');
       const typeName = sc.add(itc);
       expect(typeName).toBe('UserInput');
       expect(sc.get('UserInput')).toBe(itc);
@@ -590,7 +590,7 @@ describe('SchemaComposer', () => {
 
     it('should add ScalarTypeComposer', () => {
       const sc = new SchemaComposer();
-      const stc = sc.ScalarTypeComposer.createTemp('UserScalar');
+      const stc = ScalarTypeComposer.createTemp('UserScalar');
       const typeName = sc.add(stc);
       expect(typeName).toBe('UserScalar');
       expect(sc.get('UserScalar')).toBe(stc);
@@ -601,7 +601,7 @@ describe('SchemaComposer', () => {
 
     it('should add EnumTypeComposer', () => {
       const sc = new SchemaComposer();
-      const etc = sc.EnumTypeComposer.createTemp('UserEnum');
+      const etc = EnumTypeComposer.createTemp('UserEnum');
       const typeName = sc.add(etc);
       expect(typeName).toBe('UserEnum');
       expect(sc.get('UserEnum')).toBe(etc);
@@ -623,7 +623,7 @@ describe('SchemaComposer', () => {
 
     it('should add InterfaceTypeComposer', () => {
       const sc = new SchemaComposer();
-      const iftc = sc.InterfaceTypeComposer.createTemp('UserInterface');
+      const iftc = InterfaceTypeComposer.createTemp('UserInterface');
       const typeName = sc.add(iftc);
       expect(typeName).toBe('UserInterface');
       expect(sc.get('UserInterface')).toBe(iftc);
@@ -634,7 +634,7 @@ describe('SchemaComposer', () => {
 
     it('should add UnionTypeComposer', () => {
       const sc = new SchemaComposer();
-      const utc = sc.UnionTypeComposer.createTemp('UserUnion');
+      const utc = UnionTypeComposer.createTemp('UserUnion');
       const typeName = sc.add(utc);
       expect(typeName).toBe('UserUnion');
       expect(sc.get('UserUnion')).toBe(utc);
@@ -649,7 +649,7 @@ describe('SchemaComposer', () => {
     it('should add TypeComposer', () => {
       const sc = new SchemaComposer();
       sc.addAsComposer(`type Object1 { name: String }`);
-      sc.addAsComposer(sc.TypeComposer.createTemp(`type Object2 { name: String }`));
+      sc.addAsComposer(TypeComposer.createTemp(`type Object2 { name: String }`));
       sc.addAsComposer(
         new GraphQLObjectType({
           name: 'Object3',
@@ -665,7 +665,7 @@ describe('SchemaComposer', () => {
     it('should return InputTypeComposer', () => {
       const sc = new SchemaComposer();
       sc.addAsComposer(`input Object1 { name: String }`);
-      sc.addAsComposer(sc.InputTypeComposer.createTemp(`input Object2 { name: String }`));
+      sc.addAsComposer(InputTypeComposer.createTemp(`input Object2 { name: String }`));
       sc.addAsComposer(
         new GraphQLInputObjectType({
           name: 'Object3',
@@ -681,7 +681,7 @@ describe('SchemaComposer', () => {
     it('should return ScalarTypeComposer', () => {
       const sc = new SchemaComposer();
       sc.addAsComposer(`scalar Object1`);
-      sc.addAsComposer(sc.ScalarTypeComposer.createTemp(`scalar Object2`));
+      sc.addAsComposer(ScalarTypeComposer.createTemp(`scalar Object2`));
       sc.addAsComposer(
         new GraphQLScalarType({
           name: 'Object3',
@@ -697,7 +697,7 @@ describe('SchemaComposer', () => {
     it('should return EnumTypeComposer', () => {
       const sc = new SchemaComposer();
       sc.addAsComposer(`enum Object1 { A B }`);
-      sc.addAsComposer(sc.EnumTypeComposer.createTemp(`enum Object2 { A B }`));
+      sc.addAsComposer(EnumTypeComposer.createTemp(`enum Object2 { A B }`));
       sc.addAsComposer(
         new GraphQLEnumType({
           name: 'Object3',
@@ -713,7 +713,7 @@ describe('SchemaComposer', () => {
     it('should return InterfaceTypeComposer', () => {
       const sc = new SchemaComposer();
       sc.addAsComposer(`interface Object1 { a: Int }`);
-      sc.addAsComposer(sc.InterfaceTypeComposer.createTemp(`interface Object2 { a: Int }`));
+      sc.addAsComposer(InterfaceTypeComposer.createTemp(`interface Object2 { a: Int }`));
       sc.addAsComposer(
         new GraphQLInterfaceType({
           name: 'Object3',
@@ -730,7 +730,7 @@ describe('SchemaComposer', () => {
       const sc = new SchemaComposer();
       const a = sc.createObjectTC(`type A { f: Int }`);
       sc.addAsComposer(`union Object1 = A`);
-      sc.addAsComposer(sc.UnionTypeComposer.createTemp(`union Object2 = A`));
+      sc.addAsComposer(UnionTypeComposer.createTemp(`union Object2 = A`));
       sc.addAsComposer(
         new GraphQLUnionType({
           name: 'Object3',
@@ -788,14 +788,14 @@ describe('SchemaComposer', () => {
 
       // Post type should be the same instance
       const Post = sc.get('Post');
-      const PostInAuthor = sc.TypeComposer.createTemp((sc.get('Author'): any))
+      const PostInAuthor = TypeComposer.createTemp((sc.get('Author'): any))
         .getFieldTC('posts')
         .getType();
       expect(Post).toBe(PostInAuthor);
 
       // Author type should be the same instance
       const Author = sc.get('Author');
-      const AuthorInPost = sc.TypeComposer.createTemp((sc.get('Post'): any))
+      const AuthorInPost = TypeComposer.createTemp((sc.get('Post'): any))
         .getFieldTC('author')
         .getType();
       expect(Author).toBe(AuthorInPost);
@@ -927,6 +927,10 @@ describe('SchemaComposer', () => {
       const tc2 = sc.createTC(`type B { f: Int }`);
       expect(tc2).toBeInstanceOf(TypeComposer);
       expect(tc2.hasField('f')).toBeTruthy();
+
+      const tc3 = sc.createOutputTC(`type C { f: Int }`);
+      expect(tc3).toBeInstanceOf(TypeComposer);
+      expect(tc3.hasField('f')).toBeTruthy();
     });
 
     it('createInputTC()', () => {

--- a/src/__tests__/TypeComposer-test.js
+++ b/src/__tests__/TypeComposer-test.js
@@ -614,13 +614,13 @@ describe('TypeComposer', () => {
         name: 'findById',
         resolve: () => '123',
       });
-      expect(await tc.getResolver('findById').resolve({})).toBe('123');
+      expect(await tc.getResolver('findById').resolve(({}: any))).toBe('123');
 
       tc.wrapResolverResolve('findById', next => async rp => {
         const prev = await next(rp);
         return `${prev}456`;
       });
-      expect(await tc.getResolver('findById').resolve({})).toBe('123456');
+      expect(await tc.getResolver('findById').resolve(({}: any))).toBe('123456');
     });
 
     it('wrapResolver() should wrap resolver via callback', async () => {
@@ -628,14 +628,14 @@ describe('TypeComposer', () => {
         name: 'update',
         resolve: () => '123',
       });
-      expect(await tc.getResolver('update').resolve({})).toBe('123');
+      expect(await tc.getResolver('update').resolve(({}: any))).toBe('123');
       const prevResolver = tc.getResolver('update');
 
       tc.wrapResolver('update', resolver => {
         resolver.resolve = () => '456'; // eslint-disable-line
         return resolver;
       });
-      expect(await tc.getResolver('update').resolve({})).toBe('456');
+      expect(await tc.getResolver('update').resolve(({}: any))).toBe('456');
       expect(tc.getResolver('update')).not.toBe(prevResolver);
       expect(prevResolver.resolve((undefined: any))).toBe('123');
     });
@@ -649,15 +649,15 @@ describe('TypeComposer', () => {
         },
         resolve: () => '123',
       });
-      expect(await tc.getResolver('update').resolve({})).toBe('123');
+      expect(await tc.getResolver('update').resolve(({}: any))).toBe('123');
 
       tc.wrapResolverAs('updateExt', 'update', resolver => {
         resolver.resolve = () => '456'; // eslint-disable-line
         resolver.addArgs({ c: 'Boolean' });
         return resolver;
       });
-      expect(await tc.getResolver('updateExt').resolve({})).toBe('456');
-      expect(await tc.getResolver('update').resolve({})).toBe('123');
+      expect(await tc.getResolver('updateExt').resolve(({}: any))).toBe('456');
+      expect(await tc.getResolver('update').resolve(({}: any))).toBe('123');
 
       expect(tc.getResolver('update').getArgNames()).toEqual(['a', 'b']);
       expect(tc.getResolver('updateExt').getArgNames()).toEqual(['a', 'b', 'c']);
@@ -685,7 +685,7 @@ describe('TypeComposer', () => {
           return '123';
         },
       });
-      expect(await tc.getResolver('update', [mw1, mw2]).resolve({})).toBe('123');
+      expect(await tc.getResolver('update', [mw1, mw2]).resolve(({}: any))).toBe('123');
       expect(log).toEqual(['m1.before', 'm2.before', 'call update', 'm2.after', 'm1.after']);
     });
   });

--- a/src/__tests__/TypeMapper-test.js
+++ b/src/__tests__/TypeMapper-test.js
@@ -126,7 +126,7 @@ describe('TypeMapper', () => {
     expect(type).toBeInstanceOf(GraphQLInputObjectType);
     expect(typeMapper.get('InputIntRange')).toBe(type);
 
-    const IntRangeTC = new InputTypeComposer(type, sc);
+    const IntRangeTC: any = new InputTypeComposer(type, sc);
     expect(IntRangeTC.getTypeName()).toBe('InputIntRange');
     expect(IntRangeTC.getField('min').defaultValue).toBe(0);
     expect(IntRangeTC.getField('min').type).toBe(GraphQLInt);

--- a/src/__tests__/TypeMapper-test.js
+++ b/src/__tests__/TypeMapper-test.js
@@ -20,7 +20,7 @@ import { graphqlVersion } from '../utils/graphqlVersion';
 import GraphQLJSON from '../type/json';
 import GraphQLDate from '../type/date';
 import GraphQLBuffer from '../type/buffer';
-import { TypeComposer } from '../TypeComposer';
+import { ObjectTypeComposer } from '../ObjectTypeComposer';
 import { InputTypeComposer } from '../InputTypeComposer';
 import { ScalarTypeComposer } from '../ScalarTypeComposer';
 import { EnumTypeComposer } from '../EnumTypeComposer';
@@ -104,7 +104,7 @@ describe('TypeMapper', () => {
     expect(type).toBeInstanceOf(GraphQLObjectType);
     expect(typeMapper.get('IntRange')).toBe(type);
 
-    const IntRangeTC = new TypeComposer(type, sc);
+    const IntRangeTC = new ObjectTypeComposer(type, sc);
     expect(IntRangeTC.getTypeName()).toBe('IntRange');
     expect(IntRangeTC.getFieldNames()).toEqual(expect.arrayContaining(['max', 'min', 'arr']));
     expect(IntRangeTC.getFieldType('max')).toBe(GraphQLInt);
@@ -235,7 +235,7 @@ describe('TypeMapper', () => {
       });
 
       it('should lookup type name as string in schemaComposer', () => {
-        const tc = TypeComposer.create(`type MyType { a: Int }`, sc);
+        const tc = ObjectTypeComposer.create(`type MyType { a: Int }`, sc);
         const fc = typeMapper.convertOutputFieldConfig('MyType');
         expect(fc.type).toBe(tc.getType());
 
@@ -250,7 +250,7 @@ describe('TypeMapper', () => {
           b: Int,
         }`
         );
-        const tc = new TypeComposer((fc.type: any), sc);
+        const tc = new ObjectTypeComposer((fc.type: any), sc);
         expect(tc.getTypeName()).toBe('MyOutputType');
         expect(tc.getFieldType('a')).toBe(GraphQLString);
         expect(tc.getFieldType('b')).toBe(GraphQLInt);
@@ -282,8 +282,8 @@ describe('TypeMapper', () => {
         }).toThrowError(/should be OutputType, but got following type definition/);
       });
 
-      it('should accept TypeComposer', () => {
-        const tc = TypeComposer.create('type PriceRange { lon: Float, lat: Float }', sc);
+      it('should accept ObjectTypeComposer', () => {
+        const tc = ObjectTypeComposer.create('type PriceRange { lon: Float, lat: Float }', sc);
         tc.setDescription('Description');
         const fc = typeMapper.convertOutputFieldConfig({
           type: tc,
@@ -395,7 +395,7 @@ describe('TypeMapper', () => {
         expect(fc3.type).toBeInstanceOf(GraphQLList);
         expect(fc3.type.ofType).toBe(GraphQLString);
 
-        const tc = TypeComposer.create('type PriceRange { lon: Float, lat: Float }', sc);
+        const tc = ObjectTypeComposer.create('type PriceRange { lon: Float, lat: Float }', sc);
 
         const fc4: any = typeMapper.convertOutputFieldConfig([tc]);
         expect(fc4.type).toBeInstanceOf(GraphQLList);
@@ -592,18 +592,18 @@ describe('TypeMapper', () => {
       expect(ic2.description).toBe('Description');
     });
 
-    it('should throw error if provided TypeComposer', () => {
-      const tc = TypeComposer.create('type LonLat { lon: Float, lat: Float }', sc);
+    it('should throw error if provided ObjectTypeComposer', () => {
+      const tc = ObjectTypeComposer.create('type LonLat { lon: Float, lat: Float }', sc);
 
       expect(() => {
         typeMapper.convertInputFieldConfig({
           type: (tc: any),
         });
-      }).toThrowError(/\sTypeComposer/);
+      }).toThrowError(/\sObjectTypeComposer/);
 
       expect(() => {
         typeMapper.convertInputFieldConfig((tc: any));
-      }).toThrowError(/\sTypeComposer/);
+      }).toThrowError(/\sObjectTypeComposer/);
     });
 
     it('should pass unchanged thunk', () => {
@@ -838,16 +838,16 @@ describe('TypeMapper', () => {
       }).toThrowError(/can accept Array exact with one input type/);
     });
 
-    it('should throw error if provided TypeComposer', () => {
-      const tc = TypeComposer.create('type LonLat { lon: Float, lat: Float }', sc);
+    it('should throw error if provided ObjectTypeComposer', () => {
+      const tc = ObjectTypeComposer.create('type LonLat { lon: Float, lat: Float }', sc);
 
       expect(() => {
         typeMapper.convertArgConfig(({ type: tc }: any));
-      }).toThrowError(/\sTypeComposer/);
+      }).toThrowError(/\sObjectTypeComposer/);
 
       expect(() => {
         typeMapper.convertArgConfig((tc: any));
-      }).toThrowError(/\sTypeComposer/);
+      }).toThrowError(/\sObjectTypeComposer/);
     });
 
     it('should process ArgConfigMap', () => {
@@ -934,7 +934,7 @@ describe('TypeMapper', () => {
       const t2 = typeMapper.createType('type SameType { a: Int }');
       expect(t1).toBe(t2);
 
-      const tc = TypeComposer.create((t1: any), sc);
+      const tc = ObjectTypeComposer.create((t1: any), sc);
       expect(tc.getTypeName()).toBe('SameType');
       expect(tc.getFieldType('a')).toBe(GraphQLInt);
     });

--- a/src/__tests__/TypeStorage-test.js
+++ b/src/__tests__/TypeStorage-test.js
@@ -2,7 +2,7 @@
 
 import { TypeStorage } from '../TypeStorage';
 import { GraphQLString, GraphQLObjectType } from '../graphql';
-import { TypeComposer } from '../TypeComposer';
+import { ObjectTypeComposer } from '../ObjectTypeComposer';
 import { InputTypeComposer } from '../InputTypeComposer';
 import { ScalarTypeComposer } from '../ScalarTypeComposer';
 import { EnumTypeComposer } from '../EnumTypeComposer';
@@ -52,8 +52,8 @@ describe('typeStorage', () => {
   });
 
   describe('add()', () => {
-    it('should add TypeComposer', () => {
-      const tc = TypeComposer.createTemp('User');
+    it('should add ObjectTypeComposer', () => {
+      const tc = ObjectTypeComposer.createTemp('User');
       const typeName = typeStorage.add(tc);
       expect(typeName).toBe('User');
       expect(typeStorage.get('User')).toBe(tc);

--- a/src/__tests__/TypeStorage-test.js
+++ b/src/__tests__/TypeStorage-test.js
@@ -2,14 +2,12 @@
 
 import { TypeStorage } from '../TypeStorage';
 import { GraphQLString, GraphQLObjectType } from '../graphql';
-import {
-  TypeComposer,
-  InputTypeComposer,
-  ScalarTypeComposer,
-  EnumTypeComposer,
-  InterfaceTypeComposer,
-  UnionTypeComposer,
-} from '..';
+import { TypeComposer } from '../TypeComposer';
+import { InputTypeComposer } from '../InputTypeComposer';
+import { ScalarTypeComposer } from '../ScalarTypeComposer';
+import { EnumTypeComposer } from '../EnumTypeComposer';
+import { InterfaceTypeComposer } from '../InterfaceTypeComposer';
+import { UnionTypeComposer } from '../UnionTypeComposer';
 
 let typeStorage;
 beforeEach(() => {
@@ -59,7 +57,6 @@ describe('typeStorage', () => {
       const typeName = typeStorage.add(tc);
       expect(typeName).toBe('User');
       expect(typeStorage.get('User')).toBe(tc);
-      expect(typeStorage.getTC('User')).toBe(tc);
     });
 
     it('should add InputTypeComposer', () => {
@@ -67,7 +64,6 @@ describe('typeStorage', () => {
       const typeName = typeStorage.add(itc);
       expect(typeName).toBe('UserInput');
       expect(typeStorage.get('UserInput')).toBe(itc);
-      expect(typeStorage.getITC('UserInput')).toBe(itc);
     });
 
     it('should add ScalarTypeComposer', () => {
@@ -75,7 +71,6 @@ describe('typeStorage', () => {
       const typeName = typeStorage.add(stc);
       expect(typeName).toBe('UserScalar');
       expect(typeStorage.get('UserScalar')).toBe(stc);
-      expect(typeStorage.getSTC('UserScalar')).toBe(stc);
     });
 
     it('should add EnumTypeComposer', () => {
@@ -83,7 +78,6 @@ describe('typeStorage', () => {
       const typeName = typeStorage.add(etc);
       expect(typeName).toBe('UserEnum');
       expect(typeStorage.get('UserEnum')).toBe(etc);
-      expect(typeStorage.getETC('UserEnum')).toBe(etc);
     });
 
     it('should add GraphQLObjectType', () => {
@@ -101,7 +95,6 @@ describe('typeStorage', () => {
       const typeName = typeStorage.add(iftc);
       expect(typeName).toBe('UserInterface');
       expect(typeStorage.get('UserInterface')).toBe(iftc);
-      expect(typeStorage.getIFTC('UserInterface')).toBe(iftc);
     });
 
     it('should add UnionTypeComposer', () => {
@@ -109,7 +102,6 @@ describe('typeStorage', () => {
       const typeName = typeStorage.add(utc);
       expect(typeName).toBe('UserUnion');
       expect(typeStorage.get('UserUnion')).toBe(utc);
-      expect(typeStorage.getUTC('UserUnion')).toBe(utc);
     });
   });
 });

--- a/src/__tests__/UnionTypeComposer-test.js
+++ b/src/__tests__/UnionTypeComposer-test.js
@@ -360,8 +360,8 @@ describe('UnionTypeComposer', () => {
     describe('setTypeResolvers()', () => {
       it('async mode', async () => {
         const map = new Map([
-          [PersonTC.getType(), async () => Promise.resolve(false)],
-          [KindRedTC, async () => Promise.resolve(true)],
+          [PersonTC.getType(), async () => false],
+          [KindRedTC, async () => true],
         ]);
         utc.setTypeResolvers(map);
 

--- a/src/__tests__/UnionTypeComposer-test.js
+++ b/src/__tests__/UnionTypeComposer-test.js
@@ -10,7 +10,7 @@ import {
 } from '../graphql';
 import { schemaComposer as sc } from '..';
 import { UnionTypeComposer } from '../UnionTypeComposer';
-import { TypeComposer } from '../TypeComposer';
+import { ObjectTypeComposer } from '../ObjectTypeComposer';
 
 beforeEach(() => {
   sc.clear();
@@ -53,8 +53,8 @@ describe('UnionTypeComposer', () => {
       expect(() => myUTC.getTypes()).toThrowError("Cannot find type with name 'A'");
 
       // when types A & B defined, getTypes() returns them
-      TypeComposer.create('type A { a: Int }', sc);
-      TypeComposer.create('type B { b: Int }', sc);
+      ObjectTypeComposer.create('type A { a: Int }', sc);
+      ObjectTypeComposer.create('type B { b: Int }', sc);
       const types = myUTC.getTypes();
       expect(types).toHaveLength(2);
       expect(types[0]).toBeInstanceOf(GraphQLObjectType);
@@ -70,7 +70,7 @@ describe('UnionTypeComposer', () => {
         sc
       );
       expect(myUTC).toBeInstanceOf(UnionTypeComposer);
-      TypeComposer.create(`type BB { b: Int }`, sc);
+      ObjectTypeComposer.create(`type BB { b: Int }`, sc);
       const types = myUTC.getTypes();
       expect(types).toHaveLength(2);
       expect(types[0]).toBeInstanceOf(GraphQLObjectType);
@@ -132,7 +132,7 @@ describe('UnionTypeComposer', () => {
       it('should add by type name', () => {
         utc.addType('SomeType');
         expect(utc.hasType('SomeType')).toBeTruthy();
-        TypeComposer.create('SomeType', sc);
+        ObjectTypeComposer.create('SomeType', sc);
         expect(utc.getTypes()).toHaveLength(3);
       });
 
@@ -166,7 +166,7 @@ describe('UnionTypeComposer', () => {
 
         expect(utc.getTypes()).toHaveLength(3);
 
-        TypeComposer.create('type DD { a: Int }', sc);
+        ObjectTypeComposer.create('type DD { a: Int }', sc);
         expect(utc.getType().getTypes()).toHaveLength(3);
       });
     });
@@ -249,7 +249,7 @@ describe('UnionTypeComposer', () => {
     beforeEach(() => {
       utc.clearTypes();
 
-      PersonTC = TypeComposer.create(
+      PersonTC = ObjectTypeComposer.create(
         `
         type Person { age: Int, field1: String, field2: String }
       `,
@@ -259,7 +259,7 @@ describe('UnionTypeComposer', () => {
         return value.hasOwnProperty('age');
       });
 
-      KindRedTC = TypeComposer.create(
+      KindRedTC = ObjectTypeComposer.create(
         `
         type KindRed { kind: String, field1: String, field2: String, red: String }
       `,
@@ -269,7 +269,7 @@ describe('UnionTypeComposer', () => {
         return value.kind === 'red';
       });
 
-      KindBlueTC = TypeComposer.create(
+      KindBlueTC = ObjectTypeComposer.create(
         `
         type KindBlue { kind: String, field1: String, field2: String, blue: String }
       `,
@@ -330,7 +330,7 @@ describe('UnionTypeComposer', () => {
       expect(utc.hasTypeResolver(PersonTC)).toBeTruthy();
       expect(utc.hasTypeResolver(KindRedTC)).toBeTruthy();
       expect(utc.hasTypeResolver(KindBlueTC)).toBeTruthy();
-      expect(utc.hasTypeResolver(TypeComposer.create('NewOne', sc))).toBeFalsy();
+      expect(utc.hasTypeResolver(ObjectTypeComposer.create('NewOne', sc))).toBeFalsy();
     });
 
     it('getTypeResolvers()', () => {

--- a/src/__tests__/UnionTypeComposer-test.js
+++ b/src/__tests__/UnionTypeComposer-test.js
@@ -423,8 +423,8 @@ describe('UnionTypeComposer', () => {
       });
 
       it('integration test', async () => {
-        const aTC = sc.createTC('type A { a: Int }');
-        const bTC = sc.createTC('type B { b: Int }');
+        const aTC = sc.createObjectTC('type A { a: Int }');
+        const bTC = sc.createObjectTC('type B { b: Int }');
         const utc1 = sc.createUnionTC(`union U = A | B`);
         const resolveType = value => {
           if (value) {

--- a/src/__tests__/_flowtype-test.js
+++ b/src/__tests__/_flowtype-test.js
@@ -14,8 +14,8 @@ describe('Flowtype tests', () => {
       d2: number,
     };
 
-    const Schema: SchemaComposer<Context> = new SchemaComposer();
-    const UserTC = Schema.TypeComposer.create('User');
+    const sc: SchemaComposer<Context> = new SchemaComposer();
+    const UserTC = sc.createObjectTC('User');
     UserTC.addResolver({
       name: 'findOne',
       resolve: ({ context }) => {
@@ -28,8 +28,8 @@ describe('Flowtype tests', () => {
     //
     //
 
-    const Schema2: SchemaComposer<Context2> = new SchemaComposer();
-    const UserTC2 = Schema2.TypeComposer.create('User');
+    const sc2: SchemaComposer<Context2> = new SchemaComposer();
+    const UserTC2 = sc2.createObjectTC('User');
     UserTC2.addResolver({
       name: 'findOne',
       resolve: ({ context }) => {

--- a/src/__tests__/_integration-test.js
+++ b/src/__tests__/_integration-test.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import { TypeComposer, schemaComposer } from '..';
+import { schemaComposer } from '..';
 
 beforeEach(() => {
   schemaComposer.clear();
@@ -8,13 +8,13 @@ beforeEach(() => {
 
 describe('created types via TypeComposer.create should be avaliable in SDL', () => {
   it('simple case', () => {
-    const UserTC = TypeComposer.create(`
+    const UserTC = schemaComposer.createObjectTC(`
       type User {
         name: String
       }
     `);
 
-    const ArticleTC = TypeComposer.create(`
+    const ArticleTC = schemaComposer.createObjectTC(`
       type Article {
         text: String
         user: User
@@ -25,7 +25,7 @@ describe('created types via TypeComposer.create should be avaliable in SDL', () 
   });
 
   it('hoisting case', () => {
-    const UserTC = TypeComposer.create({
+    const UserTC = schemaComposer.createObjectTC({
       name: 'User',
       fields: {
         name: 'String',
@@ -33,7 +33,7 @@ describe('created types via TypeComposer.create should be avaliable in SDL', () 
       },
     });
 
-    const ArticleTC = TypeComposer.create({
+    const ArticleTC = schemaComposer.createObjectTC({
       name: 'Article',
       fields: {
         text: 'String',

--- a/src/__tests__/_integration-test.js
+++ b/src/__tests__/_integration-test.js
@@ -6,7 +6,7 @@ beforeEach(() => {
   schemaComposer.clear();
 });
 
-describe('created types via TypeComposer.create should be avaliable in SDL', () => {
+describe('created types via ObjectTypeComposer.create should be avaliable in SDL', () => {
   it('simple case', () => {
     const UserTC = schemaComposer.createObjectTC(`
       type User {

--- a/src/__tests__/github_issues/107-test.js
+++ b/src/__tests__/github_issues/107-test.js
@@ -52,8 +52,8 @@ describe('github issue #107 merge Schema types on GQL', () => {
     expect(RemoteQueryTC.getTypeName()).toBe('Query');
     expect(RemoteQueryTC.getFieldNames()).toEqual(['users']);
 
-    // remoteMutationTC = TypeComposer.create(remoteSchema._mutationType);
-    // remoteSubscriptionTC = TypeComposer.create(remoteSchema._subscriptionType);
+    // remoteMutationTC = ObjectTypeComposer.create(remoteSchema._mutationType);
+    // remoteSubscriptionTC = ObjectTypeComposer.create(remoteSchema._subscriptionType);
   });
 
   it('get nested TC from remote schema', () => {

--- a/src/__tests__/github_issues/107-test.js
+++ b/src/__tests__/github_issues/107-test.js
@@ -8,7 +8,7 @@ import {
   GraphQLList,
   graphql,
 } from 'graphql';
-import { TypeComposer, schemaComposer } from '../..';
+import { schemaComposer } from '../..';
 
 const remoteSchema = new GraphQLSchema({
   query: new GraphQLObjectType({
@@ -48,8 +48,7 @@ beforeEach(() => {
 describe('github issue #107 merge Schema types on GQL', () => {
   it('get QueryTC from remote schema', () => {
     const RemoteQueryType: any = remoteSchema._queryType;
-    const RemoteQueryTC = TypeComposer.create(RemoteQueryType);
-    expect(RemoteQueryTC).toBeInstanceOf(TypeComposer);
+    const RemoteQueryTC = schemaComposer.createObjectTC(RemoteQueryType);
     expect(RemoteQueryTC.getTypeName()).toBe('Query');
     expect(RemoteQueryTC.getFieldNames()).toEqual(['users']);
 
@@ -59,7 +58,7 @@ describe('github issue #107 merge Schema types on GQL', () => {
 
   it('get nested TC from remote schema', () => {
     const RemoteQueryType: any = remoteSchema._queryType;
-    const RemoteQueryTC = TypeComposer.create(RemoteQueryType);
+    const RemoteQueryTC = schemaComposer.createObjectTC(RemoteQueryType);
     const RemoteUserTC = RemoteQueryTC.get('users');
     expect(RemoteUserTC.getTypeName()).toEqual('User');
 
@@ -69,11 +68,11 @@ describe('github issue #107 merge Schema types on GQL', () => {
 
   it('schema stiching on Query', async () => {
     const RemoteQueryType: any = remoteSchema._queryType;
-    const RemoteQueryTC = TypeComposer.create(RemoteQueryType);
+    const RemoteQueryTC = schemaComposer.createObjectTC(RemoteQueryType);
 
     schemaComposer.Query.addFields({
       tag: {
-        type: TypeComposer.create(`type Tag { id: Int, title: String}`),
+        type: schemaComposer.createObjectTC(`type Tag { id: Int, title: String}`),
         resolve: () => ({ id: 1, title: 'Some tag' }),
       },
       ...RemoteQueryTC.getFields(),
@@ -104,15 +103,15 @@ describe('github issue #107 merge Schema types on GQL', () => {
 
   it('schema stiching on Query.remote', async () => {
     const RemoteQueryType: any = remoteSchema._queryType;
-    const RemoteQueryTC = TypeComposer.create(RemoteQueryType);
+    const RemoteQueryTC = schemaComposer.createObjectTC(RemoteQueryType);
 
     schemaComposer.Query.addFields({
       tag: {
-        type: TypeComposer.create(`type Tag { id: Int, title: String}`),
+        type: schemaComposer.createObjectTC(`type Tag { id: Int, title: String}`),
         resolve: () => ({ id: 1, title: 'Some tag' }),
       },
       remote: {
-        type: TypeComposer.create({
+        type: schemaComposer.createObjectTC({
           name: 'RemoteSchema',
           fields: RemoteQueryTC.getFields(),
         }),
@@ -150,11 +149,11 @@ describe('github issue #107 merge Schema types on GQL', () => {
 
   it('using remote type in local schema', async () => {
     const RemoteQueryType: any = remoteSchema._queryType;
-    const RemoteQueryTC = TypeComposer.create(RemoteQueryType);
+    const RemoteQueryTC = schemaComposer.createObjectTC(RemoteQueryType);
     const RemoteUserTC = RemoteQueryTC.getFieldTC('users');
     const remoteUsersFC = RemoteQueryTC.getFieldConfig('users');
 
-    const LocalArticleTC = TypeComposer.create({
+    const LocalArticleTC = schemaComposer.createObjectTC({
       name: 'Article',
       fields: {
         text: {
@@ -211,11 +210,11 @@ describe('github issue #107 merge Schema types on GQL', () => {
 
   it('adding remote type to SchemaComposer and check reference by name', () => {
     const RemoteQueryType: any = remoteSchema._queryType;
-    const RemoteQueryTC = TypeComposer.create(RemoteQueryType);
+    const RemoteQueryTC = schemaComposer.createObjectTC(RemoteQueryType);
     const UserTC = RemoteQueryTC.getFieldTC('users');
     schemaComposer.add(UserTC);
 
-    const ArticleTC = TypeComposer.create({
+    const ArticleTC = schemaComposer.createObjectTC({
       name: 'Article',
       fields: {
         user: 'User',

--- a/src/__tests__/github_issues/165-test.js
+++ b/src/__tests__/github_issues/165-test.js
@@ -855,7 +855,7 @@ describe('github issue #165: Add support for `directives` in SDL', () => {
     schemaComposer.clear();
     schemaComposer.addTypeDefs(typeDefs);
     expect(schemaComposer.types.size).toBe(99);
-    const SettingTC = schemaComposer.getTC('Settings');
+    const SettingTC = schemaComposer.getOTC('Settings');
     expect(SettingTC.getFieldNames()).toEqual(['cache_id', 'notificationSounds', 'notifications']);
   });
 });

--- a/src/__tests__/github_issues/72-test.js
+++ b/src/__tests__/github_issues/72-test.js
@@ -1,11 +1,11 @@
 /* @flow strict */
 
-import { TypeComposer } from '../..';
+import { schemaComposer } from '../..';
 
 describe('github issue #72', () => {
   it('extendField after addRelation', () => {
-    const MyTypeTC = TypeComposer.create(`type MyType { name: String }`);
-    const OtherTypeTC = TypeComposer.create(`type OtherType { name: String }`);
+    const MyTypeTC = schemaComposer.createObjectTC(`type MyType { name: String }`);
+    const OtherTypeTC = schemaComposer.createObjectTC(`type OtherType { name: String }`);
     OtherTypeTC.addResolver({
       name: 'findOne',
       type: OtherTypeTC,

--- a/src/__tests__/typedefs/Others.spec.ts
+++ b/src/__tests__/typedefs/Others.spec.ts
@@ -1,4 +1,4 @@
 import { Post, schemaComposerWithContext } from './mock-typedefs';
 
-// getTC from TypeStorage
-const Post = schemaComposerWithContext.getTC<Post>('Post');
+// getOTC from TypeStorage
+const Post = schemaComposerWithContext.getOTC<Post>('Post');

--- a/src/__tests__/typedefs/Resolver.spec.ts
+++ b/src/__tests__/typedefs/Resolver.spec.ts
@@ -1,33 +1,40 @@
 import { GraphQLInt, GraphQLString } from 'graphql';
 import { Resolver } from '../../Resolver';
+import { schemaComposer } from '../..';
 import { Args, Art, Context, Post } from './mock-typedefs';
 
-const findManyPost = new Resolver<Post, Context, Args>({
-  args: {
-    filter: { type: GraphQLString },
-    limit: { type: GraphQLInt },
-    skip: { type: GraphQLInt },
-    sort: { type: GraphQLString },
-    // unknown: {type: GraphQLInt}, errors
+const findManyPost = new Resolver<Post, Context, Args>(
+  {
+    args: {
+      filter: { type: GraphQLString },
+      limit: { type: GraphQLInt },
+      skip: { type: GraphQLInt },
+      sort: { type: GraphQLString },
+      // unknown: {type: GraphQLInt}, errors
+    },
+    resolve: rp => {
+      if (rp.source && rp.context) {
+        // rp.source.timestamp = 'fails';
+        rp.source.timestamp = 4;
+        rp.source.author = 'GraphQL superb with Compose';
+      }
+    },
   },
-  resolve: rp => {
-    if (rp.source && rp.context) {
-      // rp.source.timestamp = 'fails';
-      rp.source.timestamp = 4;
-      rp.source.author = 'GraphQL superb with Compose';
-    }
-  },
-});
+  schemaComposer,
+);
 
-const findOnePostAny = new Resolver({
-  resolve: rp => {
-    if (rp.source && rp.context) {
-      // rp.source.timestamp = 'fails';
-      rp.source.timestamp = 'compose';
-      rp.source.author = 4;
-    }
+const findOnePostAny = new Resolver(
+  {
+    resolve: rp => {
+      if (rp.source && rp.context) {
+        // rp.source.timestamp = 'fails';
+        rp.source.timestamp = 'compose';
+        rp.source.author = 4;
+      }
+    },
   },
-});
+  schemaComposer,
+);
 
 // wrap
 const findManyArt = findManyPost.wrap<Art>(
@@ -70,31 +77,37 @@ interface FindManyArtArgs {
   skip: number;
 }
 
-const findManyArt1 = new Resolver<any, any, FindManyArtArgs>({
-  resolve: rp => {
-    if (rp.args) {
-      // rp.args.skip = 'dsd';
-      rp.args.skip = 4;
-      rp.args.filter.id = 'string';
-    }
+const findManyArt1 = new Resolver<any, any, FindManyArtArgs>(
+  {
+    resolve: rp => {
+      if (rp.args) {
+        // rp.args.skip = 'dsd';
+        rp.args.skip = 4;
+        rp.args.filter.id = 'string';
+      }
+    },
   },
-});
+  schemaComposer,
+);
 
 // all any
-const findManyPost1 = new Resolver({
-  args: {
-    skip: { type: GraphQLInt },
-  },
-  resolve: ({ source, context, args }) => {
-    source.title = 555; // pass as source is any fails
-    source.title = 'A Title';
+const findManyPost1 = new Resolver(
+  {
+    args: {
+      skip: { type: GraphQLInt },
+    },
+    resolve: ({ source, context, args }) => {
+      source.title = 555; // pass as source is any fails
+      source.title = 'A Title';
 
-    if (args) {
-      args.skip = 'hello';
-      args.skip = 4;
-    }
+      if (args) {
+        args.skip = 'hello';
+        args.skip = 4;
+      }
+    },
   },
-});
+  schemaComposer,
+);
 
 // inherits findManyArtArgs, can be overwritten
 findManyArt1.wrapResolve<Art, FindManyArtArgs>(next => rp => {

--- a/src/__tests__/typedefs/TypeComposer.spec.ts
+++ b/src/__tests__/typedefs/TypeComposer.spec.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-param-reassign, no-unused-vars, import/no-unresolved */
 
-import { TypeComposer } from '../../TypeComposer';
+import { ObjectTypeComposer } from '../../ObjectTypeComposer';
 
 // Person from this schemaComposer gets the context defined for that schemaComposer
 import {
@@ -17,7 +17,7 @@ import {
 
 // create from default schemaComposer uses the context type passed in
 // TSource Person, TContext Context
-const PersonTC = TypeComposer.create<Person, Context>({
+const PersonTC = ObjectTypeComposer.create<Person, Context>({
   name: 'Person',
   fields: {
     name: 'String',
@@ -27,10 +27,10 @@ const PersonTC = TypeComposer.create<Person, Context>({
 });
 
 // TSource Art, TContext Context
-const ArtTC = schemaComposerWithContext.getOrCreateTC<Art>('Art');
+const ArtTC = schemaComposerWithContext.getOrCreateOTC<Art>('Art');
 
 // TSource any, TContext any
-const PostTC = TypeComposer.create('Post');
+const PostTC = ObjectTypeComposer.create('Post');
 
 // ****************************
 // Resolvers
@@ -42,7 +42,7 @@ const PostTC = TypeComposer.create('Post');
 // ****************************
 
 // TC.getResolver()
-// should be without errors! By default in resolvers source should be `any` even if provided TypeComposer.create<Person, Context>
+// should be without errors! By default in resolvers source should be `any` even if provided ObjectTypeComposer.create<Person, Context>
 PersonTC.getResolver('findOne').wrapResolve(next => rp => {
   rp.source.name = 5; // source any
   rp.source.age = 'string';
@@ -150,7 +150,7 @@ PersonTC.addFields({
       // An error pops up here, this is as TypeScript cannot infer TSource and TContext
       // So you need to explicitly set it up.
       // The error actually shows up at the resolve field of ageIn2030
-      TypeComposer.create<Person, Context>({
+      ObjectTypeComposer.create<Person, Context>({
         name: 'deepAge',
         fields: {
           age: {

--- a/src/__tests__/typedefs/TypeComposer.spec.ts
+++ b/src/__tests__/typedefs/TypeComposer.spec.ts
@@ -17,20 +17,23 @@ import {
 
 // create from default schemaComposer uses the context type passed in
 // TSource Person, TContext Context
-const PersonTC = ObjectTypeComposer.create<Person, Context>({
-  name: 'Person',
-  fields: {
-    name: 'String',
-    nickName: 'String',
-    age: 'Int',
+const PersonTC = ObjectTypeComposer.create<Person, Context>(
+  {
+    name: 'Person',
+    fields: {
+      name: 'String',
+      nickName: 'String',
+      age: 'Int',
+    },
   },
-});
+  schemaComposerWithContext,
+);
 
 // TSource Art, TContext Context
 const ArtTC = schemaComposerWithContext.getOrCreateOTC<Art>('Art');
 
 // TSource any, TContext any
-const PostTC = ObjectTypeComposer.create('Post');
+const PostTC = ObjectTypeComposer.createTemp('Post');
 
 // ****************************
 // Resolvers
@@ -150,7 +153,7 @@ PersonTC.addFields({
       // An error pops up here, this is as TypeScript cannot infer TSource and TContext
       // So you need to explicitly set it up.
       // The error actually shows up at the resolve field of ageIn2030
-      ObjectTypeComposer.create<Person, Context>({
+      ObjectTypeComposer.createTemp<Person, Context>({
         name: 'deepAge',
         fields: {
           age: {

--- a/src/__tests__/typedefs/flow.js
+++ b/src/__tests__/typedefs/flow.js
@@ -1,0 +1,16 @@
+/* @flow */
+
+import { schemaComposer } from '../..';
+
+// Should not be Flow errors
+export const resolver = schemaComposer.createResolver({
+  name: 'findMany',
+  kind: 'query',
+  type: 'String',
+  args: {
+    filter: 'JSON',
+    limit: 'Int',
+    skip: 'Int',
+  },
+  resolve: () => Promise.resolve(123),
+});

--- a/src/__tests__/typedefs/no-flow-errors.js
+++ b/src/__tests__/typedefs/no-flow-errors.js
@@ -2,7 +2,6 @@
 
 import { schemaComposer } from '../..';
 
-// Should not be Flow errors
 export const resolver = schemaComposer.createResolver({
   name: 'findMany',
   kind: 'query',
@@ -14,3 +13,12 @@ export const resolver = schemaComposer.createResolver({
   },
   resolve: () => Promise.resolve(123),
 });
+
+export const UserTC = schemaComposer.createObjectTC(`
+  type User {
+    id: Int
+    name: String
+    age: Int
+    gender: String
+  }
+`);

--- a/src/graphql.d.ts
+++ b/src/graphql.d.ts
@@ -1,2 +1,1 @@
-/// <reference types="graphql" />
 export * from 'graphql';

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -5,7 +5,11 @@ export { graphql };
 
 declare const schemaComposer: SchemaComposer<any>;
 declare const sc: SchemaComposer<any>;
-export { SchemaComposer, schemaComposer, sc };
+export {
+  SchemaComposer, // SchemaComposer class
+  schemaComposer, // SchemaComposer default global instance
+  sc, // SchemaComposer default global instance (alias for schemaComposer)
+};
 
 export { ObjectTypeComposer, isComposeOutputType } from './ObjectTypeComposer';
 export { InputTypeComposer, isComposeInputType } from './InputTypeComposer';
@@ -14,6 +18,7 @@ export { ScalarTypeComposer } from './ScalarTypeComposer';
 export { InterfaceTypeComposer } from './InterfaceTypeComposer';
 export { UnionTypeComposer } from './UnionTypeComposer';
 export { Resolver } from './Resolver';
+
 export { TypeStorage } from './TypeStorage';
 export { TypeMapper } from './TypeMapper';
 
@@ -39,7 +44,8 @@ export * from './utils/is';
 export * from './utils/graphqlVersion';
 export { default as toDottedObject } from './utils/toDottedObject';
 export { default as deepmerge } from './utils/deepmerge';
-export { default as filterByDotPaths } from './utils/filterByDotPaths';
+export { filterByDotPaths } from './utils/filterByDotPaths';
+export { pluralize } from './utils/pluralize';
 
 export {
   GetRecordIdFn,

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -77,7 +77,7 @@ export {
   RelationOpts,
   RelationOptsWithResolver,
   RelationOptsWithFieldConfig,
-  ArgsType,
+  ArgsMap,
   RelationArgsMapperFn,
   RelationArgsMapper,
 } from './TypeComposer';

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -3,39 +3,19 @@ import { SchemaComposer } from './SchemaComposer';
 
 export { graphql };
 
-export { TypeComposer } from './TypeComposer';
-export { InputTypeComposer } from './InputTypeComposer';
-export { ScalarTypeComposer } from './ScalarTypeComposer';
+declare const schemaComposer: SchemaComposer<any>;
+declare const sc: SchemaComposer<any>;
+export { SchemaComposer, schemaComposer, sc };
+
+export { ObjectTypeComposer, isComposeOutputType } from './ObjectTypeComposer';
+export { InputTypeComposer, isComposeInputType } from './InputTypeComposer';
 export { EnumTypeComposer } from './EnumTypeComposer';
+export { ScalarTypeComposer } from './ScalarTypeComposer';
 export { InterfaceTypeComposer } from './InterfaceTypeComposer';
 export { UnionTypeComposer } from './UnionTypeComposer';
 export { Resolver } from './Resolver';
-export { TypeMapper } from './TypeMapper';
-declare const GQC: SchemaComposer<any>;
-declare const schemaComposer: SchemaComposer<any>;
-export { SchemaComposer, schemaComposer, GQC };
-
-export {
-  TypeComposer as TypeComposerClass,
-  isComposeOutputType,
-} from './TypeComposer';
-export {
-  InputTypeComposer as InputTypeComposerClass,
-  isComposeInputType,
-} from './InputTypeComposer';
-export { EnumTypeComposer as EnumTypeComposerClass } from './EnumTypeComposer';
-export {
-  ScalarTypeComposer as ScalarTypeComposerClass,
-} from './ScalarTypeComposer';
-export {
-  InterfaceTypeComposer as InterfaceTypeComposerClass,
-} from './InterfaceTypeComposer';
-export {
-  UnionTypeComposer as UnionTypeComposerClass,
-} from './UnionTypeComposer';
-export { Resolver as ResolverClass } from './Resolver';
-
 export { TypeStorage } from './TypeStorage';
+export { TypeMapper } from './TypeMapper';
 
 // Scalar types
 export {
@@ -80,7 +60,7 @@ export {
   ArgsMap,
   RelationArgsMapperFn,
   RelationArgsMapper,
-} from './TypeComposer';
+} from './ObjectTypeComposer';
 
 export {
   ComposeInputType,

--- a/src/index.js
+++ b/src/index.js
@@ -7,31 +7,13 @@ export { graphql };
 
 const schemaComposer = new SchemaComposer<any>();
 const sc = schemaComposer;
-const GQC = schemaComposer;
-const TypeComposer = schemaComposer.TypeComposer;
-const InputTypeComposer = schemaComposer.InputTypeComposer;
-const ScalarTypeComposer = schemaComposer.ScalarTypeComposer;
-const EnumTypeComposer = schemaComposer.EnumTypeComposer;
-const InterfaceTypeComposer = schemaComposer.InterfaceTypeComposer;
-const UnionTypeComposer = schemaComposer.UnionTypeComposer;
-const Resolver = schemaComposer.Resolver;
-const TypeMapper = schemaComposer.typeMapper;
 export {
   // SchemaComposer default global instance (alias for schemaComposer)
   sc,
-  GQC,
   // SchemaComposer default global instance
   schemaComposer,
   // SchemaComposer class
   SchemaComposer,
-  TypeComposer,
-  InputTypeComposer,
-  EnumTypeComposer,
-  ScalarTypeComposer,
-  InterfaceTypeComposer,
-  UnionTypeComposer,
-  Resolver,
-  TypeMapper,
 };
 
 export { TypeComposer as TypeComposerClass, isComposeOutputType } from './TypeComposer';

--- a/src/index.js
+++ b/src/index.js
@@ -37,7 +37,8 @@ export * from './utils/is';
 export * from './utils/graphqlVersion';
 export { default as toDottedObject } from './utils/toDottedObject';
 export { default as deepmerge } from './utils/deepmerge';
-export { default as filterByDotPaths } from './utils/filterByDotPaths';
+export { filterByDotPaths } from './utils/filterByDotPaths';
+export { pluralize } from './utils/pluralize';
 
 export type {
   GetRecordIdFn,

--- a/src/index.js
+++ b/src/index.js
@@ -8,26 +8,21 @@ export { graphql };
 const schemaComposer = new SchemaComposer<any>();
 const sc = schemaComposer;
 export {
-  // SchemaComposer default global instance (alias for schemaComposer)
-  sc,
-  // SchemaComposer default global instance
-  schemaComposer,
-  // SchemaComposer class
-  SchemaComposer,
+  SchemaComposer, // SchemaComposer class
+  schemaComposer, // SchemaComposer default global instance
+  sc, // SchemaComposer default global instance (alias for schemaComposer)
 };
 
-export { TypeComposer as TypeComposerClass, isComposeOutputType } from './TypeComposer';
-export {
-  InputTypeComposer as InputTypeComposerClass,
-  isComposeInputType,
-} from './InputTypeComposer';
-export { EnumTypeComposer as EnumTypeComposerClass } from './EnumTypeComposer';
-export { ScalarTypeComposer as ScalarTypeComposerClass } from './ScalarTypeComposer';
-export { InterfaceTypeComposer as InterfaceTypeComposerClass } from './InterfaceTypeComposer';
-export { UnionTypeComposer as UnionTypeComposerClass } from './UnionTypeComposer';
-export { Resolver as ResolverClass } from './Resolver';
+export { ObjectTypeComposer, isComposeOutputType } from './ObjectTypeComposer';
+export { InputTypeComposer, isComposeInputType } from './InputTypeComposer';
+export { EnumTypeComposer } from './EnumTypeComposer';
+export { ScalarTypeComposer } from './ScalarTypeComposer';
+export { InterfaceTypeComposer } from './InterfaceTypeComposer';
+export { UnionTypeComposer } from './UnionTypeComposer';
+export { Resolver } from './Resolver';
 
 export { TypeStorage } from './TypeStorage';
+export { TypeMapper } from './TypeMapper';
 
 // Scalar types
 export { GraphQLDate, GraphQLBuffer, GraphQLGeneric, GraphQLJSON } from './type';
@@ -61,7 +56,7 @@ export type {
   ArgsMap,
   RelationArgsMapperFn,
   RelationArgsMapper,
-} from './TypeComposer';
+} from './ObjectTypeComposer';
 
 export type {
   ComposeInputType,

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,9 @@ import { SchemaComposer } from './SchemaComposer';
 
 export { graphql };
 
-const schemaComposer = new SchemaComposer<any>();
+type TContext = any;
+
+const schemaComposer = new SchemaComposer<TContext>();
 const sc = schemaComposer;
 export {
   SchemaComposer, // SchemaComposer class

--- a/src/index.js
+++ b/src/index.js
@@ -74,7 +74,7 @@ export type {
   RelationOpts,
   RelationOptsWithResolver,
   RelationOptsWithFieldConfig,
-  ArgsType,
+  ArgsMap,
   RelationArgsMapperFn,
   RelationArgsMapper,
 } from './TypeComposer';

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,8 @@ import { SchemaComposer } from './SchemaComposer';
 
 export { graphql };
 
-const schemaComposer: SchemaComposer<any> = new SchemaComposer();
+const schemaComposer = new SchemaComposer<any>();
+const sc = schemaComposer;
 const GQC = schemaComposer;
 const TypeComposer = schemaComposer.TypeComposer;
 const InputTypeComposer = schemaComposer.InputTypeComposer;
@@ -17,6 +18,7 @@ const Resolver = schemaComposer.Resolver;
 const TypeMapper = schemaComposer.typeMapper;
 export {
   // SchemaComposer default global instance (alias for schemaComposer)
+  sc,
   GQC,
   // SchemaComposer default global instance
   schemaComposer,

--- a/src/utils/__tests__/configAsThunk-test.js
+++ b/src/utils/__tests__/configAsThunk-test.js
@@ -1,7 +1,7 @@
 /* @flow strict */
 
 import { GraphQLString, GraphQLObjectType, GraphQLInputObjectType } from '../../graphql';
-import { TypeComposer, InputTypeComposer, schemaComposer } from '../..';
+import { schemaComposer } from '../..';
 import {
   resolveOutputConfigMapAsThunk,
   resolveInputConfigMapAsThunk,
@@ -31,7 +31,7 @@ describe('configAsThunk', () => {
           description: 'Field3',
         },
         f5: () => ({
-          type: TypeComposer.create('type LonLat { lon: Float, lat: Float}'),
+          type: schemaComposer.createObjectTC('type LonLat { lon: Float, lat: Float}'),
           description: 'Field5',
         }),
       };
@@ -73,7 +73,7 @@ describe('configAsThunk', () => {
           type: () => 'String',
         },
         f5: {
-          type: () => TypeComposer.create('type LonLat { lon: Float, lat: Float}'),
+          type: () => schemaComposer.createObjectTC('type LonLat { lon: Float, lat: Float}'),
           description: 'Field5',
         },
       };
@@ -152,7 +152,7 @@ describe('configAsThunk', () => {
           description: 'Field3',
         },
         f5: () => ({
-          type: InputTypeComposer.create('input LonLat { lon: Float, lat: Float}'),
+          type: schemaComposer.createInputTC('input LonLat { lon: Float, lat: Float}'),
           description: 'Field5',
         }),
       };
@@ -194,7 +194,7 @@ describe('configAsThunk', () => {
           type: () => 'String',
         },
         f5: {
-          type: () => InputTypeComposer.create('input LonLat { lon: Float, lat: Float}'),
+          type: () => schemaComposer.createInputTC('input LonLat { lon: Float, lat: Float}'),
           description: 'Field5',
         },
       };
@@ -258,7 +258,7 @@ describe('configAsThunk', () => {
           description: 'Field3',
         },
         f5: () => ({
-          type: InputTypeComposer.create('input LonLat { lon: Float, lat: Float}'),
+          type: schemaComposer.createInputTC('input LonLat { lon: Float, lat: Float}'),
           description: 'Field5',
         }),
       };
@@ -300,7 +300,7 @@ describe('configAsThunk', () => {
           type: () => 'String',
         },
         f5: {
-          type: () => InputTypeComposer.create('input LonLat { lon: Float, lat: Float}'),
+          type: () => schemaComposer.createInputTC('input LonLat { lon: Float, lat: Float}'),
           description: 'Field5',
         },
       };
@@ -350,7 +350,7 @@ describe('configAsThunk', () => {
           name: 'SubtypeAsGQL',
           fields: () => ({ a: { type: GraphQLString } }),
         }),
-        TypeComposer.create('type SubtypeAsTC { a: String }'),
+        schemaComposer.createObjectTC('type SubtypeAsTC { a: String }'),
         'type SubtypeAsSDL { name: Int }',
       ];
 

--- a/src/utils/__tests__/filterByDotPaths-test.js
+++ b/src/utils/__tests__/filterByDotPaths-test.js
@@ -1,6 +1,7 @@
 /* @flow strict */
 
-import filterByDotPaths, {
+import {
+  filterByDotPaths,
   isPresentInDotFilter,
   hideComplexValue,
   hideField,

--- a/src/utils/__tests__/projection-test.js
+++ b/src/utils/__tests__/projection-test.js
@@ -33,7 +33,7 @@ const Level1TC = schemaComposer.createObjectTC({
   },
 });
 const resolve = jest.fn(() => ({}));
-schemaComposer.rootQuery().addFields({ field0: { type: Level1TC, resolve } });
+schemaComposer.Query.addFields({ field0: { type: Level1TC, resolve } });
 const schema = schemaComposer.buildSchema();
 
 const getResolveInfo = async (query: string): Promise<GraphQLResolveInfo> => {

--- a/src/utils/__tests__/projection-test.js
+++ b/src/utils/__tests__/projection-test.js
@@ -3,9 +3,9 @@
 import { graphql } from '../../graphql';
 import type { GraphQLResolveInfo, GraphQLObjectType } from '../../graphql';
 import { getProjectionFromAST, extendByFieldProjection } from '../projection';
-import { TypeComposer, schemaComposer } from '../..';
+import { schemaComposer } from '../..';
 
-const Level2TC = TypeComposer.create({
+const Level2TC = schemaComposer.createObjectTC({
   name: 'Level2',
   fields: {
     field2a: 'String',
@@ -18,7 +18,7 @@ const Level2TC = TypeComposer.create({
     },
   },
 });
-const Level1TC = TypeComposer.create({
+const Level1TC = schemaComposer.createObjectTC({
   name: 'Level1',
   fields: {
     field1a: [Level2TC],

--- a/src/utils/__tests__/toInputObjectType-test.js
+++ b/src/utils/__tests__/toInputObjectType-test.js
@@ -8,17 +8,17 @@ import {
   GraphQLInt,
 } from '../../graphql';
 import { schemaComposer as sc } from '../..';
-import { TypeComposer } from '../../TypeComposer';
+import { ObjectTypeComposer } from '../../ObjectTypeComposer';
 import { InputTypeComposer } from '../../InputTypeComposer';
 import { InterfaceTypeComposer } from '../../InterfaceTypeComposer';
 import { toInputObjectType } from '../toInputObjectType';
 
 describe('toInputObjectType()', () => {
-  let PersonTC: TypeComposer<any, any>;
+  let PersonTC: ObjectTypeComposer<any, any>;
 
   beforeEach(() => {
     sc.clear();
-    PersonTC = TypeComposer.create(
+    PersonTC = ObjectTypeComposer.create(
       {
         name: 'Person',
         fields: {
@@ -107,7 +107,7 @@ describe('toInputObjectType()', () => {
     `,
       sc
     );
-    const tc = TypeComposer.create(
+    const tc = ObjectTypeComposer.create(
       `
       type Example implements IFace {
         name: String

--- a/src/utils/__tests__/toInputObjectType-test.js
+++ b/src/utils/__tests__/toInputObjectType-test.js
@@ -7,30 +7,36 @@ import {
   GraphQLList,
   GraphQLInt,
 } from '../../graphql';
-import { TypeComposer, InputTypeComposer, InterfaceTypeComposer, schemaComposer } from '../..';
+import { schemaComposer as sc } from '../..';
+import { TypeComposer } from '../../TypeComposer';
+import { InputTypeComposer } from '../../InputTypeComposer';
+import { InterfaceTypeComposer } from '../../InterfaceTypeComposer';
 import { toInputObjectType } from '../toInputObjectType';
 
 describe('toInputObjectType()', () => {
-  let PersonTC: TypeComposer;
+  let PersonTC: TypeComposer<any, any>;
 
   beforeEach(() => {
-    schemaComposer.clear();
-    PersonTC = TypeComposer.create({
-      name: 'Person',
-      fields: {
-        name: 'String',
-        age: { type: GraphQLInt },
-        address: {
-          type: new GraphQLObjectType({
-            name: 'Address',
-            fields: {
-              city: { type: GraphQLString },
-              street: { type: GraphQLString },
-            },
-          }),
+    sc.clear();
+    PersonTC = TypeComposer.create(
+      {
+        name: 'Person',
+        fields: {
+          name: 'String',
+          age: { type: GraphQLInt },
+          address: {
+            type: new GraphQLObjectType({
+              name: 'Address',
+              fields: {
+                city: { type: GraphQLString },
+                street: { type: GraphQLString },
+              },
+            }),
+          },
         },
       },
-    });
+      sc
+    );
   });
 
   it('should return InputTypeComposer', () => {
@@ -76,12 +82,15 @@ describe('toInputObjectType()', () => {
   });
 
   it('should convert InterfaceTypeComposer to InputTypeComposer', () => {
-    const iftc = InterfaceTypeComposer.create(`
+    const iftc = InterfaceTypeComposer.create(
+      `
       interface IFace {
         name: String
         age: Int
       }
-    `);
+    `,
+      sc
+    );
     const itc = toInputObjectType(iftc);
     expect(itc.getFieldType('name')).toBe(GraphQLString);
     expect(itc.getFieldType('age')).toBe(GraphQLInt);
@@ -89,19 +98,25 @@ describe('toInputObjectType()', () => {
   });
 
   it('should convert field with InterfaceType to InputType', () => {
-    InterfaceTypeComposer.create(`
+    InterfaceTypeComposer.create(
+      `
       interface IFace {
         name: String
         age: Int
       }
-    `);
-    const tc = TypeComposer.create(`
+    `,
+      sc
+    );
+    const tc = TypeComposer.create(
+      `
       type Example implements IFace {
         name: String
         age: Int
         neighbor: IFace
       }
-    `);
+    `,
+      sc
+    );
     const itc = toInputObjectType(tc);
     expect(itc.getFieldType('name')).toBe(GraphQLString);
     expect(itc.getFieldType('age')).toBe(GraphQLInt);

--- a/src/utils/__tests__/typeByPath-test.js
+++ b/src/utils/__tests__/typeByPath-test.js
@@ -2,19 +2,19 @@
 
 import { GraphQLString, GraphQLInt, GraphQLFloat } from '../../graphql';
 import { sc } from '../..';
-import { TypeComposer } from '../../TypeComposer';
+import { ObjectTypeComposer } from '../../ObjectTypeComposer';
 import { InputTypeComposer } from '../../InputTypeComposer';
 import { Resolver } from '../../Resolver';
 import { InterfaceTypeComposer } from '../../InterfaceTypeComposer';
 
 describe('typeByPath', () => {
-  const lonLatTC = TypeComposer.create('type LonLat { lon: Float, lat: Float }', sc);
+  const lonLatTC = ObjectTypeComposer.create('type LonLat { lon: Float, lat: Float }', sc);
   const spotITC = InputTypeComposer.create(
     'input SpotInput { lon: Float, lat: Float, distance: Float }',
     sc
   );
   spotITC.setField('subSpot', spotITC);
-  const tc = TypeComposer.create(
+  const tc = ObjectTypeComposer.create(
     {
       name: 'Place',
       fields: {
@@ -62,13 +62,13 @@ describe('typeByPath', () => {
     sc
   );
 
-  describe('for TypeComposer', () => {
+  describe('for ObjectTypeComposer', () => {
     it('should return field type', () => {
       expect(tc.get('title')).toBe(GraphQLString);
     });
 
     it('should return TypeCompose for complex type', () => {
-      expect(tc.get('lonLat')).toBeInstanceOf(TypeComposer);
+      expect(tc.get('lonLat')).toBeInstanceOf(ObjectTypeComposer);
       expect(tc.get('lonLat').getTypeName()).toBe('LonLat');
     });
 
@@ -98,7 +98,7 @@ describe('typeByPath', () => {
 
     it('should return same GraphQL type instances', () => {
       expect(tc.get('lonLat').getType()).toBeTruthy();
-      // via TypeComposer
+      // via ObjectTypeComposer
       expect(tc.get('lonLat').getType()).toBe(tc.get('lonLat').getType());
       // scalar type
       expect(tc.get('lonLat.lat')).toBe(tc.get('lonLat.lat'));
@@ -153,7 +153,7 @@ describe('typeByPath', () => {
     });
 
     it('should return TypeCompose for complex type', () => {
-      expect(ifc.get('lonLat')).toBeInstanceOf(TypeComposer);
+      expect(ifc.get('lonLat')).toBeInstanceOf(ObjectTypeComposer);
       expect(ifc.get('lonLat').getTypeName()).toBe('LonLat');
     });
 
@@ -168,7 +168,7 @@ describe('typeByPath', () => {
 
     it('should return same GraphQL type instances', () => {
       expect(ifc.get('lonLat').getType()).toBeTruthy();
-      // via TypeComposer
+      // via ObjectTypeComposer
       expect(ifc.get('lonLat').getType()).toBe(ifc.get('lonLat').getType());
       // scalar type
       expect(ifc.get('lonLat.lat')).toBe(ifc.get('lonLat.lat'));

--- a/src/utils/__tests__/typeByPath-test.js
+++ b/src/utils/__tests__/typeByPath-test.js
@@ -1,52 +1,66 @@
 /* @flow strict */
 
 import { GraphQLString, GraphQLInt, GraphQLFloat } from '../../graphql';
-import { TypeComposer, InputTypeComposer, Resolver, InterfaceTypeComposer } from '../..';
+import { sc } from '../..';
+import { TypeComposer } from '../../TypeComposer';
+import { InputTypeComposer } from '../../InputTypeComposer';
+import { Resolver } from '../../Resolver';
+import { InterfaceTypeComposer } from '../../InterfaceTypeComposer';
 
 describe('typeByPath', () => {
-  const lonLatTC = TypeComposer.create('type LonLat { lon: Float, lat: Float }');
+  const lonLatTC = TypeComposer.create('type LonLat { lon: Float, lat: Float }', sc);
   const spotITC = InputTypeComposer.create(
-    'input SpotInput { lon: Float, lat: Float, distance: Float }'
+    'input SpotInput { lon: Float, lat: Float, distance: Float }',
+    sc
   );
   spotITC.setField('subSpot', spotITC);
-  const tc = TypeComposer.create({
-    name: 'Place',
-    fields: {
-      title: 'String!',
-      lonLat: lonLatTC,
-      image: {
-        type: 'String',
-        args: {
-          size: 'Int',
+  const tc = TypeComposer.create(
+    {
+      name: 'Place',
+      fields: {
+        title: 'String!',
+        lonLat: lonLatTC,
+        image: {
+          type: 'String',
+          args: {
+            size: 'Int',
+          },
         },
+        points: '[LonLat]',
       },
-      points: '[LonLat]',
     },
-  });
-  const rsv = new Resolver({
-    name: 'findMany',
-    args: {
-      limit: 'Int',
-      search: 'String',
-      spot: spotITC,
+    sc
+  );
+  const rsv = new Resolver(
+    {
+      name: 'findMany',
+      args: {
+        limit: 'Int',
+        search: 'String',
+        spot: spotITC,
+      },
+      type: tc,
     },
-    type: tc,
-  });
+    sc
+  );
   tc.setResolver('findSpots', rsv);
-  const ifc = InterfaceTypeComposer.create({
-    name: 'Place',
-    fields: {
-      title: 'String!',
-      lonLat: lonLatTC,
-      image: {
-        type: 'String',
-        args: {
-          size: 'Int',
+  const ifc = InterfaceTypeComposer.create(
+    {
+      name: 'Place',
+      fields: {
+        title: 'String!',
+        lonLat: lonLatTC,
+        image: {
+          type: 'String',
+          args: {
+            size: 'Int',
+          },
         },
+        points: '[LonLat]',
       },
-      points: '[LonLat]',
     },
-  });
+    sc
+  );
 
   describe('for TypeComposer', () => {
     it('should return field type', () => {

--- a/src/utils/__tests__/typeHelpers-test.js
+++ b/src/utils/__tests__/typeHelpers-test.js
@@ -2,7 +2,7 @@
 
 import { getComposeTypeName } from '../typeHelpers';
 import { GraphQLObjectType, GraphQLInputObjectType } from '../../graphql';
-import { schemaComposer } from '../..';
+import { schemaComposer as sc } from '../..';
 
 describe('typeHelpers', () => {
   describe('getComposeTypeName()', () => {
@@ -32,10 +32,8 @@ describe('typeHelpers', () => {
     });
 
     it('understands compose types', () => {
-      expect(getComposeTypeName(schemaComposer.TypeComposer.create('TypeTC'))).toBe('TypeTC');
-      expect(getComposeTypeName(schemaComposer.InputTypeComposer.create('TypeITC'))).toBe(
-        'TypeITC'
-      );
+      expect(getComposeTypeName(sc.createObjectTC('TypeTC'))).toBe('TypeTC');
+      expect(getComposeTypeName(sc.createInputTC('TypeITC'))).toBe('TypeITC');
     });
   });
 });

--- a/src/utils/configAsThunk.js
+++ b/src/utils/configAsThunk.js
@@ -123,7 +123,7 @@ export function resolveArgConfigAsThunk(
 
 export function resolveArgConfigMapAsThunk(
   schema: SchemaComposer<any>,
-  argMap: ComposeFieldConfigArgumentMap,
+  argMap: ComposeFieldConfigArgumentMap<any>,
   fieldName?: string,
   typeName?: string
 ): GraphQLFieldConfigArgumentMap {

--- a/src/utils/configAsThunk.js
+++ b/src/utils/configAsThunk.js
@@ -18,7 +18,7 @@ import type {
   ComposeFieldConfigMap,
   ComposeArgumentConfig,
   ComposeFieldConfigArgumentMap,
-} from '../TypeComposer';
+} from '../ObjectTypeComposer';
 import type { ComposeObjectType } from '../TypeMapper';
 import type { Thunk } from './definitions';
 

--- a/src/utils/definitions.js
+++ b/src/utils/definitions.js
@@ -1,9 +1,6 @@
 /* @flow strict */
 
 export type ObjMap<T> = { [key: string]: T, __proto__: null };
-
 export type Thunk<+T> = (() => T) | T;
-
 export type Extensions = { [key: string]: any };
-
 export type MaybePromise<+T> = Promise<T> | T;

--- a/src/utils/deprecate.d.ts
+++ b/src/utils/deprecate.d.ts
@@ -1,0 +1,1 @@
+export default function deprecate(msg: string): void;

--- a/src/utils/deprecate.js
+++ b/src/utils/deprecate.js
@@ -1,6 +1,6 @@
 /* @flow strict */
 
-export function deprecate(msg: string) {
+export default function deprecate(msg: string) {
   let stack;
   let stackStr = '';
   const error = new Error();

--- a/src/utils/deprecate.js
+++ b/src/utils/deprecate.js
@@ -7,7 +7,10 @@ export default function deprecate(msg: string) {
 
   if (error.stack) {
     stack = error.stack.replace(/^\s+at\s+/gm, '').split('\n');
-    stackStr = `\n    ${stack.slice(2, 7).join('\n    ')}`;
+    stack.slice(2, 7).forEach((s, i) => {
+      stackStr += i === 1 ? '\n--> ' : '\n    ';
+      stackStr += s;
+    });
   }
 
   // eslint-disable-next-line

--- a/src/utils/filterByDotPaths.d.ts
+++ b/src/utils/filterByDotPaths.d.ts
@@ -5,8 +5,17 @@ export interface FilterOpts {
 
 export type PathsFilter = string | string[];
 
-export default function filterByDotPaths(
+export function filterByDotPaths(
   obj: object,
   pathsFilter: PathsFilter | null,
   opts?: FilterOpts,
 ): object;
+
+export function preparePathsFilter(
+  pathsFilter?: PathsFilter | null,
+): string[] | null;
+
+export function isPresentInDotFilter(
+  name: string,
+  pathsFilter: string | string[] | null,
+): boolean;

--- a/src/utils/filterByDotPaths.js
+++ b/src/utils/filterByDotPaths.js
@@ -10,7 +10,7 @@ type FilterOpts = {
 
 type PathsFilter = string | string[];
 
-export default function filterByDotPaths(
+export function filterByDotPaths(
   obj: Object,
   pathsFilter: ?PathsFilter,
   opts?: FilterOpts

--- a/src/utils/misc.js
+++ b/src/utils/misc.js
@@ -1,7 +1,7 @@
 /* @flow strict */
 /* eslint-disable no-nested-ternary */
 
-import pluralize from './pluralize';
+import { pluralize } from './pluralize';
 import type { Thunk } from './definitions';
 
 export function resolveMaybeThunk<+T>(thingOrThunk: Thunk<T>): T {

--- a/src/utils/pluralize.d.ts
+++ b/src/utils/pluralize.d.ts
@@ -1,0 +1,1 @@
+export function pluralize(str: string): string;

--- a/src/utils/pluralize.js
+++ b/src/utils/pluralize.js
@@ -55,7 +55,7 @@ const uncountables = [
   'media',
 ];
 
-function pluralize(str: string): string {
+export function pluralize(str: string): string {
   let found;
   // eslint-disable-next-line
   if (!~uncountables.indexOf(str.toLowerCase())) {
@@ -66,5 +66,3 @@ function pluralize(str: string): string {
   }
   return str;
 }
-
-export default pluralize;

--- a/src/utils/projection.d.ts
+++ b/src/utils/projection.d.ts
@@ -7,8 +7,8 @@ import {
 } from 'graphql';
 
 export type ProjectionNode = { [fieldName: string]: any };
-export type ProjectionType<TSource = any> = {
-  [fieldName in keyof TSource]: any
+export type ProjectionType = {
+  [fieldName: string]: any;
 };
 
 export function getProjectionFromAST(

--- a/src/utils/toInputObjectType.d.ts
+++ b/src/utils/toInputObjectType.d.ts
@@ -1,6 +1,6 @@
 import { GraphQLType, GraphQLInputType, GraphQLObjectType } from '../graphql';
 import { InputTypeComposer } from '../InputTypeComposer';
-import { TypeComposer } from '../TypeComposer';
+import { ObjectTypeComposer } from '../ObjectTypeComposer';
 import { InterfaceTypeComposer } from '../InterfaceTypeComposer';
 import { SchemaComposer } from '../SchemaComposer';
 
@@ -10,7 +10,7 @@ export interface ToInputObjectTypeOpts {
 }
 
 export function toInputObjectType(
-  typeComposer: TypeComposer<any, any> | InterfaceTypeComposer<any, any>,
+  tc: ObjectTypeComposer<any, any> | InterfaceTypeComposer<any, any>,
   opts?: ToInputObjectTypeOpts,
 ): InputTypeComposer;
 

--- a/src/utils/toInputObjectType.d.ts
+++ b/src/utils/toInputObjectType.d.ts
@@ -1,6 +1,7 @@
 import { GraphQLType, GraphQLInputType, GraphQLObjectType } from '../graphql';
 import { InputTypeComposer } from '../InputTypeComposer';
 import { TypeComposer } from '../TypeComposer';
+import { InterfaceTypeComposer } from '../InterfaceTypeComposer';
 import { SchemaComposer } from '../SchemaComposer';
 
 export interface ToInputObjectTypeOpts {
@@ -9,7 +10,7 @@ export interface ToInputObjectTypeOpts {
 }
 
 export function toInputObjectType(
-  typeComposer: TypeComposer<any, any>,
+  typeComposer: TypeComposer<any, any> | InterfaceTypeComposer<any, any>,
   opts?: ToInputObjectTypeOpts,
 ): InputTypeComposer;
 
@@ -24,4 +25,4 @@ export function convertInputObjectField(
   field: GraphQLType,
   opts: ConvertInputObjectFieldOpts,
   schemaComposer: SchemaComposer<any>,
-): GraphQLInputType;
+): GraphQLInputType | null;

--- a/src/utils/toInputObjectType.d.ts
+++ b/src/utils/toInputObjectType.d.ts
@@ -9,10 +9,10 @@ export interface ToInputObjectTypeOpts {
   postfix?: string;
 }
 
-export function toInputObjectType(
-  tc: ObjectTypeComposer<any, any> | InterfaceTypeComposer<any, any>,
+export function toInputObjectType<TContext>(
+  tc: ObjectTypeComposer<any, TContext> | InterfaceTypeComposer<any, TContext>,
   opts?: ToInputObjectTypeOpts,
-): InputTypeComposer;
+): InputTypeComposer<TContext>;
 
 export interface ConvertInputObjectFieldOpts {
   prefix?: string;

--- a/src/utils/toInputObjectType.js
+++ b/src/utils/toInputObjectType.js
@@ -10,7 +10,7 @@ import {
   GraphQLList,
   GraphQLNonNull,
 } from '../graphql';
-import { TypeComposer } from '../TypeComposer';
+import { ObjectTypeComposer } from '../ObjectTypeComposer';
 import type { InterfaceTypeComposer } from '../InterfaceTypeComposer';
 import type { InputTypeComposer } from '../InputTypeComposer';
 import type { SchemaComposer } from '../SchemaComposer';
@@ -23,7 +23,7 @@ export type toInputObjectTypeOpts = {
 };
 
 export function toInputObjectType(
-  tc: TypeComposer<any, any> | InterfaceTypeComposer<any, any>,
+  tc: ObjectTypeComposer<any, any> | InterfaceTypeComposer<any, any>,
   opts: toInputObjectTypeOpts = {}
 ): InputTypeComposer {
   if (tc.hasInputTypeComposer()) {

--- a/src/utils/toInputObjectType.js
+++ b/src/utils/toInputObjectType.js
@@ -22,10 +22,10 @@ export type toInputObjectTypeOpts = {
   postfix?: string,
 };
 
-export function toInputObjectType(
-  tc: ObjectTypeComposer<any, any> | InterfaceTypeComposer<any, any>,
+export function toInputObjectType<TContext>(
+  tc: ObjectTypeComposer<any, TContext> | InterfaceTypeComposer<any, TContext>,
   opts: toInputObjectTypeOpts = {}
-): InputTypeComposer {
+): InputTypeComposer<TContext> {
   if (tc.hasInputTypeComposer()) {
     return tc.getInputTypeComposer();
   }
@@ -73,7 +73,7 @@ export type ConvertInputObjectFieldOpts = {
 export function convertInputObjectField(
   field: GraphQLType,
   opts: ConvertInputObjectFieldOpts,
-  sc: SchemaComposer<any>
+  schemaComposer: SchemaComposer<any>
 ): ?GraphQLInputType {
   let fieldType = field;
 
@@ -95,8 +95,8 @@ export function convertInputObjectField(
       };
       const tc =
         fieldType instanceof GraphQLObjectType
-          ? sc.createObjectTC(fieldType)
-          : sc.createInterfaceTC(fieldType);
+          ? schemaComposer.createObjectTC(fieldType)
+          : schemaComposer.createInterfaceTC(fieldType);
       fieldType = toInputObjectType(tc, typeOpts).getType();
     } else {
       // eslint-disable-next-line

--- a/src/utils/toInputObjectType.js
+++ b/src/utils/toInputObjectType.js
@@ -35,7 +35,7 @@ export function toInputObjectType(
 
   const inputTypeName = `${prefix}${tc.getTypeName()}${postfix}`;
 
-  const inputTypeComposer = tc.sc.createInputTC({
+  const inputTypeComposer = tc.schemaComposer.createInputTC({
     name: inputTypeName,
     fields: {},
   });
@@ -50,7 +50,7 @@ export function toInputObjectType(
       outputTypeName: tc.getTypeName(),
     };
     const fc = tc.getFieldConfig(fieldName);
-    const inputType = convertInputObjectField(fc.type, fieldOpts, tc.sc);
+    const inputType = convertInputObjectField(fc.type, fieldOpts, tc.schemaComposer);
     if (inputType) {
       inputFields[fieldName] = {
         type: inputType,

--- a/src/utils/toInputObjectType.js
+++ b/src/utils/toInputObjectType.js
@@ -24,7 +24,7 @@ export type toInputObjectTypeOpts = {
 };
 
 export function toInputObjectType(
-  typeComposer: TypeComposer<any> | InterfaceTypeComposer<any>,
+  typeComposer: TypeComposer<any, any> | InterfaceTypeComposer<any, any>,
   opts: toInputObjectTypeOpts = {}
 ): InputTypeComposer {
   if (typeComposer.hasInputTypeComposer()) {

--- a/src/utils/typeByPath.js
+++ b/src/utils/typeByPath.js
@@ -3,8 +3,7 @@
 
 import { GraphQLObjectType, GraphQLInputObjectType, getNamedType } from '../graphql';
 import type { GraphQLInputType, GraphQLOutputType } from '../graphql';
-// import { deprecate } from './debug';
-import { TypeComposer } from '../TypeComposer';
+import { ObjectTypeComposer } from '../ObjectTypeComposer';
 import { InputTypeComposer } from '../InputTypeComposer';
 import { InterfaceTypeComposer } from '../InterfaceTypeComposer';
 import { UnionTypeComposer } from '../UnionTypeComposer';
@@ -18,7 +17,7 @@ import type { SchemaComposer } from '../SchemaComposer';
  */
 export function typeByPath(
   src:
-    | TypeComposer<any, any>
+    | ObjectTypeComposer<any, any>
     | InputTypeComposer
     | Resolver<any, any, any>
     | InterfaceTypeComposer<any, any>
@@ -31,7 +30,7 @@ export function typeByPath(
     return src;
   }
 
-  if (src instanceof TypeComposer) {
+  if (src instanceof ObjectTypeComposer) {
     return typeByPathTC(src, parts);
   } else if (src instanceof InputTypeComposer) {
     return typeByPathITC(src, parts);
@@ -44,7 +43,7 @@ export function typeByPath(
   return src;
 }
 
-export function typeByPathTC(tc: TypeComposer<any, any>, parts: Array<string>) {
+export function typeByPathTC(tc: ObjectTypeComposer<any, any>, parts: Array<string>) {
   if (!tc) return undefined;
   if (parts.length === 0) return tc;
 
@@ -128,7 +127,7 @@ export function processType(
   const unwrappedType = getNamedType(type);
 
   if (unwrappedType instanceof GraphQLObjectType) {
-    const tc = new TypeComposer(unwrappedType, schema);
+    const tc = new ObjectTypeComposer(unwrappedType, schema);
     if (restParts.length > 0) {
       return typeByPathTC(tc, restParts);
     }

--- a/src/utils/typeByPath.js
+++ b/src/utils/typeByPath.js
@@ -97,12 +97,6 @@ function typeByPathRSV(rsv: Resolver<any, any, any>, parts: Array<string>) {
   return processType(rsv.getType(), parts, rsv.constructor.schemaComposer);
 }
 
-/** @deprecated 6.0.0 */
-export function typeByPathFTC(tc: InterfaceTypeComposer<any, any>, parts: Array<string>) {
-  deprecate('Use `typeByPathIFTC()` method instead');
-  return typeByPathIFTC(tc, parts);
-}
-
 export function typeByPathIFTC(tc: InterfaceTypeComposer<any, any>, parts: Array<string>) {
   if (!tc) return undefined;
   if (parts.length === 0) return tc;

--- a/src/utils/typeByPath.js
+++ b/src/utils/typeByPath.js
@@ -3,7 +3,7 @@
 
 import { GraphQLObjectType, GraphQLInputObjectType, getNamedType } from '../graphql';
 import type { GraphQLInputType, GraphQLOutputType } from '../graphql';
-import { deprecate } from './debug';
+// import { deprecate } from './debug';
 import { TypeComposer } from '../TypeComposer';
 import { InputTypeComposer } from '../InputTypeComposer';
 import { InterfaceTypeComposer } from '../InterfaceTypeComposer';

--- a/src/utils/typeByPath.js
+++ b/src/utils/typeByPath.js
@@ -66,11 +66,11 @@ export function typeByPathTC(tc: TypeComposer<any, any>, parts: Array<string>) {
 
   if (nextName && nextName.startsWith('@')) {
     const argType = tc.getFieldArgType(name, nextName.substring(1));
-    return processType(argType, parts.slice(2), tc.constructor.schemaComposer);
+    return processType(argType, parts.slice(2), tc.sc);
   }
 
   const fieldType = tc.getFieldType(name);
-  return processType(fieldType, parts.slice(1), tc.constructor.schemaComposer);
+  return processType(fieldType, parts.slice(1), tc.sc);
 }
 
 export function typeByPathITC(itc: InputTypeComposer, parts: Array<string>) {
@@ -78,7 +78,7 @@ export function typeByPathITC(itc: InputTypeComposer, parts: Array<string>) {
   if (parts.length === 0) return itc;
 
   const fieldType = itc.getFieldType(parts[0]);
-  return processType(fieldType, parts.slice(1), itc.constructor.schemaComposer);
+  return processType(fieldType, parts.slice(1), itc.sc);
 }
 
 function typeByPathRSV(rsv: Resolver<any, any, any>, parts: Array<string>) {
@@ -91,10 +91,10 @@ function typeByPathRSV(rsv: Resolver<any, any, any>, parts: Array<string>) {
     const argName = name.substring(1);
     const arg = rsv.getArg(argName);
     if (!arg) return undefined;
-    return processType(rsv.getArgType(argName), parts.slice(1), rsv.constructor.schemaComposer);
+    return processType(rsv.getArgType(argName), parts.slice(1), rsv.sc);
   }
 
-  return processType(rsv.getType(), parts, rsv.constructor.schemaComposer);
+  return processType(rsv.getType(), parts, rsv.sc);
 }
 
 export function typeByPathIFTC(tc: InterfaceTypeComposer<any, any>, parts: Array<string>) {
@@ -112,11 +112,11 @@ export function typeByPathIFTC(tc: InterfaceTypeComposer<any, any>, parts: Array
 
   if (nextName && nextName.startsWith('@')) {
     const argType = tc.getFieldArgType(name, nextName.substring(1));
-    return processType(argType, parts.slice(2), tc.constructor.schemaComposer);
+    return processType(argType, parts.slice(2), tc.sc);
   }
 
   const fieldType = tc.getFieldType(name);
-  return processType(fieldType, parts.slice(1), tc.constructor.schemaComposer);
+  return processType(fieldType, parts.slice(1), tc.sc);
 }
 
 export function processType(
@@ -128,13 +128,13 @@ export function processType(
   const unwrappedType = getNamedType(type);
 
   if (unwrappedType instanceof GraphQLObjectType) {
-    const tc = new schema.TypeComposer(unwrappedType);
+    const tc = new TypeComposer(unwrappedType, schema);
     if (restParts.length > 0) {
       return typeByPathTC(tc, restParts);
     }
     return tc;
   } else if (unwrappedType instanceof GraphQLInputObjectType) {
-    const itc = new schema.InputTypeComposer(unwrappedType);
+    const itc = new InputTypeComposer(unwrappedType, schema);
     if (restParts.length > 0) {
       return typeByPathITC(itc, restParts);
     }

--- a/src/utils/typeByPath.js
+++ b/src/utils/typeByPath.js
@@ -18,7 +18,7 @@ import type { SchemaComposer } from '../SchemaComposer';
 export function typeByPath(
   src:
     | ObjectTypeComposer<any, any>
-    | InputTypeComposer
+    | InputTypeComposer<any>
     | Resolver<any, any, any>
     | InterfaceTypeComposer<any, any>
     | UnionTypeComposer<any, any>,
@@ -72,7 +72,7 @@ export function typeByPathTC(tc: ObjectTypeComposer<any, any>, parts: Array<stri
   return processType(fieldType, parts.slice(1), tc.schemaComposer);
 }
 
-export function typeByPathITC(itc: InputTypeComposer, parts: Array<string>) {
+export function typeByPathITC(itc: InputTypeComposer<any>, parts: Array<string>) {
   if (!itc) return undefined;
   if (parts.length === 0) return itc;
 

--- a/src/utils/typeByPath.js
+++ b/src/utils/typeByPath.js
@@ -18,11 +18,11 @@ import type { SchemaComposer } from '../SchemaComposer';
  */
 export function typeByPath(
   src:
-    | TypeComposer<any>
+    | TypeComposer<any, any>
     | InputTypeComposer
-    | Resolver<any, any>
-    | InterfaceTypeComposer<any>
-    | UnionTypeComposer<any>,
+    | Resolver<any, any, any>
+    | InterfaceTypeComposer<any, any>
+    | UnionTypeComposer<any, any>,
   path: string | Array<string>
 ) {
   const parts = Array.isArray(path) ? path : String(path).split('.');
@@ -44,7 +44,7 @@ export function typeByPath(
   return src;
 }
 
-export function typeByPathTC(tc: TypeComposer<any>, parts: Array<string>) {
+export function typeByPathTC(tc: TypeComposer<any, any>, parts: Array<string>) {
   if (!tc) return undefined;
   if (parts.length === 0) return tc;
 
@@ -81,7 +81,7 @@ export function typeByPathITC(itc: InputTypeComposer, parts: Array<string>) {
   return processType(fieldType, parts.slice(1), itc.constructor.schemaComposer);
 }
 
-function typeByPathRSV(rsv: Resolver<any, any>, parts: Array<string>) {
+function typeByPathRSV(rsv: Resolver<any, any, any>, parts: Array<string>) {
   if (!rsv) return undefined;
   if (parts.length === 0) return rsv;
   const name = parts[0];
@@ -98,12 +98,12 @@ function typeByPathRSV(rsv: Resolver<any, any>, parts: Array<string>) {
 }
 
 /** @deprecated 6.0.0 */
-export function typeByPathFTC(tc: InterfaceTypeComposer<any>, parts: Array<string>) {
+export function typeByPathFTC(tc: InterfaceTypeComposer<any, any>, parts: Array<string>) {
   deprecate('Use `typeByPathIFTC()` method instead');
   return typeByPathIFTC(tc, parts);
 }
 
-export function typeByPathIFTC(tc: InterfaceTypeComposer<any>, parts: Array<string>) {
+export function typeByPathIFTC(tc: InterfaceTypeComposer<any, any>, parts: Array<string>) {
   if (!tc) return undefined;
   if (parts.length === 0) return tc;
 

--- a/src/utils/typeByPath.js
+++ b/src/utils/typeByPath.js
@@ -65,11 +65,11 @@ export function typeByPathTC(tc: ObjectTypeComposer<any, any>, parts: Array<stri
 
   if (nextName && nextName.startsWith('@')) {
     const argType = tc.getFieldArgType(name, nextName.substring(1));
-    return processType(argType, parts.slice(2), tc.sc);
+    return processType(argType, parts.slice(2), tc.schemaComposer);
   }
 
   const fieldType = tc.getFieldType(name);
-  return processType(fieldType, parts.slice(1), tc.sc);
+  return processType(fieldType, parts.slice(1), tc.schemaComposer);
 }
 
 export function typeByPathITC(itc: InputTypeComposer, parts: Array<string>) {
@@ -77,7 +77,7 @@ export function typeByPathITC(itc: InputTypeComposer, parts: Array<string>) {
   if (parts.length === 0) return itc;
 
   const fieldType = itc.getFieldType(parts[0]);
-  return processType(fieldType, parts.slice(1), itc.sc);
+  return processType(fieldType, parts.slice(1), itc.schemaComposer);
 }
 
 function typeByPathRSV(rsv: Resolver<any, any, any>, parts: Array<string>) {
@@ -90,10 +90,10 @@ function typeByPathRSV(rsv: Resolver<any, any, any>, parts: Array<string>) {
     const argName = name.substring(1);
     const arg = rsv.getArg(argName);
     if (!arg) return undefined;
-    return processType(rsv.getArgType(argName), parts.slice(1), rsv.sc);
+    return processType(rsv.getArgType(argName), parts.slice(1), rsv.schemaComposer);
   }
 
-  return processType(rsv.getType(), parts, rsv.sc);
+  return processType(rsv.getType(), parts, rsv.schemaComposer);
 }
 
 export function typeByPathIFTC(tc: InterfaceTypeComposer<any, any>, parts: Array<string>) {
@@ -111,11 +111,11 @@ export function typeByPathIFTC(tc: InterfaceTypeComposer<any, any>, parts: Array
 
   if (nextName && nextName.startsWith('@')) {
     const argType = tc.getFieldArgType(name, nextName.substring(1));
-    return processType(argType, parts.slice(2), tc.sc);
+    return processType(argType, parts.slice(2), tc.schemaComposer);
   }
 
   const fieldType = tc.getFieldType(name);
-  return processType(fieldType, parts.slice(1), tc.sc);
+  return processType(fieldType, parts.slice(1), tc.schemaComposer);
 }
 
 export function processType(

--- a/src/utils/typeHelpers.js
+++ b/src/utils/typeHelpers.js
@@ -6,7 +6,7 @@ import { inspect } from './misc';
 export function getGraphQLType(anyType: mixed): GraphQLType {
   let type = (anyType: any);
 
-  // extract type from TypeComposer, InputTypeComposer, EnumTypeComposer and Resolver
+  // extract type from ObjectTypeComposer, InputTypeComposer, EnumTypeComposer and Resolver
   if (type && isFunction(type.getType)) {
     type = type.getType();
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2850,10 +2850,10 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
-flow-bin@0.91.0:
-  version "0.91.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.91.0.tgz#f5c89729f74b2ccbd47df6fbfadbdcc89cc1e478"
-  integrity sha512-j+L+xNiUYnZZ27MjVI0y2c9474ZHOvdSQq0Tjwh56mEA7tfxYqp5Dcb6aZSwvs3tGMTjCrZow9aUlZf3OoRyDQ==
+flow-bin@0.94.0:
+  version "0.94.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.94.0.tgz#b5d58fe7559705b73a18229f97edfc3ab6ffffcb"
+  integrity sha512-DYF7r9CJ/AksfmmB4+q+TyLMoeQPRnqtF1Pk7KY3zgfkB/nVuA3nXyzqgsIPIvnMSiFEXQcFK4z+iPxSLckZhQ==
 
 flush-write-stream@^1.0.0:
   version "1.0.3"


### PR DESCRIPTION
BREAKING CHANGE: Most TypeComposers get `TSource` generic which may cause errors on static analysis. Updating to this version may require to fix definitions in your code.

- [x] remove deprecated methods
- [x] check with graphql-compose-mongoose
- [x] check with graphql-compose-relay
- [x] check with graphql-compose-json
- [x] check with graphql-compose-connection
- [x] check with graphql-compose-pagination
- [x] check with graphql-compose-elasticsearch
- [x] check with graphql-compose-aws
- [x] sync TypeScript definitions