### PR TITLE
fix: exclude scalars defined in directives

### DIFF
--- a/src/__tests__/github_issues/246-test.js
+++ b/src/__tests__/github_issues/246-test.js
@@ -28,7 +28,8 @@ describe('github issue #246: Directives are removed from schema in SchemaCompose
   it('via addTypeDefs', async () => {
     const schemaComposer = new SchemaComposer();
     schemaComposer.addTypeDefs(sdl);
-    expect(schemaComposer.toSDL({ omitDescriptions: true })).toMatchInlineSnapshot(`
+
+    expect(schemaComposer.toSDL({ omitDescriptions: true, exclude: ['String'] })).toMatchInlineSnapshot(`
       "directive @test(reason: String = \\"No longer supported\\") on FIELD_DEFINITION | ENUM_VALUE | ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
 
       scalar ID

--- a/src/__tests__/github_issues/246-test.js
+++ b/src/__tests__/github_issues/246-test.js
@@ -29,7 +29,8 @@ describe('github issue #246: Directives are removed from schema in SchemaCompose
     const schemaComposer = new SchemaComposer();
     schemaComposer.addTypeDefs(sdl);
 
-    expect(schemaComposer.toSDL({ omitDescriptions: true, exclude: ['String'] })).toMatchInlineSnapshot(`
+    expect(schemaComposer.toSDL({ omitDescriptions: true, exclude: ['String'] }))
+      .toMatchInlineSnapshot(`
       "directive @test(reason: String = \\"No longer supported\\") on FIELD_DEFINITION | ENUM_VALUE | ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
 
       scalar ID
@@ -50,15 +51,14 @@ describe('github issue #246: Directives are removed from schema in SchemaCompose
 
       enum Status {
         OK @test(reason: \\"enum\\")
-      }
-
-      scalar String"
+      }"
     `);
   });
 
   it('via constructor', async () => {
     const schemaComposer = new SchemaComposer(sdl);
-    expect(schemaComposer.toSDL({ omitDescriptions: true })).toMatchInlineSnapshot(`
+    expect(schemaComposer.toSDL({ omitDescriptions: true, exclude: ['String'] }))
+      .toMatchInlineSnapshot(`
       "directive @test(reason: String = \\"No longer supported\\") on FIELD_DEFINITION | ENUM_VALUE | ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
 
       scalar ID
@@ -79,9 +79,7 @@ describe('github issue #246: Directives are removed from schema in SchemaCompose
 
       enum Status {
         OK @test(reason: \\"enum\\")
-      }
-
-      scalar String"
+      }"
     `);
   });
 });

--- a/src/utils/schemaPrinter.js
+++ b/src/utils/schemaPrinter.js
@@ -119,19 +119,21 @@ export function printSchemaComposer(
     const directives = sc._directives.filter((d) => !BUILT_IN_DIRECTIVES.includes(d));
     res.push(...directives.map((d) => printDirective(d, innerOpts)));
     // directives may have specific types in arguments, so add them to includeTypes
-    directives.forEach(d => {
+    directives.forEach((d) => {
       if (!Array.isArray(d.args)) return;
-      d.args.map(ac => sc.getAnyTC(ac.type))
-        .filter(tc => {
+      d.args
+        .map((ac) => sc.getAnyTC(ac.type))
+        .filter((tc) => {
           // remove scalars specified in `exclude`
           // from being added to schema SDL
           if (tc instanceof ScalarTypeComposer) {
-            const scalarName = tc.getTypeName()
+            const scalarName = tc.getTypeName();
             return !exclude.includes(scalarName);
           }
 
           return true;
-        }).forEach(tc => {
+        })
+        .forEach((tc) => {
           includeTypes.add(tc);
         });
     });
@@ -286,7 +288,7 @@ export function printImplementedInterfaces(
   type: GraphQLObjectType | GraphQLInterfaceType,
   options?: Options
 ): string {
-  const interfaces = type.getInterfaces ? (type: any).getInterfaces(): [];
+  const interfaces = type.getInterfaces ? (type: any).getInterfaces() : [];
   if (!interfaces.length) return '';
   if (options?.sortAll || options?.sortInterfaces) {
     return ` implements ${interfaces
@@ -424,7 +426,7 @@ export function printDirective(directive: GraphQLDirective, options?: Options) {
 
 export function printNodeDirectives(
   node: ?{
-    +directives ?: $ReadOnlyArray < DirectiveNode >,
+    +directives ?: $ReadOnlyArray<DirectiveNode>,
   }
 ): string {
   if (!node || !node.directives || !node.directives.length) return '';

--- a/src/utils/schemaPrinter.js
+++ b/src/utils/schemaPrinter.js
@@ -39,7 +39,6 @@ import { astFromValue } from 'graphql/utilities/astFromValue';
 
 import { BUILT_IN_DIRECTIVES } from '../SchemaComposer';
 import { ObjectTypeComposer } from '../ObjectTypeComposer';
-import { ScalarTypeComposer } from '../ScalarTypeComposer';
 import { InputTypeComposer } from '../InputTypeComposer';
 import { InterfaceTypeComposer } from '../InterfaceTypeComposer';
 import { UnionTypeComposer } from '../UnionTypeComposer';
@@ -121,21 +120,12 @@ export function printSchemaComposer(
     // directives may have specific types in arguments, so add them to includeTypes
     directives.forEach((d) => {
       if (!Array.isArray(d.args)) return;
-      d.args
-        .map((ac) => sc.getAnyTC(ac.type))
-        .filter((tc) => {
-          // remove scalars specified in `exclude`
-          // from being added to schema SDL
-          if (tc instanceof ScalarTypeComposer) {
-            const scalarName = tc.getTypeName();
-            return !exclude.includes(scalarName);
-          }
-
-          return true;
-        })
-        .forEach((tc) => {
+      d.args.forEach((ac) => {
+        const tc = sc.getAnyTC(ac.type);
+        if (!exclude.includes(tc.getTypeName())) {
           includeTypes.add(tc);
-        });
+        }
+      });
     });
   }
 
@@ -426,7 +416,7 @@ export function printDirective(directive: GraphQLDirective, options?: Options) {
 
 export function printNodeDirectives(
   node: ?{
-    +directives ?: $ReadOnlyArray<DirectiveNode>,
+    +directives?: $ReadOnlyArray<DirectiveNode>,
   }
 ): string {
   if (!node || !node.directives || !node.directives.length) return '';


### PR DESCRIPTION
`.toSDL({exclude: ['String']})` does not exclude String from schema SDL if it has also been defined in a directive definition.