### PR TITLE
Update Resolver.wrap()

### DIFF
--- a/docs/basics/what-is-resolver.md
+++ b/docs/basics/what-is-resolver.md
@@ -188,7 +188,7 @@ const findManyReduced = AuthorTC.getResolver('findMany').wrap(newResolver => {
   // for new created resolver, clone its `filter` argument with a new name
   newResolver.cloneArg('filter', 'AuthorFilterForUsers');
   // remove some filter fields to which regular users should not have access
-  newResolver.getArgTC('filter').removeFields(['age', 'other_sensetive_filter']);
+  newResolver.getArgITC('filter').removeFields(['age', 'other_sensetive_filter']);
   // and return modified resolver with new set of args
   return newResolver;
 });


### PR DESCRIPTION
``` diff
- newResolver.getArgTC('filter').removeFields(['age', 'other_sensetive_filter']);
+ newResolver.getArgITC('filter').removeFields(['age', 'other_sensetive_filter']);
```

The former throws an error.

``` zsh
- error TS2339: Property 'removeField' does not exist on type 'ComposeNamedInputType<unknown>'.
  Property 'removeField' does not exist on type 'ScalarTypeComposer<unknown>'.

13                      resolver.getArgTC('record').removeField(['role', 'is_active', 'is_deleted', '_id']);
                                                    ~~~~~~~~~~~

```

Arguments uses InputTypeComposer (ITC) and not the regular ObjectTypeComposer