### PR TITLE
feat: support for adding interfaces to other interfaces

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ node_js:
 script:
   - yarn run test
   - yarn run build
+  - echo "[COMPATIBILITY CHECK] Testing with previous graphql versions..."
+  - yarn run test-prev-vers
 after_success:
   - 'curl -Lo travis_after_all.py https://git.io/travis_after_all'
   - python travis_after_all.py

--- a/README.md
+++ b/README.md
@@ -12,9 +12,7 @@
 [![Backers on Open Collective](https://opencollective.com/graphql-compose/backers/badge.svg)](#backers)
 [![Sponsors on Open Collective](https://opencollective.com/graphql-compose/sponsors/badge.svg)](#sponsors)
 
-[GraphQL](http://graphql.org/) – is a query language for APIs. [graphql-js](https://github.com/graphql/graphql-js) is the reference implementation of GraphQL for nodejs which introduce GraphQL type system for describing schema _(definition over configuration)_ and executes queries on the server side. [express-graphql](https://github.com/graphql/express-graphql) is a HTTP server which gets request data, passes it to `graphql-js` and returned result passes to response.
-
-**`graphql-compose`** – the _imperative tool_ which works on top of `graphql-js`. It provides some methods for creating types and GraphQL Models (so I call types with a list of common resolvers) for further building of complex relations in your schema.
+**`graphql-compose`** – provides a type registry with a bunch of methods for programmatic schema construction. It allows not only to extend types but also remove fields, interfaces, args. **If you want to write your graphql schema generator – `graphql-compose` is a good instrument for you.**
 
 * provides methods for editing GraphQL output/input types (add/remove fields/args/interfaces)
 * introduces `Resolver`s – the named graphql fieldConfigs, which can be used for finding, updating, removing records
@@ -24,16 +22,18 @@
 * provides `GraphQL schema language` for defining simple types
 * adds additional types `Date`, `Json`
 
+## And a little bit more
+
 **`graphql-compose-[plugin]`** – are _declarative generators/plugins_ built on top of `graphql-compose`, which take some ORMs, schema definitions and create GraphQL Models from them or modify existing GraphQL Types.
 
-Type generator plugins:
+### Type generators built on top `graphql-compose`
 
 * [graphql-compose-json](https://github.com/graphql-compose/graphql-compose-json) - generates GraphQL type from JSON (a good helper for wrapping REST APIs)
 * [graphql-compose-mongoose](https://github.com/graphql-compose/graphql-compose-mongoose) - generates GraphQL types from mongoose (MongoDB models) with Resolvers.
 * [graphql-compose-elasticsearch](https://github.com/graphql-compose/graphql-compose-elasticsearch) - generates GraphQL types from elastic mappings; ElasticSearch REST API proxy via GraphQL.
 * [graphql-compose-aws](https://github.com/graphql-compose/graphql-compose-aws) - expose AWS Cloud API via GraphQL
 
-Utility plugins:
+### Utility plugins:
 
 * [graphql-compose-relay](https://github.com/graphql-compose/graphql-compose-relay) - reassemble GraphQL types with `Relay` specific things, like `Node` type and interface, `globalId`, `clientMutationId`.
 * [graphql-compose-connection](https://github.com/graphql-compose/graphql-compose-connection) - generates `connection` Resolver from `findMany` and `count` Resolvers.

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "flow": "./node_modules/.bin/flow",
     "test": "npm run coverage && npm run lint && npm run flow && npm run tscheck",
     "semantic-release": "semantic-release",
-    "test-vers": "yarn add graphql@0.13.0 --dev && jest && yarn add graphql@14.0.0 --dev && jest"
+    "test-prev-vers": "yarn add graphql@14.2.0 --dev && jest && git checkout HEAD -- package.json yarn.lock"
   },
   "collective": {
     "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "flow": "./node_modules/.bin/flow",
     "test": "npm run coverage && npm run lint && npm run flow && npm run tscheck",
     "semantic-release": "semantic-release",
-    "test-prev-vers": "yarn add graphql@14.2.0 --dev && jest && git checkout HEAD -- package.json yarn.lock"
+    "test-prev-vers": "yarn add graphql@14.2.0 --dev && jest && yarn remove graphql && yarn add graphql --dev --exact && git checkout HEAD -- package.json yarn.lock"
   },
   "collective": {
     "type": "opencollective",

--- a/src/TypeMapper.js
+++ b/src/TypeMapper.js
@@ -990,7 +990,11 @@ export class TypeMapper<TContext> {
   }
 
   makeImplementedInterfaces(
-    def: ObjectTypeDefinitionNode | ObjectTypeExtensionNode
+    def:
+      | ObjectTypeDefinitionNode
+      | ObjectTypeExtensionNode
+      | InterfaceTypeDefinitionNode
+      | InterfaceTypeExtensionNode
   ): Array<InterfaceTypeComposerThunked<any, TContext>> {
     return (def.interfaces || []).map((iface) => {
       const name = this.getNamedTypeAST(iface).name.value;
@@ -1021,6 +1025,7 @@ export class TypeMapper<TContext> {
       name: def.name.value,
       description: getDescription(def),
       fields: this.makeFieldDefMap(def),
+      interfaces: this.makeImplementedInterfaces(def),
       astNode: def,
     });
     if (def.directives) {

--- a/src/utils/schemaPrinter.js
+++ b/src/utils/schemaPrinter.js
@@ -298,7 +298,8 @@ export function printObject(type: GraphQLObjectType, options?: Options): string 
 
 export function printInterface(type: GraphQLInterfaceType, options?: Options): string {
   return `${printDescription(type, options)}interface ${type.name}${printImplementedInterfaces(
-    type
+    type,
+    options
   )}${printNodeDirectives(type.astNode)}${printFields(type, options)}`;
 }
 


### PR DESCRIPTION
From GraphQL 15.0.0 Interfaces can now implement other interfaces. So adding the following helper methods to `InterfaceTypeComposer`:
- `getInterfaces()`
- `getInterfacesTypes()`
- `setInterfaces()`
- `hasInterface()`
- `addInterface()`
- `addInterfaces()`
- `removeInterface()`

Closes #251
