### PR TITLE
Extend field extensions in extendField

### DIFF
--- a/src/InputTypeComposer.d.ts
+++ b/src/InputTypeComposer.d.ts
@@ -117,7 +117,7 @@ export class InputTypeComposer<TContext = any> {
 
   public extendField(
     fieldName: string,
-    parialFieldConfig: Partial<ComposeInputFieldConfig>,
+    partialFieldConfig: Partial<ComposeInputFieldConfig>,
   ): this;
 
   public reorderFields(names: string[]): this;

--- a/src/InputTypeComposer.js
+++ b/src/InputTypeComposer.js
@@ -300,7 +300,7 @@ export class InputTypeComposer<TContext> {
   ): InputTypeComposer<TContext> {
     let prevFieldConfig;
     try {
-      prevFieldConfig = this.getFieldConfig(fieldName);
+      prevFieldConfig = (this.getFieldConfig(fieldName): any);
     } catch (e) {
       throw new Error(
         `Cannot extend field '${fieldName}' from input type '${this.getTypeName()}'. Field does not exist.`
@@ -308,7 +308,7 @@ export class InputTypeComposer<TContext> {
     }
 
     this.setField(fieldName, {
-      ...(prevFieldConfig: any),
+      ...prevFieldConfig,
       ...partialFieldConfig,
       extensions: {
         ...(prevFieldConfig.extensions || {}),

--- a/src/InputTypeComposer.js
+++ b/src/InputTypeComposer.js
@@ -296,7 +296,7 @@ export class InputTypeComposer<TContext> {
 
   extendField(
     fieldName: string,
-    parialFieldConfig: $Shape<ComposeInputFieldConfigAsObject>
+    partialFieldConfig: $Shape<ComposeInputFieldConfigAsObject>
   ): InputTypeComposer<TContext> {
     let prevFieldConfig;
     try {
@@ -308,8 +308,12 @@ export class InputTypeComposer<TContext> {
     }
 
     this.setField(fieldName, {
-      ...prevFieldConfig,
-      ...parialFieldConfig,
+      ...(prevFieldConfig: any),
+      ...partialFieldConfig,
+      extensions: {
+        ...(prevFieldConfig.extensions || {}),
+        ...(partialFieldConfig.extensions || {}),
+      },
     });
     return this;
   }
@@ -524,7 +528,9 @@ export class InputTypeComposer<TContext> {
   }
 
   setFieldExtensions(fieldName: string, extensions: Extensions): InputTypeComposer<TContext> {
-    this.extendField(fieldName, {
+    const fieldConfig = this.getFieldConfig(fieldName);
+    this.setField(fieldName, {
+      ...fieldConfig,
       extensions,
     });
     return this;

--- a/src/InterfaceTypeComposer.js
+++ b/src/InterfaceTypeComposer.js
@@ -280,7 +280,7 @@ export class InterfaceTypeComposer<TSource, TContext> {
   ): InterfaceTypeComposer<TSource, TContext> {
     let prevFieldConfig;
     try {
-      prevFieldConfig = this.getFieldConfig(fieldName);
+      prevFieldConfig = (this.getFieldConfig(fieldName): any);
     } catch (e) {
       throw new Error(
         `Cannot extend field '${fieldName}' from type '${this.getTypeName()}'. Field does not exist.`
@@ -288,7 +288,7 @@ export class InterfaceTypeComposer<TSource, TContext> {
     }
 
     this.setField(fieldName, {
-      ...(prevFieldConfig: any),
+      ...prevFieldConfig,
       ...partialFieldConfig,
       extensions: {
         ...(prevFieldConfig.extensions || {}),
@@ -759,10 +759,13 @@ export class InterfaceTypeComposer<TSource, TContext> {
     extensions: Extensions
   ): InterfaceTypeComposer<TSource, TContext> {
     const fieldConfig = this.getFieldConfig(fieldName);
-    this.setField(fieldName, {
-      ...fieldConfig,
-      extensions,
-    });
+    this.setField(
+      fieldName,
+      ({
+        ...fieldConfig,
+        extensions,
+      }: any)
+    );
     return this;
   }
 

--- a/src/InterfaceTypeComposer.js
+++ b/src/InterfaceTypeComposer.js
@@ -276,7 +276,7 @@ export class InterfaceTypeComposer<TSource, TContext> {
 
   extendField(
     fieldName: string,
-    parialFieldConfig: $Shape<ComposeFieldConfigAsObject<TSource, TContext, any>>
+    partialFieldConfig: $Shape<ComposeFieldConfigAsObject<TSource, TContext, any>>
   ): InterfaceTypeComposer<TSource, TContext> {
     let prevFieldConfig;
     try {
@@ -289,7 +289,11 @@ export class InterfaceTypeComposer<TSource, TContext> {
 
     this.setField(fieldName, {
       ...(prevFieldConfig: any),
-      ...parialFieldConfig,
+      ...partialFieldConfig,
+      extensions: {
+        ...(prevFieldConfig.extensions || {}),
+        ...(partialFieldConfig.extensions || {}),
+      },
     });
     return this;
   }
@@ -754,7 +758,9 @@ export class InterfaceTypeComposer<TSource, TContext> {
     fieldName: string,
     extensions: Extensions
   ): InterfaceTypeComposer<TSource, TContext> {
-    this.extendField(fieldName, {
+    const fieldConfig = this.getFieldConfig(fieldName);
+    this.setField(fieldName, {
+      ...fieldConfig,
       extensions,
     });
     return this;

--- a/src/ObjectTypeComposer.js
+++ b/src/ObjectTypeComposer.js
@@ -438,7 +438,7 @@ export class ObjectTypeComposer<TSource, TContext> {
   ): ObjectTypeComposer<TSource, TContext> {
     let prevFieldConfig;
     try {
-      prevFieldConfig = this.getFieldConfig(fieldName);
+      prevFieldConfig = (this.getFieldConfig(fieldName): any);
     } catch (e) {
       throw new Error(
         `Cannot extend field '${fieldName}' from type '${this.getTypeName()}'. Field does not exist.`
@@ -446,7 +446,7 @@ export class ObjectTypeComposer<TSource, TContext> {
     }
 
     this.setField(fieldName, {
-      ...(prevFieldConfig: any),
+      ...prevFieldConfig,
       ...partialFieldConfig,
       extensions: {
         ...(prevFieldConfig.extensions || {}),
@@ -973,10 +973,13 @@ export class ObjectTypeComposer<TSource, TContext> {
     extensions: Extensions
   ): ObjectTypeComposer<TSource, TContext> {
     const fieldConfig = this.getFieldConfig(fieldName);
-    this.setField(fieldName, {
-      ...fieldConfig,
-      extensions,
-    });
+    this.setField(
+      fieldName,
+      ({
+        ...fieldConfig,
+        extensions,
+      }: any)
+    );
     return this;
   }
 

--- a/src/ObjectTypeComposer.js
+++ b/src/ObjectTypeComposer.js
@@ -448,6 +448,10 @@ export class ObjectTypeComposer<TSource, TContext> {
     this.setField(fieldName, {
       ...(prevFieldConfig: any),
       ...partialFieldConfig,
+      extensions: {
+        ...(prevFieldConfig.extensions || {}),
+        ...(partialFieldConfig.extensions || {}),
+      },
     });
     return this;
   }
@@ -968,7 +972,9 @@ export class ObjectTypeComposer<TSource, TContext> {
     fieldName: string,
     extensions: Extensions
   ): ObjectTypeComposer<TSource, TContext> {
-    this.extendField(fieldName, {
+    const fieldConfig = this.getFieldConfig(fieldName);
+    this.setField(fieldName, {
+      ...fieldConfig,
       extensions,
     });
     return this;

--- a/src/__tests__/InputTypeComposer-test.js
+++ b/src/__tests__/InputTypeComposer-test.js
@@ -214,6 +214,7 @@ describe('InputTypeComposer', () => {
           description: 'this is field #3',
           extensions: { second: true },
         });
+        // $FlowFixMe
         expect(itc.getFieldConfig('input3').extensions).toEqual({
           first: true,
           second: true,

--- a/src/__tests__/InputTypeComposer-test.js
+++ b/src/__tests__/InputTypeComposer-test.js
@@ -205,6 +205,21 @@ describe('InputTypeComposer', () => {
         expect(itc.getFieldConfig('input3').type).toBe(GraphQLInt);
       });
 
+      it('should extend field extensions', () => {
+        itc.setField('input3', {
+          type: GraphQLString,
+          extensions: { first: true },
+        });
+        itc.extendField('input3', {
+          description: 'this is field #3',
+          extensions: { second: true },
+        });
+        expect(itc.getFieldConfig('input3').extensions).toEqual({
+          first: true,
+          second: true,
+        });
+      });
+
       it('should work with fieldConfig as string', () => {
         itc.setField('field4', 'String');
         itc.extendField('field4', {

--- a/src/__tests__/InterfaceTypeComposer-test.js
+++ b/src/__tests__/InterfaceTypeComposer-test.js
@@ -249,6 +249,21 @@ describe('InterfaceTypeComposer', () => {
         expect(iftc.getFieldType('field3')).toBe(GraphQLInt);
       });
 
+      it('should extend field extensions', () => {
+        iftc.setField('field3', {
+          type: GraphQLString,
+          extensions: { first: true },
+        });
+        iftc.extendField('field3', {
+          description: 'this is field #3',
+          extensions: { second: true },
+        });
+        expect(iftc.getFieldConfig('field3').extensions).toEqual({
+          first: true,
+          second: true,
+        });
+      });
+
       it('should work with fieldConfig as string', () => {
         iftc.setField('field4', 'String');
         iftc.extendField('field4', {

--- a/src/__tests__/InterfaceTypeComposer-test.js
+++ b/src/__tests__/InterfaceTypeComposer-test.js
@@ -258,6 +258,7 @@ describe('InterfaceTypeComposer', () => {
           description: 'this is field #3',
           extensions: { second: true },
         });
+        // $FlowFixMe
         expect(iftc.getFieldConfig('field3').extensions).toEqual({
           first: true,
           second: true,

--- a/src/__tests__/ObjectTypeComposer-test.js
+++ b/src/__tests__/ObjectTypeComposer-test.js
@@ -278,6 +278,7 @@ describe('ObjectTypeComposer', () => {
           description: 'this is field #3',
           extensions: { second: true },
         });
+        // $FlowFixMe
         expect(tc.getFieldConfig('field3').extensions).toEqual({
           first: true,
           second: true,

--- a/src/__tests__/ObjectTypeComposer-test.js
+++ b/src/__tests__/ObjectTypeComposer-test.js
@@ -269,6 +269,21 @@ describe('ObjectTypeComposer', () => {
         expect(tc.getFieldType('field3')).toBe(GraphQLInt);
       });
 
+      it('should extend field extensions', () => {
+        tc.setField('field3', {
+          type: GraphQLString,
+          extensions: { first: true },
+        });
+        tc.extendField('field3', {
+          description: 'this is field #3',
+          extensions: { second: true },
+        });
+        expect(tc.getFieldConfig('field3').extensions).toEqual({
+          first: true,
+          second: true,
+        });
+      });
+
       it('should work with fieldConfig as string', () => {
         tc.setField('field4', 'String');
         tc.extendField('field4', {


### PR DESCRIPTION
This PR changes the behavior of `extendField` to shallow-merge `extensions` instead of overwriting.

I am not very good with Flow - could you check what needs to be changed with the `setField` call? Thank you!

Fixes #177