### PR TITLE
feat(buildSchema): add option to keep unused types

### DIFF
--- a/src/SchemaComposer.d.ts
+++ b/src/SchemaComposer.d.ts
@@ -3,8 +3,10 @@ import {
   GraphQLNamedType,
   GraphQLDirective,
   SchemaDefinitionNode,
+  SchemaExtensionNode,
   GraphQLResolveInfo,
   GraphQLType,
+  GraphQLSchemaExtensions,
 } from 'graphql';
 import { ObjectTypeComposer, ObjectTypeComposerDefinition } from './ObjectTypeComposer';
 import { InputTypeComposer, InputTypeComposerDefinition } from './InputTypeComposer';
@@ -12,8 +14,6 @@ import { ScalarTypeComposer, ScalarTypeComposerDefinition } from './ScalarTypeCo
 import { EnumTypeComposer, EnumTypeComposerDefinition } from './EnumTypeComposer';
 import { InterfaceTypeComposer, InterfaceTypeComposerDefinition } from './InterfaceTypeComposer';
 import { UnionTypeComposer, UnionTypeComposerDefinition } from './UnionTypeComposer';
-import { ListComposer } from './ListComposer';
-import { NonNullComposer } from './NonNullComposer';
 import { TypeStorage } from './TypeStorage';
 import { TypeMapper } from './TypeMapper';
 import { Resolver, ResolverDefinition } from './Resolver';
@@ -21,10 +21,14 @@ import { NamedTypeComposer, AnyType } from './utils/typeHelpers';
 import { SchemaComposerPrinterOptions, SchemaPrinterOptions } from './utils/schemaPrinter';
 
 type ExtraSchemaConfig = {
+  description?: string | null;
   types?: GraphQLNamedType[] | null;
   directives?: GraphQLDirective[] | null;
+  extensions?: GraphQLSchemaExtensions | null;
   astNode?: SchemaDefinitionNode | null;
-  description?: string | null;
+  extensionASTNodes?: ReadonlyArray<SchemaExtensionNode> | null;
+  /** You may pass all unused types from type registry to GraphQL schema if set this option to `true` */
+  keepUnusedTypes?: boolean | null;
 };
 
 type GraphQLToolsResolveMethods<TContext> = {

--- a/src/__tests__/SchemaComposer-test.js
+++ b/src/__tests__/SchemaComposer-test.js
@@ -1,6 +1,6 @@
 /* @flow strict */
 
-import { printSchema } from 'graphql';
+import { printSchema, buildSchema } from 'graphql';
 import { SchemaComposer, BUILT_IN_DIRECTIVES } from '../SchemaComposer';
 import { ObjectTypeComposer } from '../ObjectTypeComposer';
 import { InputTypeComposer } from '../InputTypeComposer';
@@ -25,7 +25,6 @@ import {
 } from '../graphql';
 import { dedent } from '../utils/dedent';
 import { graphqlVersion } from '../utils/graphqlVersion';
-import { buildSchema } from 'graphql';
 
 describe('SchemaComposer', () => {
   it('should implements `add` method', () => {
@@ -348,14 +347,6 @@ describe('SchemaComposer', () => {
           `,
         })
       ).toEqual({ data: { num: null } });
-    });
-
-    it('should throw error if only Mutation provided', async () => {
-      const sc = new SchemaComposer();
-      sc.Mutation.addFields({ num: 'Int' });
-      expect(() => {
-        sc.buildSchema();
-      }).toThrow('Must be initialized Query type');
     });
 
     it('should keep unused types', () => {


### PR DESCRIPTION
Closes https://github.com/graphql-compose/graphql-compose/issues/293

This PR adds a `keepUnusedTypes` config option to `buildSchema()`, which defaults to false, so there is no breaking change to this change.

## Verification

See the unit test added.