### PR TITLE
Don't mutate built-in directives

### DIFF
--- a/src/SchemaComposer.js
+++ b/src/SchemaComposer.js
@@ -76,7 +76,7 @@ export const BUILT_IN_DIRECTIVES = [
 export class SchemaComposer<TContext> extends TypeStorage<any, NamedTypeComposer<TContext>> {
   typeMapper: TypeMapper<TContext>;
   _schemaMustHaveTypes: Array<AnyType<TContext>> = [];
-  _directives: Array<GraphQLDirective> = BUILT_IN_DIRECTIVES;
+  _directives: Array<GraphQLDirective> = [...BUILT_IN_DIRECTIVES];
 
   constructor(schema?: GraphQLSchema): SchemaComposer<TContext> {
     super();


### PR DESCRIPTION
Don't mutate `BUILT_IN_DIRECTIVES` when adding directives.

Would it be possible to also release a v6 with this? This would be awesome, thanks so much!