### PR TITLE
Modificators via getters

### DIFF
--- a/src/EnumTypeComposer.d.ts
+++ b/src/EnumTypeComposer.d.ts
@@ -140,6 +140,32 @@ export class EnumTypeComposer<TContext = any> {
 
   public getTypeNonNull(): NonNullComposer<this>;
 
+  /**
+   * Get Type wrapped in List modifier
+   *
+   * @example
+   *   const ColorTC = schemaComposer.createEnumTC(`enum Color { RED GREEN }`);
+   *   schemaComposer.Query.addFields({
+   *     color1: { type: ColorTC.List }  // in SDL: color1: [Color]
+   *     color2: { type: ColorTC.NonNull.List }  // in SDL: color2: [Color!]
+   *     color3: { type: ColorTC.NonNull.List.NonNull }  // in SDL: color2: [Color!]!
+   *   })
+   */
+  public get List(): ListComposer<EnumTypeComposer<TContext>>;
+
+  /**
+   * Get Type wrapped in NonNull modifier
+   *
+   * @example
+   *   const ColorTC = schemaComposer.createEnumTC(`enum Color { RED GREEN }`);
+   *   schemaComposer.Query.addFields({
+   *     color1: { type: ColorTC.List }  // in SDL: color1: [Color]
+   *     color2: { type: ColorTC.NonNull.List }  // in SDL: color2: [Color!]
+   *     color3: { type: ColorTC.NonNull.List.NonNull }  // in SDL: color2: [Color!]!
+   *   })
+   */
+  public get NonNull(): NonNullComposer<EnumTypeComposer<TContext>>;
+
   public getTypeName(): string;
 
   public setTypeName(name: string): this;

--- a/src/EnumTypeComposer.js
+++ b/src/EnumTypeComposer.js
@@ -343,6 +343,36 @@ export class EnumTypeComposer<TContext> {
     return new NonNullComposer(this);
   }
 
+  /**
+   * Get Type wrapped in List modifier
+   *
+   * @example
+   *   const ColorTC = schemaComposer.createEnumTC(`enum Color { RED GREEN }`);
+   *   schemaComposer.Query.addFields({
+   *     color1: { type: ColorTC.List }  // in SDL: color1: [Color]
+   *     color2: { type: ColorTC.NonNull.List }  // in SDL: color2: [Color!]
+   *     color3: { type: ColorTC.NonNull.List.NonNull }  // in SDL: color2: [Color!]!
+   *   })
+   */
+  get List(): ListComposer<EnumTypeComposer<TContext>> {
+    return new ListComposer(this);
+  }
+
+  /**
+   * Get Type wrapped in NonNull modifier
+   *
+   * @example
+   *   const ColorTC = schemaComposer.createEnumTC(`enum Color { RED GREEN }`);
+   *   schemaComposer.Query.addFields({
+   *     color1: { type: ColorTC.List }  // in SDL: color1: [Color]
+   *     color2: { type: ColorTC.NonNull.List }  // in SDL: color2: [Color!]
+   *     color3: { type: ColorTC.NonNull.List.NonNull }  // in SDL: color2: [Color!]!
+   *   })
+   */
+  get NonNull(): NonNullComposer<EnumTypeComposer<TContext>> {
+    return new NonNullComposer(this);
+  }
+
   getTypeName(): string {
     return this._gqType.name;
   }

--- a/src/InputTypeComposer.d.ts
+++ b/src/InputTypeComposer.d.ts
@@ -196,6 +196,40 @@ export class InputTypeComposer<TContext = any> {
 
   public getTypeNonNull(): NonNullComposer<this>;
 
+  /**
+   * Get Type wrapped in List modifier
+   *
+   * @example
+   *   const UserTC = schemaComposer.createInputTC(`input UserInput { name: String }`);
+   *   schemaComposer.Mutation.addFields({
+   *     add: {
+   *       args: {
+   *         users1: UserTC.List, // in SDL: users1: [UserInput]
+   *         users2: UserTC.NonNull.List, // in SDL: users2: [UserInput!]
+   *         users3: UserTC.NonNull.List.NonNull, // in SDL: users2: [UserInput!]!
+   *       }
+   *     }
+   *   })
+   */
+  public get List(): ListComposer<InputTypeComposer<TContext>>;
+
+  /**
+   * Get Type wrapped in NonNull modifier
+   *
+   * @example
+   *   const UserTC = schemaComposer.createInputTC(`input UserInput { name: String }`);
+   *   schemaComposer.Mutation.addFields({
+   *     add: {
+   *       args: {
+   *         users1: UserTC.List, // in SDL: users1: [UserInput]
+   *         users2: UserTC.NonNull.List, // in SDL: users2: [UserInput!]
+   *         users3: UserTC.NonNull.List.NonNull, // in SDL: users2: [UserInput!]!
+   *       }
+   *     }
+   *   })
+   */
+  public get NonNull(): NonNullComposer<InputTypeComposer<TContext>>;
+
   public getTypeName(): string;
 
   public setTypeName(name: string): this;

--- a/src/InputTypeComposer.js
+++ b/src/InputTypeComposer.js
@@ -525,6 +525,44 @@ export class InputTypeComposer<TContext> {
     return new NonNullComposer(this);
   }
 
+  /**
+   * Get Type wrapped in List modifier
+   *
+   * @example
+   *   const UserTC = schemaComposer.createInputTC(`input UserInput { name: String }`);
+   *   schemaComposer.Mutation.addFields({
+   *     add: {
+   *       args: {
+   *         users1: UserTC.List, // in SDL: users1: [UserInput]
+   *         users2: UserTC.NonNull.List, // in SDL: users2: [UserInput!]
+   *         users3: UserTC.NonNull.List.NonNull, // in SDL: users2: [UserInput!]!
+   *       }
+   *     }
+   *   })
+   */
+  get List(): ListComposer<InputTypeComposer<TContext>> {
+    return new ListComposer(this);
+  }
+
+  /**
+   * Get Type wrapped in NonNull modifier
+   *
+   * @example
+   *   const UserTC = schemaComposer.createInputTC(`input UserInput { name: String }`);
+   *   schemaComposer.Mutation.addFields({
+   *     add: {
+   *       args: {
+   *         users1: UserTC.List, // in SDL: users1: [UserInput]
+   *         users2: UserTC.NonNull.List, // in SDL: users2: [UserInput!]
+   *         users3: UserTC.NonNull.List.NonNull, // in SDL: users2: [UserInput!]!
+   *       }
+   *     }
+   *   })
+   */
+  get NonNull(): NonNullComposer<InputTypeComposer<TContext>> {
+    return new NonNullComposer(this);
+  }
+
   getTypeName(): string {
     return this._gqType.name;
   }

--- a/src/InterfaceTypeComposer.d.ts
+++ b/src/InterfaceTypeComposer.d.ts
@@ -173,6 +173,32 @@ export class InterfaceTypeComposer<TSource = any, TContext = any> {
 
   public makeFieldPlural(fieldNameOrArray: string | string[]): this;
 
+  /**
+   * Get Type wrapped in List modifier
+   *
+   * @example
+   *   const UserTC = schemaComposer.createInterfaceTC(`interface UserIface { name: String }`);
+   *   schemaComposer.Query.addFields({
+   *     users1: { type: UserTC.List }, // in SDL: users1: [UserIface]
+   *     users2: { type: UserTC.NonNull.List }, // in SDL: users2: [UserIface!]
+   *     users3: { type: UserTC.NonNull.List.NonNull }, // in SDL: users2: [UserIface!]!
+   *   })
+   */
+  public get List(): ListComposer<InterfaceTypeComposer<TSource, TContext>>;
+
+  /**
+   * Get Type wrapped in NonNull modifier
+   *
+   * @example
+   *   const UserTC = schemaComposer.createInterfaceTC(`interface UserIface { name: String }`);
+   *   schemaComposer.Query.addFields({
+   *     users1: { type: UserTC.List }, // in SDL: users1: [UserIface]
+   *     users2: { type: UserTC.NonNull.List }, // in SDL: users2: [UserIface!]!
+   *     users3: { type: UserTC.NonNull.List.NonNull }, // in SDL: users2: [UserIface!]!
+   *   })
+   */
+  public get NonNull(): NonNullComposer<InterfaceTypeComposer<TSource, TContext>>;
+
   public makeFieldNonPlural(fieldNameOrArray: string | string[]): this;
 
   public deprecateFields(fields: { [fieldName: string]: string } | string[] | string): this;

--- a/src/InterfaceTypeComposer.js
+++ b/src/InterfaceTypeComposer.js
@@ -1092,6 +1092,7 @@ export class InterfaceTypeComposer<TSource, TContext> {
     const typeResolversMap = this.getTypeResolvers();
     typeResolversMap.set(type, checkFn);
     this.setTypeResolvers(typeResolversMap);
+    this.schemaComposer.addSchemaMustHaveType(type);
     return this;
   }
 

--- a/src/InterfaceTypeComposer.js
+++ b/src/InterfaceTypeComposer.js
@@ -743,6 +743,36 @@ export class InterfaceTypeComposer<TSource, TContext> {
     return new NonNullComposer(this);
   }
 
+  /**
+   * Get Type wrapped in List modifier
+   *
+   * @example
+   *   const UserTC = schemaComposer.createInterfaceTC(`interface UserIface { name: String }`);
+   *   schemaComposer.Query.addFields({
+   *     users1: { type: UserTC.List }, // in SDL: users1: [UserIface]
+   *     users2: { type: UserTC.NonNull.List }, // in SDL: users2: [UserIface!]
+   *     users3: { type: UserTC.NonNull.List.NonNull }, // in SDL: users2: [UserIface!]!
+   *   })
+   */
+  get List(): ListComposer<InterfaceTypeComposer<TSource, TContext>> {
+    return new ListComposer(this);
+  }
+
+  /**
+   * Get Type wrapped in NonNull modifier
+   *
+   * @example
+   *   const UserTC = schemaComposer.createInterfaceTC(`interface UserIface { name: String }`);
+   *   schemaComposer.Query.addFields({
+   *     users1: { type: UserTC.List }, // in SDL: users1: [UserIface]
+   *     users2: { type: UserTC.NonNull.List }, // in SDL: users2: [UserIface!]!
+   *     users3: { type: UserTC.NonNull.List.NonNull }, // in SDL: users2: [UserIface!]!
+   *   })
+   */
+  get NonNull(): NonNullComposer<InterfaceTypeComposer<TSource, TContext>> {
+    return new NonNullComposer(this);
+  }
+
   getTypeName(): string {
     return this._gqType.name;
   }

--- a/src/ListComposer.d.ts
+++ b/src/ListComposer.d.ts
@@ -19,6 +19,32 @@ export class ListComposer<T extends AnyTypeComposer<any>> {
   public getTypeNonNull(): NonNullComposer<ListComposer<T>>;
 
   /**
+   * Get Type wrapped in List modifier
+   *
+   * @example
+   *   const UserTC = schemaComposer.createObjectTC(`type User { name: String }`);
+   *   schemaComposer.Query.addFields({
+   *     users1: { type: UserTC.List }, // in SDL: users1: [User]
+   *     users2: { type: UserTC.NonNull.List }, // in SDL: users2: [User!]
+   *     users3: { type: UserTC.NonNull.List.NonNull }, // in SDL: users2: [User!]!
+   *   })
+   */
+  public get List(): ListComposer<ListComposer<T>>;
+
+  /**
+   * Get Type wrapped in NonNull modifier
+   *
+   * @example
+   *   const UserTC = schemaComposer.createObjectTC(`type User { name: String }`);
+   *   schemaComposer.Query.addFields({
+   *     users1: { type: UserTC.List }, // in SDL: users1: [User]
+   *     users2: { type: UserTC.NonNull.List }, // in SDL: users2: [User!]!
+   *     users3: { type: UserTC.NonNull.List.NonNull }, // in SDL: users2: [User!]!
+   *   })
+   */
+  public get NonNull(): NonNullComposer<ListComposer<T>>;
+
+  /**
    * Clone this type to another SchemaComposer.
    * Also will be clonned all wrapped types.
    */

--- a/src/ListComposer.js
+++ b/src/ListComposer.js
@@ -44,6 +44,36 @@ export class ListComposer<+T: AnyTypeComposer<any>> {
   }
 
   /**
+   * Get Type wrapped in List modifier
+   *
+   * @example
+   *   const UserTC = schemaComposer.createObjectTC(`type User { name: String }`);
+   *   schemaComposer.Query.addFields({
+   *     users1: { type: UserTC.List }, // in SDL: users1: [User]
+   *     users2: { type: UserTC.NonNull.List }, // in SDL: users2: [User!]
+   *     users3: { type: UserTC.NonNull.List.NonNull }, // in SDL: users2: [User!]!
+   *   })
+   */
+  get List(): ListComposer<ListComposer<T>> {
+    return new ListComposer(this);
+  }
+
+  /**
+   * Get Type wrapped in NonNull modifier
+   *
+   * @example
+   *   const UserTC = schemaComposer.createObjectTC(`type User { name: String }`);
+   *   schemaComposer.Query.addFields({
+   *     users1: { type: UserTC.List }, // in SDL: users1: [User]
+   *     users2: { type: UserTC.NonNull.List }, // in SDL: users2: [User!]!
+   *     users3: { type: UserTC.NonNull.List.NonNull }, // in SDL: users2: [User!]!
+   *   })
+   */
+  get NonNull(): NonNullComposer<ListComposer<T>> {
+    return new NonNullComposer(this);
+  }
+
+  /**
    * Clone this type to another SchemaComposer.
    * Also will be clonned all wrapped types.
    */

--- a/src/NonNullComposer.d.ts
+++ b/src/NonNullComposer.d.ts
@@ -19,6 +19,32 @@ export class NonNullComposer<T extends AnyTypeComposer<any>> {
   public getTypeNonNull(): NonNullComposer<T>;
 
   /**
+   * Get Type wrapped in List modifier
+   *
+   * @example
+   *   const UserTC = schemaComposer.createObjectTC(`type User { name: String }`);
+   *   schemaComposer.Query.addFields({
+   *     users1: { type: UserTC.List }, // in SDL: users1: [User]
+   *     users2: { type: UserTC.NonNull.List }, // in SDL: users2: [User!]
+   *     users3: { type: UserTC.NonNull.List.NonNull }, // in SDL: users2: [User!]!
+   *   })
+   */
+  public get List(): ListComposer<NonNullComposer<T>>;
+
+  /**
+   * Get Type wrapped in NonNull modifier
+   *
+   * @example
+   *   const UserTC = schemaComposer.createObjectTC(`type User { name: String }`);
+   *   schemaComposer.Query.addFields({
+   *     users1: { type: UserTC.List }, // in SDL: users1: [User]
+   *     users2: { type: UserTC.NonNull.List }, // in SDL: users2: [User!]!
+   *     users3: { type: UserTC.NonNull.List.NonNull }, // in SDL: users2: [User!]!
+   *   })
+   */
+  public get NonNull(): NonNullComposer<T>;
+
+  /**
    * Clone this type to another SchemaComposer.
    * Also will be clonned all wrapped types.
    */

--- a/src/NonNullComposer.js
+++ b/src/NonNullComposer.js
@@ -49,6 +49,36 @@ export class NonNullComposer<+T: AnyTypeComposer<any>> {
   }
 
   /**
+   * Get Type wrapped in List modifier
+   *
+   * @example
+   *   const UserTC = schemaComposer.createObjectTC(`type User { name: String }`);
+   *   schemaComposer.Query.addFields({
+   *     users1: { type: UserTC.List }, // in SDL: users1: [User]
+   *     users2: { type: UserTC.NonNull.List }, // in SDL: users2: [User!]
+   *     users3: { type: UserTC.NonNull.List.NonNull }, // in SDL: users2: [User!]!
+   *   })
+   */
+  get List(): ListComposer<NonNullComposer<T>> {
+    return new ListComposer(this);
+  }
+
+  /**
+   * Get Type wrapped in NonNull modifier
+   *
+   * @example
+   *   const UserTC = schemaComposer.createObjectTC(`type User { name: String }`);
+   *   schemaComposer.Query.addFields({
+   *     users1: { type: UserTC.List }, // in SDL: users1: [User]
+   *     users2: { type: UserTC.NonNull.List }, // in SDL: users2: [User!]!
+   *     users3: { type: UserTC.NonNull.List.NonNull }, // in SDL: users2: [User!]!
+   *   })
+   */
+  get NonNull(): NonNullComposer<T> {
+    return this;
+  }
+
+  /**
    * Clone this type to another SchemaComposer.
    * Also will be clonned all wrapped types.
    */

--- a/src/ObjectTypeComposer.d.ts
+++ b/src/ObjectTypeComposer.d.ts
@@ -395,6 +395,32 @@ export class ObjectTypeComposer<TSource = any, TContext = any> {
 
   public getTypeNonNull(): NonNullComposer<this>;
 
+  /**
+   * Get Type wrapped in List modifier
+   *
+   * @example
+   *   const UserTC = schemaComposer.createObjectTC(`type User { name: String }`);
+   *   schemaComposer.Query.addFields({
+   *     users1: { type: UserTC.List }, // in SDL: users1: [User]
+   *     users2: { type: UserTC.NonNull.List }, // in SDL: users2: [User!]
+   *     users3: { type: UserTC.NonNull.List.NonNull }, // in SDL: users2: [User!]!
+   *   })
+   */
+  public get List(): ListComposer<ObjectTypeComposer<TSource, TContext>>;
+
+  /**
+   * Get Type wrapped in NonNull modifier
+   *
+   * @example
+   *   const UserTC = schemaComposer.createObjectTC(`type User { name: String }`);
+   *   schemaComposer.Query.addFields({
+   *     users1: { type: UserTC.List }, // in SDL: users1: [User]
+   *     users2: { type: UserTC.NonNull.List }, // in SDL: users2: [User!]!
+   *     users3: { type: UserTC.NonNull.List.NonNull }, // in SDL: users2: [User!]!
+   *   })
+   */
+  public get NonNull(): NonNullComposer<ObjectTypeComposer<TSource, TContext>>;
+
   public getTypeName(): string;
 
   public setTypeName(name: string): this;

--- a/src/ObjectTypeComposer.js
+++ b/src/ObjectTypeComposer.js
@@ -954,6 +954,36 @@ export class ObjectTypeComposer<TSource, TContext> {
     return new NonNullComposer(this);
   }
 
+  /**
+   * Get Type wrapped in List modifier
+   *
+   * @example
+   *   const UserTC = schemaComposer.createObjectTC(`type User { name: String }`);
+   *   schemaComposer.Query.addFields({
+   *     users1: { type: UserTC.List }, // in SDL: users1: [User]
+   *     users2: { type: UserTC.NonNull.List }, // in SDL: users2: [User!]
+   *     users3: { type: UserTC.NonNull.List.NonNull }, // in SDL: users2: [User!]!
+   *   })
+   */
+  get List(): ListComposer<ObjectTypeComposer<TSource, TContext>> {
+    return new ListComposer(this);
+  }
+
+  /**
+   * Get Type wrapped in NonNull modifier
+   *
+   * @example
+   *   const UserTC = schemaComposer.createObjectTC(`type User { name: String }`);
+   *   schemaComposer.Query.addFields({
+   *     users1: { type: UserTC.List }, // in SDL: users1: [User]
+   *     users2: { type: UserTC.NonNull.List }, // in SDL: users2: [User!]!
+   *     users3: { type: UserTC.NonNull.List.NonNull }, // in SDL: users2: [User!]!
+   *   })
+   */
+  get NonNull(): NonNullComposer<ObjectTypeComposer<TSource, TContext>> {
+    return new NonNullComposer(this);
+  }
+
   getTypeName(): string {
     return this._gqType.name;
   }

--- a/src/ScalarTypeComposer.d.ts
+++ b/src/ScalarTypeComposer.d.ts
@@ -81,6 +81,32 @@ export class ScalarTypeComposer<TContext = any> {
 
   public getTypeNonNull(): NonNullComposer<ScalarTypeComposer<TContext>>;
 
+  /**
+   * Get Type wrapped in List modifier
+   *
+   * @example
+   *   const ColorTC = schemaComposer.createScalarTC(`scalar Color`);
+   *   schemaComposer.Query.addFields({
+   *     color1: { type: ColorTC.List }, // in SDL: color1: [Color]
+   *     color2: { type: ColorTC.NonNull.List }, // in SDL: color2: [Color!]
+   *     color3: { type: ColorTC.NonNull.List.NonNull }, // in SDL: color2: [Color!]!
+   *   })
+   */
+  public get List(): ListComposer<ScalarTypeComposer<TContext>>;
+
+  /**
+   * Get Type wrapped in NonNull modifier
+   *
+   * @example
+   *   const ColorTC = schemaComposer.createScalarTC(`scalar Color`);
+   *   schemaComposer.Query.addFields({
+   *     color1: { type: ColorTC.List }, // in SDL: color1: [Color]
+   *     color2: { type: ColorTC.NonNull.List }, // in SDL: color2: [Color!]
+   *     color3: { type: ColorTC.NonNull.List.NonNull }, // in SDL: color2: [Color!]!
+   *   })
+   */
+  public get NonNull(): NonNullComposer<ScalarTypeComposer<TContext>>;
+
   public getTypeName(): string;
 
   public setTypeName(name: string): this;

--- a/src/ScalarTypeComposer.js
+++ b/src/ScalarTypeComposer.js
@@ -198,6 +198,36 @@ export class ScalarTypeComposer<TContext> {
     return new NonNullComposer(this);
   }
 
+  /**
+   * Get Type wrapped in List modifier
+   *
+   * @example
+   *   const ColorTC = schemaComposer.createScalarTC(`scalar Color`);
+   *   schemaComposer.Query.addFields({
+   *     color1: { type: ColorTC.List }, // in SDL: color1: [Color]
+   *     color2: { type: ColorTC.NonNull.List }, // in SDL: color2: [Color!]
+   *     color3: { type: ColorTC.NonNull.List.NonNull }, // in SDL: color2: [Color!]!
+   *   })
+   */
+  get List(): ListComposer<ScalarTypeComposer<TContext>> {
+    return new ListComposer(this);
+  }
+
+  /**
+   * Get Type wrapped in NonNull modifier
+   *
+   * @example
+   *   const ColorTC = schemaComposer.createScalarTC(`scalar Color`);
+   *   schemaComposer.Query.addFields({
+   *     color1: { type: ColorTC.List }, // in SDL: color1: [Color]
+   *     color2: { type: ColorTC.NonNull.List }, // in SDL: color2: [Color!]
+   *     color3: { type: ColorTC.NonNull.List.NonNull }, // in SDL: color2: [Color!]!
+   *   })
+   */
+  get NonNull(): NonNullComposer<ScalarTypeComposer<TContext>> {
+    return new NonNullComposer(this);
+  }
+
   getTypeName(): string {
     return this._gqType.name;
   }

--- a/src/ThunkComposer.d.ts
+++ b/src/ThunkComposer.d.ts
@@ -28,6 +28,16 @@ export class ThunkComposer<
   public getTypeNonNull(): NonNullComposer<ThunkComposer<T, G>>;
 
   /**
+   * Get Type wrapped in List modifier
+   */
+  public get List(): ListComposer<ThunkComposer<T, G>>;
+
+  /**
+   * Get Type wrapped in NonNull modifier
+   */
+  public get NonNull(): NonNullComposer<ThunkComposer<T, G>>;
+
+  /**
    * Clone this type to another SchemaComposer.
    * Also will be clonned all wrapped types.
    */

--- a/src/ThunkComposer.js
+++ b/src/ThunkComposer.js
@@ -64,6 +64,20 @@ export class ThunkComposer<T = NamedTypeComposer<any>, G = GraphQLType> {
   }
 
   /**
+   * Get Type wrapped in List modifier
+   */
+  get List(): ListComposer<ThunkComposer<T, G>> {
+    return new ListComposer(this);
+  }
+
+  /**
+   * Get Type wrapped in NonNull modifier
+   */
+  get NonNull(): NonNullComposer<ThunkComposer<T, G>> {
+    return new NonNullComposer(this);
+  }
+
+  /**
    * Clone this type to another SchemaComposer.
    * Also will be clonned all wrapped types.
    */

--- a/src/UnionTypeComposer.d.ts
+++ b/src/UnionTypeComposer.d.ts
@@ -138,6 +138,32 @@ export class UnionTypeComposer<TSource = any, TContext = any> {
 
   public getTypeNonNull(): NonNullComposer<UnionTypeComposer<TSource, TContext>>;
 
+  /**
+   * Get Type wrapped in List modifier
+   *
+   * @example
+   *   const UserTC = schemaComposer.createUnionTC(`union User = Admin | Client`);
+   *   schemaComposer.Query.addFields({
+   *     users1: { type: UserTC.List }  // in SDL: users1: [User]
+   *     users2: { type: UserTC.NonNull.List }  // in SDL: users2: [User!]
+   *     users3: { type: UserTC.NonNull.List.NonNull }  // in SDL: users2: [User!]!
+   *   })
+   */
+  public get List(): ListComposer<UnionTypeComposer<TSource, TContext>>;
+
+  /**
+   * Get Type wrapped in NonNull modifier
+   *
+   * @example
+   *   const UserTC = schemaComposer.createUnionTC(`union User = Admin | Client`);
+   *   schemaComposer.Query.addFields({
+   *     users1: { type: UserTC.List }, // in SDL: users1: [User]
+   *     users2: { type: UserTC.NonNull.List }, // in SDL: users2: [User!]
+   *     users3: { type: UserTC.NonNull.List.NonNull }, // in SDL: users2: [User!]!
+   *   })
+   */
+  public get NonNull(): NonNullComposer<UnionTypeComposer<TSource, TContext>>;
+
   public getTypeName(): string;
 
   public setTypeName(name: string): this;

--- a/src/UnionTypeComposer.js
+++ b/src/UnionTypeComposer.js
@@ -318,6 +318,36 @@ export class UnionTypeComposer<TSource, TContext> {
     return new NonNullComposer(this);
   }
 
+  /**
+   * Get Type wrapped in List modifier
+   *
+   * @example
+   *   const UserTC = schemaComposer.createUnionTC(`union User = Admin | Client`);
+   *   schemaComposer.Query.addFields({
+   *     users1: { type: UserTC.List }, // in SDL: users1: [User]
+   *     users2: { type: UserTC.NonNull.List }, // in SDL: users2: [User!]
+   *     users3: { type: UserTC.NonNull.List.NonNull }, // in SDL: users2: [User!]!
+   *   })
+   */
+  get List(): ListComposer<UnionTypeComposer<TSource, TContext>> {
+    return new ListComposer(this);
+  }
+
+  /**
+   * Get Type wrapped in NonNull modifier
+   *
+   * @example
+   *   const UserTC = schemaComposer.createUnionTC(`union User = Admin | Client`);
+   *   schemaComposer.Query.addFields({
+   *     users1: { type: UserTC.List }, // in SDL: users1: [User]
+   *     users2: { type: UserTC.NonNull.List }, // in SDL: users2: [User!]
+   *     users3: { type: UserTC.NonNull.List.NonNull }, // in SDL: users2: [User!]!
+   *   })
+   */
+  get NonNull(): NonNullComposer<UnionTypeComposer<TSource, TContext>> {
+    return new NonNullComposer(this);
+  }
+
   getTypeName(): string {
     return this._gqType.name;
   }

--- a/src/UnionTypeComposer.js
+++ b/src/UnionTypeComposer.js
@@ -621,6 +621,7 @@ export class UnionTypeComposer<TSource, TContext> {
     const typeResolversMap = this.getTypeResolvers();
     const tc = this._convertObjectType(type);
     typeResolversMap.set(tc, checkFn);
+    this.schemaComposer.addSchemaMustHaveType((tc: any));
     this.setTypeResolvers(typeResolversMap);
     return this;
   }

--- a/src/__tests__/EnumTypeComposer-test.js
+++ b/src/__tests__/EnumTypeComposer-test.js
@@ -237,6 +237,20 @@ describe('EnumTypeComposer', () => {
       expect(etc.getTypeNonNull()).toBeInstanceOf(NonNullComposer);
       expect(etc.getTypeNonNull().ofType).toBe(etc);
     });
+
+    it('check getters List, NonNull', () => {
+      const ColorTC = schemaComposer.createEnumTC(`enum Color { RED GREEN }`);
+      expect(ColorTC.List).toBeInstanceOf(ListComposer);
+      expect(ColorTC.List.ofType).toBe(ColorTC);
+      expect(ColorTC.List.getTypeName()).toBe('[Color]');
+      expect(ColorTC.NonNull).toBeInstanceOf(NonNullComposer);
+      expect(ColorTC.NonNull.ofType).toBe(ColorTC);
+      expect(ColorTC.NonNull.getTypeName()).toBe('Color!');
+      expect(ColorTC.NonNull.List).toBeInstanceOf(ListComposer);
+      expect(ColorTC.NonNull.List.getTypeName()).toBe('[Color!]');
+      expect(ColorTC.NonNull.List.NonNull).toBeInstanceOf(NonNullComposer);
+      expect(ColorTC.NonNull.List.NonNull.getTypeName()).toBe('[Color!]!');
+    });
   });
 
   describe('deprecateFields()', () => {

--- a/src/__tests__/InputTypeComposer-test.js
+++ b/src/__tests__/InputTypeComposer-test.js
@@ -429,6 +429,20 @@ describe('InputTypeComposer', () => {
       itc.setDescription('Changed description');
       expect(itc.getDescription()).toBe('Changed description');
     });
+
+    it('check getters List, NonNull', () => {
+      const UserTC = schemaComposer.createInputTC(`input UserInput { name: String }`);
+      expect(UserTC.List).toBeInstanceOf(ListComposer);
+      expect(UserTC.List.ofType).toBe(UserTC);
+      expect(UserTC.List.getTypeName()).toBe('[UserInput]');
+      expect(UserTC.NonNull).toBeInstanceOf(NonNullComposer);
+      expect(UserTC.NonNull.ofType).toBe(UserTC);
+      expect(UserTC.NonNull.getTypeName()).toBe('UserInput!');
+      expect(UserTC.NonNull.List).toBeInstanceOf(ListComposer);
+      expect(UserTC.NonNull.List.getTypeName()).toBe('[UserInput!]');
+      expect(UserTC.NonNull.List.NonNull).toBeInstanceOf(NonNullComposer);
+      expect(UserTC.NonNull.List.NonNull.getTypeName()).toBe('[UserInput!]!');
+    });
   });
 
   describe('static method create()', () => {

--- a/src/__tests__/InterfaceTypeComposer-test.js
+++ b/src/__tests__/InterfaceTypeComposer-test.js
@@ -715,6 +715,20 @@ describe('InterfaceTypeComposer', () => {
       expect(iftc.getTypeNonNull()).toBeInstanceOf(NonNullComposer);
       expect(iftc.getTypeNonNull().getType().ofType).toBe(iftc.getType());
     });
+
+    it('check getters List, NonNull', () => {
+      const UserTC = schemaComposer.createInterfaceTC(`interface UserIface { name: String }`);
+      expect(UserTC.List).toBeInstanceOf(ListComposer);
+      expect(UserTC.List.ofType).toBe(UserTC);
+      expect(UserTC.List.getTypeName()).toBe('[UserIface]');
+      expect(UserTC.NonNull).toBeInstanceOf(NonNullComposer);
+      expect(UserTC.NonNull.ofType).toBe(UserTC);
+      expect(UserTC.NonNull.getTypeName()).toBe('UserIface!');
+      expect(UserTC.NonNull.List).toBeInstanceOf(ListComposer);
+      expect(UserTC.NonNull.List.getTypeName()).toBe('[UserIface!]');
+      expect(UserTC.NonNull.List.NonNull).toBeInstanceOf(NonNullComposer);
+      expect(UserTC.NonNull.List.NonNull.getTypeName()).toBe('[UserIface!]!');
+    });
   });
 
   it('should have chainable methods', () => {

--- a/src/__tests__/ListComposer-test.js
+++ b/src/__tests__/ListComposer-test.js
@@ -44,6 +44,16 @@ describe('ListComposer', () => {
     expect(tc.getTypeNonNull().ofType).toBe(tc);
   });
 
+  it('check getters List, NonNull', () => {
+    const UserTC = schemaComposer.createObjectTC(`type User { name: String }`);
+    expect(UserTC.List).toBeInstanceOf(ListComposer);
+    expect(UserTC.List.ofType).toBe(UserTC);
+    expect(UserTC.List.getTypeName()).toBe('[User]');
+    expect(UserTC.List.List.getTypeName()).toBe('[[User]]');
+    expect(UserTC.List.List.List.getTypeName()).toBe('[[[User]]]');
+    expect(UserTC.List.NonNull.getTypeName()).toBe('[User]!');
+  });
+
   it('getUnwrappedTC() should return NamedTypeComposer', () => {
     const UserTC1 = tc.getUnwrappedTC();
     expect(UserTC1).toBeInstanceOf(ObjectTypeComposer);

--- a/src/__tests__/NonNullComposer-test.js
+++ b/src/__tests__/NonNullComposer-test.js
@@ -52,6 +52,15 @@ describe('NonNullComposer', () => {
     expect(tc.getTypeNonNull()).toBe(tc);
   });
 
+  it('check getters List, NonNull', () => {
+    const UserTC = schemaComposer.createObjectTC(`type User { name: String }`);
+    expect(UserTC.NonNull).toBeInstanceOf(NonNullComposer);
+    expect(UserTC.NonNull.ofType).toBe(UserTC);
+    expect(UserTC.NonNull.getTypeName()).toBe('User!');
+    expect(UserTC.NonNull.NonNull.NonNull.getTypeName()).toBe('User!');
+    expect(UserTC.NonNull.List.getTypeName()).toBe('[User!]');
+  });
+
   it('getUnwrappedTC() should return NamedTypeComposer', () => {
     const UserTC1 = tc.getUnwrappedTC();
     expect(UserTC1).toBeInstanceOf(ObjectTypeComposer);

--- a/src/__tests__/ObjectTypeComposer-test.js
+++ b/src/__tests__/ObjectTypeComposer-test.js
@@ -440,111 +440,127 @@ describe('ObjectTypeComposer', () => {
       });
     });
 
-    it('isFieldNonNull()', () => {
-      tc.setField('fieldNN', 'String');
-      expect(tc.isFieldNonNull('fieldNN')).toBe(false);
-      tc.setField('fieldNN', 'String!');
-      expect(tc.isFieldNonNull('fieldNN')).toBe(true);
-    });
-
-    it('makeFieldNonNull()', () => {
-      tc.setField('fieldNN', 'String');
-      expect(tc.getFieldType('fieldNN')).toBe(GraphQLString);
-
-      // should wrap with GraphQLNonNull
-      tc.makeFieldNonNull('fieldNN');
-      expect(tc.getFieldType('fieldNN')).toBeInstanceOf(GraphQLNonNull);
-      expect((tc.getFieldType('fieldNN'): any).ofType).toBe(GraphQLString);
-
-      // should not wrap twice
-      tc.makeFieldNonNull('fieldNN');
-      expect(tc.getFieldType('fieldNN')).toBeInstanceOf(GraphQLNonNull);
-      expect((tc.getFieldType('fieldNN'): any).ofType).toBe(GraphQLString);
-    });
-
-    it('makeFieldNullable()', () => {
-      tc.setField('fieldNN', 'String!');
-      expect(tc.getFieldType('fieldNN')).toBeInstanceOf(GraphQLNonNull);
-      expect((tc.getFieldType('fieldNN'): any).ofType).toBe(GraphQLString);
-
-      // should unwrap GraphQLNonNull
-      tc.makeFieldNullable('fieldNN');
-      expect(tc.getFieldType('fieldNN')).toBe(GraphQLString);
-
-      // should work for already unwrapped type
-      tc.makeFieldNullable('fieldNN');
-      expect(tc.getFieldType('fieldNN')).toBe(GraphQLString);
-    });
-
-    it('check field Plural methods, wrap/unwrap from ListComposer', () => {
-      tc.setFields({
-        b1: { type: new GraphQLNonNull(GraphQLString) },
-        b2: { type: '[String]' },
-        b3: 'String!',
-        b4: '[String!]!',
+    describe('check modificators', () => {
+      it('isFieldNonNull()', () => {
+        tc.setField('fieldNN', 'String');
+        expect(tc.isFieldNonNull('fieldNN')).toBe(false);
+        tc.setField('fieldNN', 'String!');
+        expect(tc.isFieldNonNull('fieldNN')).toBe(true);
       });
-      expect(tc.isFieldPlural('b1')).toBe(false);
-      expect(tc.isFieldPlural('b2')).toBe(true);
-      expect(tc.isFieldPlural('b3')).toBe(false);
-      expect(tc.isFieldPlural('b4')).toBe(true);
-      expect(tc.isFieldNonNull('b1')).toBe(true);
-      expect(tc.isFieldNonNull('b2')).toBe(false);
-      expect(tc.isFieldNonNull('b3')).toBe(true);
-      expect(tc.isFieldNonNull('b4')).toBe(true);
 
-      tc.makeFieldPlural(['b1', 'b2', 'b3', 'unexisted']);
-      expect(tc.isFieldPlural('b1')).toBe(true);
-      expect(tc.isFieldPlural('b2')).toBe(true);
-      expect(tc.isFieldPlural('b3')).toBe(true);
+      it('makeFieldNonNull()', () => {
+        tc.setField('fieldNN', 'String');
+        expect(tc.getFieldType('fieldNN')).toBe(GraphQLString);
 
-      tc.makeFieldNonNull('b2');
-      expect(tc.isFieldPlural('b2')).toBe(true);
-      expect(tc.isFieldNonNull('b2')).toBe(true);
-      tc.makeFieldNonPlural(['b2', 'b4', 'unexisted']);
-      expect(tc.isFieldPlural('b2')).toBe(false);
-      expect(tc.isFieldNonNull('b2')).toBe(true);
-      expect(tc.isFieldPlural('b4')).toBe(false);
-      tc.makeFieldNullable(['b2', 'b4', 'unexisted']);
-      expect(tc.isFieldNonNull('b2')).toBe(false);
-      expect(tc.isFieldNonNull('b4')).toBe(false);
-    });
+        // should wrap with GraphQLNonNull
+        tc.makeFieldNonNull('fieldNN');
+        expect(tc.getFieldType('fieldNN')).toBeInstanceOf(GraphQLNonNull);
+        expect((tc.getFieldType('fieldNN'): any).ofType).toBe(GraphQLString);
 
-    it('check Plural methods, wrap/unwrap from ListComposer', () => {
-      tc.setFields({
-        f: {
-          type: 'Int',
-          args: {
-            b1: { type: new GraphQLNonNull(GraphQLString) },
-            b2: { type: '[String]' },
-            b3: 'String!',
-            b4: '[String!]!',
+        // should not wrap twice
+        tc.makeFieldNonNull('fieldNN');
+        expect(tc.getFieldType('fieldNN')).toBeInstanceOf(GraphQLNonNull);
+        expect((tc.getFieldType('fieldNN'): any).ofType).toBe(GraphQLString);
+      });
+
+      it('makeFieldNullable()', () => {
+        tc.setField('fieldNN', 'String!');
+        expect(tc.getFieldType('fieldNN')).toBeInstanceOf(GraphQLNonNull);
+        expect((tc.getFieldType('fieldNN'): any).ofType).toBe(GraphQLString);
+
+        // should unwrap GraphQLNonNull
+        tc.makeFieldNullable('fieldNN');
+        expect(tc.getFieldType('fieldNN')).toBe(GraphQLString);
+
+        // should work for already unwrapped type
+        tc.makeFieldNullable('fieldNN');
+        expect(tc.getFieldType('fieldNN')).toBe(GraphQLString);
+      });
+
+      it('check field Plural methods, wrap/unwrap from ListComposer', () => {
+        tc.setFields({
+          b1: { type: new GraphQLNonNull(GraphQLString) },
+          b2: { type: '[String]' },
+          b3: 'String!',
+          b4: '[String!]!',
+        });
+        expect(tc.isFieldPlural('b1')).toBe(false);
+        expect(tc.isFieldPlural('b2')).toBe(true);
+        expect(tc.isFieldPlural('b3')).toBe(false);
+        expect(tc.isFieldPlural('b4')).toBe(true);
+        expect(tc.isFieldNonNull('b1')).toBe(true);
+        expect(tc.isFieldNonNull('b2')).toBe(false);
+        expect(tc.isFieldNonNull('b3')).toBe(true);
+        expect(tc.isFieldNonNull('b4')).toBe(true);
+
+        tc.makeFieldPlural(['b1', 'b2', 'b3', 'unexisted']);
+        expect(tc.isFieldPlural('b1')).toBe(true);
+        expect(tc.isFieldPlural('b2')).toBe(true);
+        expect(tc.isFieldPlural('b3')).toBe(true);
+
+        tc.makeFieldNonNull('b2');
+        expect(tc.isFieldPlural('b2')).toBe(true);
+        expect(tc.isFieldNonNull('b2')).toBe(true);
+        tc.makeFieldNonPlural(['b2', 'b4', 'unexisted']);
+        expect(tc.isFieldPlural('b2')).toBe(false);
+        expect(tc.isFieldNonNull('b2')).toBe(true);
+        expect(tc.isFieldPlural('b4')).toBe(false);
+        tc.makeFieldNullable(['b2', 'b4', 'unexisted']);
+        expect(tc.isFieldNonNull('b2')).toBe(false);
+        expect(tc.isFieldNonNull('b4')).toBe(false);
+      });
+
+      it('check Plural methods, wrap/unwrap from ListComposer', () => {
+        tc.setFields({
+          f: {
+            type: 'Int',
+            args: {
+              b1: { type: new GraphQLNonNull(GraphQLString) },
+              b2: { type: '[String]' },
+              b3: 'String!',
+              b4: '[String!]!',
+            },
           },
-        },
+        });
+        expect(tc.isFieldArgPlural('f', 'b1')).toBe(false);
+        expect(tc.isFieldArgPlural('f', 'b2')).toBe(true);
+        expect(tc.isFieldArgPlural('f', 'b3')).toBe(false);
+        expect(tc.isFieldArgPlural('f', 'b4')).toBe(true);
+        expect(tc.isFieldArgNonNull('f', 'b1')).toBe(true);
+        expect(tc.isFieldArgNonNull('f', 'b2')).toBe(false);
+        expect(tc.isFieldArgNonNull('f', 'b3')).toBe(true);
+        expect(tc.isFieldArgNonNull('f', 'b4')).toBe(true);
+
+        tc.makeFieldArgPlural('f', ['b1', 'b2', 'b3', 'unexisted']);
+        expect(tc.isFieldArgPlural('f', 'b1')).toBe(true);
+        expect(tc.isFieldArgPlural('f', 'b2')).toBe(true);
+        expect(tc.isFieldArgPlural('f', 'b3')).toBe(true);
+
+        tc.makeFieldArgNonNull('f', 'b2');
+        expect(tc.isFieldArgPlural('f', 'b2')).toBe(true);
+        expect(tc.isFieldArgNonNull('f', 'b2')).toBe(true);
+        tc.makeFieldArgNonPlural('f', ['b2', 'b4', 'unexisted']);
+        expect(tc.isFieldArgPlural('f', 'b2')).toBe(false);
+        expect(tc.isFieldArgNonNull('f', 'b2')).toBe(true);
+        expect(tc.isFieldArgPlural('f', 'b4')).toBe(false);
+        tc.makeFieldArgNullable('f', ['b2', 'b4', 'unexisted']);
+        expect(tc.isFieldArgNonNull('f', 'b2')).toBe(false);
+        expect(tc.isFieldArgNonNull('f', 'b4')).toBe(false);
       });
-      expect(tc.isFieldArgPlural('f', 'b1')).toBe(false);
-      expect(tc.isFieldArgPlural('f', 'b2')).toBe(true);
-      expect(tc.isFieldArgPlural('f', 'b3')).toBe(false);
-      expect(tc.isFieldArgPlural('f', 'b4')).toBe(true);
-      expect(tc.isFieldArgNonNull('f', 'b1')).toBe(true);
-      expect(tc.isFieldArgNonNull('f', 'b2')).toBe(false);
-      expect(tc.isFieldArgNonNull('f', 'b3')).toBe(true);
-      expect(tc.isFieldArgNonNull('f', 'b4')).toBe(true);
+    });
 
-      tc.makeFieldArgPlural('f', ['b1', 'b2', 'b3', 'unexisted']);
-      expect(tc.isFieldArgPlural('f', 'b1')).toBe(true);
-      expect(tc.isFieldArgPlural('f', 'b2')).toBe(true);
-      expect(tc.isFieldArgPlural('f', 'b3')).toBe(true);
-
-      tc.makeFieldArgNonNull('f', 'b2');
-      expect(tc.isFieldArgPlural('f', 'b2')).toBe(true);
-      expect(tc.isFieldArgNonNull('f', 'b2')).toBe(true);
-      tc.makeFieldArgNonPlural('f', ['b2', 'b4', 'unexisted']);
-      expect(tc.isFieldArgPlural('f', 'b2')).toBe(false);
-      expect(tc.isFieldArgNonNull('f', 'b2')).toBe(true);
-      expect(tc.isFieldArgPlural('f', 'b4')).toBe(false);
-      tc.makeFieldArgNullable('f', ['b2', 'b4', 'unexisted']);
-      expect(tc.isFieldArgNonNull('f', 'b2')).toBe(false);
-      expect(tc.isFieldArgNonNull('f', 'b4')).toBe(false);
+    it('check getters List, NonNull', () => {
+      const UserTC = schemaComposer.createObjectTC(`type User { name: String }`);
+      expect(UserTC.List).toBeInstanceOf(ListComposer);
+      expect(UserTC.List.ofType).toBe(UserTC);
+      expect(UserTC.List.getTypeName()).toBe('[User]');
+      expect(UserTC.NonNull).toBeInstanceOf(NonNullComposer);
+      expect(UserTC.NonNull.ofType).toBe(UserTC);
+      expect(UserTC.NonNull.getTypeName()).toBe('User!');
+      expect(UserTC.NonNull.List).toBeInstanceOf(ListComposer);
+      expect(UserTC.NonNull.List.getTypeName()).toBe('[User!]');
+      expect(UserTC.NonNull.List.NonNull).toBeInstanceOf(NonNullComposer);
+      expect(UserTC.NonNull.List.NonNull.getTypeName()).toBe('[User!]!');
     });
   });
 

--- a/src/__tests__/ScalarTypeComposer-test.js
+++ b/src/__tests__/ScalarTypeComposer-test.js
@@ -125,6 +125,20 @@ describe('ScalarTypeComposer', () => {
       expect(stc.getTypeNonNull()).toBeInstanceOf(NonNullComposer);
       expect(stc.getTypeNonNull().ofType).toBe(stc);
     });
+
+    it('check getters List, NonNull', () => {
+      const ColorTC = schemaComposer.createScalarTC(`scalar Color`);
+      expect(ColorTC.List).toBeInstanceOf(ListComposer);
+      expect(ColorTC.List.ofType).toBe(ColorTC);
+      expect(ColorTC.List.getTypeName()).toBe('[Color]');
+      expect(ColorTC.NonNull).toBeInstanceOf(NonNullComposer);
+      expect(ColorTC.NonNull.ofType).toBe(ColorTC);
+      expect(ColorTC.NonNull.getTypeName()).toBe('Color!');
+      expect(ColorTC.NonNull.List).toBeInstanceOf(ListComposer);
+      expect(ColorTC.NonNull.List.getTypeName()).toBe('[Color!]');
+      expect(ColorTC.NonNull.List.NonNull).toBeInstanceOf(NonNullComposer);
+      expect(ColorTC.NonNull.List.NonNull.getTypeName()).toBe('[Color!]!');
+    });
   });
 
   describe('clone()', () => {

--- a/src/__tests__/ThunkComposer-test.js
+++ b/src/__tests__/ThunkComposer-test.js
@@ -82,6 +82,16 @@ describe('ThunkComposer', () => {
     expect(tc.getTypeNonNull().ofType).toBe(tc);
   });
 
+  it('check getters List, NonNull', () => {
+    expect(tc.List).toBeInstanceOf(ListComposer);
+    expect(tc.List.ofType).toBe(tc);
+    expect(tc.List.getTypeName()).toBe('[User]');
+    expect(tc.NonNull).toBeInstanceOf(NonNullComposer);
+    expect(tc.NonNull.ofType).toBe(tc);
+    expect(tc.NonNull.getTypeName()).toBe('User!');
+    expect(tc.NonNull.List.NonNull.getTypeName()).toBe('[User!]!');
+  });
+
   it('getUnwrappedTC() should return NamedTypeComposer', () => {
     const UserTC1 = tc.getUnwrappedTC();
     expect(UserTC1).toBeInstanceOf(ObjectTypeComposer);

--- a/src/__tests__/UnionTypeComposer-test.js
+++ b/src/__tests__/UnionTypeComposer-test.js
@@ -299,6 +299,20 @@ describe('UnionTypeComposer', () => {
       utc.setTypeName('NewUnionName');
       expect(utc.getTypeName()).toBe('NewUnionName');
     });
+
+    it('check getters List, NonNull', () => {
+      const UserTC = schemaComposer.createUnionTC(`union User = Admin | Client`);
+      expect(UserTC.List).toBeInstanceOf(ListComposer);
+      expect(UserTC.List.ofType).toBe(UserTC);
+      expect(UserTC.List.getTypeName()).toBe('[User]');
+      expect(UserTC.NonNull).toBeInstanceOf(NonNullComposer);
+      expect(UserTC.NonNull.ofType).toBe(UserTC);
+      expect(UserTC.NonNull.getTypeName()).toBe('User!');
+      expect(UserTC.NonNull.List).toBeInstanceOf(ListComposer);
+      expect(UserTC.NonNull.List.getTypeName()).toBe('[User!]');
+      expect(UserTC.NonNull.List.NonNull).toBeInstanceOf(NonNullComposer);
+      expect(UserTC.NonNull.List.NonNull.getTypeName()).toBe('[User!]!');
+    });
   });
 
   it('should have chainable methods', () => {


### PR DESCRIPTION
It helps to simplify your code and make it more readable:

```diff
const UserTC = schemaComposer.createObjectTC(`type User { name: String }`);
schemaComposer.Query.addFields({
-  users: { type: UserTC.getTypeNonNull().getTypePlural() }
+  users: { type: UserTC.NonNull.List }
});
```