### PR TITLE
Use getField instead of getFieldConfig in extendField

### DIFF
--- a/src/InputTypeComposer.js
+++ b/src/InputTypeComposer.js
@@ -314,7 +314,7 @@ export class InputTypeComposer<TContext> {
   ): InputTypeComposer<TContext> {
     let prevFieldConfig;
     try {
-      prevFieldConfig = (this.getFieldConfig(fieldName): any);
+      prevFieldConfig = this.getField(fieldName);
     } catch (e) {
       throw new Error(
         `Cannot extend field '${fieldName}' from input type '${this.getTypeName()}'. Field does not exist.`

--- a/src/InterfaceTypeComposer.js
+++ b/src/InterfaceTypeComposer.js
@@ -306,7 +306,7 @@ export class InterfaceTypeComposer<TSource, TContext> {
   ): InterfaceTypeComposer<TSource, TContext> {
     let prevFieldConfig;
     try {
-      prevFieldConfig = (this.getFieldConfig(fieldName): any);
+      prevFieldConfig = this.getField(fieldName);
     } catch (e) {
       throw new Error(
         `Cannot extend field '${fieldName}' from type '${this.getTypeName()}'. Field does not exist.`

--- a/src/ObjectTypeComposer.js
+++ b/src/ObjectTypeComposer.js
@@ -468,7 +468,7 @@ export class ObjectTypeComposer<TSource, TContext> {
   ): ObjectTypeComposer<TSource, TContext> {
     let prevFieldConfig;
     try {
-      prevFieldConfig = (this.getFieldConfig(fieldName): any);
+      prevFieldConfig = this.getField(fieldName);
     } catch (e) {
       throw new Error(
         `Cannot extend field '${fieldName}' from type '${this.getTypeName()}'. Field does not exist.`


### PR DESCRIPTION
Because of https://github.com/graphql-compose/graphql-compose/commit/7c8dcd8102225be7a85b4696063805971975a1c0 is it correct to assume that we can now use `getField` instead of `getFieldConfig` in `extendField` methods (to not resolve types early)?