### PR TITLE
fix: allow empty root query

### DIFF
--- a/src/SchemaComposer.js
+++ b/src/SchemaComposer.js
@@ -150,20 +150,6 @@ export class SchemaComposer<TContext> extends TypeStorage<any, NamedTypeComposer
       roots.subscription = tc.getType();
     }
 
-    if (!roots.query) {
-      throw new Error(dedent`
-        Can not build schema. Must be initialized Query type. 
-        See: https://github.com/graphql/graphql-js/issues/448
-      `);
-    }
-
-    if (Object.keys(roots).length === 0) {
-      throw new Error(dedent`
-        Can not build schema. Must be initialized at least one of the following types: 
-          Query, Mutation, Subscription.
-      `);
-    }
-
     const types = [
       ...this._schemaMustHaveTypes.map(t => (getGraphQLType(t): any)), // additional types, eg. used in Interfaces
       ...(extraConfig && Array.isArray(extraConfig.types) ? [...extraConfig.types] : []),

--- a/src/__tests__/SchemaComposer-test.js
+++ b/src/__tests__/SchemaComposer-test.js
@@ -245,14 +245,6 @@ describe('SchemaComposer', () => {
   });
 
   describe('buildSchema()', () => {
-    it('should throw error, if root fields not defined', () => {
-      const sc = new SchemaComposer();
-      sc.clear();
-
-      expect(() => {
-        sc.buildSchema();
-      }).toThrowError();
-    });
 
     it('should accept additional types', () => {
       const sc = new SchemaComposer();
@@ -279,14 +271,6 @@ describe('SchemaComposer', () => {
           `,
         })
       ).toEqual({ data: { num: null } });
-    });
-
-    it('should throw error if only Mutation provided', async () => {
-      const sc = new SchemaComposer();
-      sc.Mutation.addFields({ num: 'Int' });
-      expect(() => {
-        sc.buildSchema();
-      }).toThrow('Must be initialized Query type');
     });
   });
 

--- a/src/__tests__/SchemaComposer-test.js
+++ b/src/__tests__/SchemaComposer-test.js
@@ -245,7 +245,6 @@ describe('SchemaComposer', () => {
   });
 
   describe('buildSchema()', () => {
-
     it('should accept additional types', () => {
       const sc = new SchemaComposer();
       sc.Query.addFields({ time: 'Int' });


### PR DESCRIPTION
[graphql-js](https://github.com/graphql/graphql-js/blob/v14.6.0/src/utilities/buildASTSchema.js#L178) `buildSchema` allows null root query types and will build the schema. This replicates this behaviour here.