### PR TITLE
Targeted projection

### DIFF
--- a/src/utils/__tests__/projection-test.js
+++ b/src/utils/__tests__/projection-test.js
@@ -85,6 +85,18 @@ describe('projection', () => {
       });
     });
 
+    it('targeted simple query nested', async () => {
+      const info = await getResolveInfo(`
+        query {
+          field0 {
+            field1a { field2a }
+            field1b
+          }
+        }
+      `);
+      expect(getProjectionFromAST(info, null, 'field1a.field2a')).toEqual({});
+    });
+
     it('inline fragments', async () => {
       const info = await getResolveInfo(`
         query {
@@ -119,6 +131,21 @@ describe('projection', () => {
         field2a: {},
         field2b: {},
       });
+    });
+
+    it('targeted inline fragments nested', async () => {
+      const info = await getResolveInfo(`
+        query {
+          field0 {
+            field1a { field2a }
+            ... {
+              field1a { field2b }
+              field1b
+            }
+          }
+        }
+      `);
+      expect(getProjectionFromAST(info, null, 'field1a.field2b')).toEqual({});
     });
 
     it('fragment spreads', async () => {

--- a/src/utils/__tests__/projection-test.js
+++ b/src/utils/__tests__/projection-test.js
@@ -71,6 +71,20 @@ describe('projection', () => {
       });
     });
 
+    it('targeted simple query', async () => {
+      const info = await getResolveInfo(`
+        query {
+          field0 {
+            field1a { field2a }
+            field1b
+          }
+        }
+      `);
+      expect(getProjectionFromAST(info, null, 'field1a')).toEqual({
+        field2a: {},
+      });
+    });
+
     it('inline fragments', async () => {
       const info = await getResolveInfo(`
         query {
@@ -86,6 +100,24 @@ describe('projection', () => {
       expect(getProjectionFromAST(info)).toEqual({
         field1a: { field2a: {}, field2b: {} },
         field1b: {},
+      });
+    });
+
+    it('targeted inline fragments', async () => {
+      const info = await getResolveInfo(`
+        query {
+          field0 {
+            field1a { field2a }
+            ... {
+              field1a { field2b }
+              field1b
+            }
+          }
+        }
+      `);
+      expect(getProjectionFromAST(info, null, 'field1a')).toEqual({
+        field2a: {},
+        field2b: {},
       });
     });
 
@@ -107,6 +139,26 @@ describe('projection', () => {
       expect(getProjectionFromAST(info)).toEqual({
         field1a: { field2b: {} },
         field1b: {},
+      });
+    });
+
+    it('targeted fragment spreads', async () => {
+      const info = await getResolveInfo(`
+        query {
+          field0 {
+            ...Frag
+            field1b
+          }
+        }
+
+        fragment Frag on Level1 {
+          field1a {
+            field2b
+          }
+        }
+      `);
+      expect(getProjectionFromAST(info, null, 'field1a')).toEqual({
+        field2b: {},
       });
     });
 

--- a/src/utils/projection.js
+++ b/src/utils/projection.js
@@ -27,7 +27,8 @@ export type ProjectionNode = { [fieldName: string]: any };
 
 export function getProjectionFromAST(
   info: GraphQLResolveInfo,
-  fieldNode?: FieldNode | InlineFragmentNode | FragmentDefinitionNode
+  fieldNode?: FieldNode | InlineFragmentNode | FragmentDefinitionNode,
+  queryName?: string
 ): ProjectionType {
   if (!info) {
     return {};
@@ -35,6 +36,11 @@ export function getProjectionFromAST(
 
   const queryProjection = getProjectionFromASTquery(info, fieldNode);
   const queryExtProjection = extendByFieldProjection(info.returnType, queryProjection);
+  if (queryName) {
+    if (queryExtProjection[queryName]) {
+      return queryExtProjection[queryName];
+    }
+  }
   return queryExtProjection;
 }
 

--- a/src/utils/projection.js
+++ b/src/utils/projection.js
@@ -39,6 +39,14 @@ export function getProjectionFromAST(
   if (queryName) {
     if (queryExtProjection[queryName]) {
       return queryExtProjection[queryName];
+    } else if (queryName.split('.').length > 1) {
+      let result = { ...queryExtProjection };
+      queryName.split('.').forEach((name) => {
+        if (result[name]) {
+          result = result[name];
+        }
+      });
+      return result;
     }
   }
   return queryExtProjection;


### PR DESCRIPTION
Closes #289 

Allows a user to return a targeted portion of the request tree after projection has parsed `ast`