### PR TITLE
fix: stack overflow for fields defined as thunks

### DIFF
--- a/src/__tests__/github_issues/314-test.js
+++ b/src/__tests__/github_issues/314-test.js
@@ -29,7 +29,7 @@ describe('github issue #314: Fields defined as thunk with arguments causes stack
       composer.buildSchema();
     }).not.toThrowError(`Maximum call stack size exceeded`);
 
-    const schema = composer.buildSchema();
+    const schema: any = composer.buildSchema();
     const barArg = schema.getType(`Foo`).getFields().bar.args[0];
     expect(barArg.type.name).toEqual(`Boolean`);
   });

--- a/src/__tests__/github_issues/314-test.js
+++ b/src/__tests__/github_issues/314-test.js
@@ -30,7 +30,7 @@ describe('github issue #314: Fields defined as thunk with arguments causes stack
     }).not.toThrowError(`Maximum call stack size exceeded`);
 
     const schema = composer.buildSchema();
-    const barArg = schema.getType(`Foo`).getFields()[`bar`].args[0];
+    const barArg = schema.getType(`Foo`).getFields().bar.args[0];
     expect(barArg.type.name).toEqual(`Boolean`);
   });
 });

--- a/src/__tests__/github_issues/314-test.js
+++ b/src/__tests__/github_issues/314-test.js
@@ -1,0 +1,36 @@
+/* @flow */
+
+import { SchemaComposer, ObjectTypeComposer } from '../..';
+
+describe('github issue #314: Fields defined as thunk with arguments causes stack overflow', () => {
+  it('should build schema successfully', async () => {
+    const composer = new SchemaComposer();
+    ObjectTypeComposer.create(
+      {
+        name: 'Foo',
+        fields: () => ({
+          bar: {
+            type: `Boolean`,
+            args: {
+              baz: {
+                type: `Boolean`,
+              },
+            },
+          },
+        }),
+      },
+      composer
+    );
+    composer.Query.addFields({
+      foo: `Foo`,
+    });
+
+    expect(() => {
+      composer.buildSchema();
+    }).not.toThrowError(`Maximum call stack size exceeded`);
+
+    const schema = composer.buildSchema();
+    const barArg = schema.getType(`Foo`).getFields()[`bar`].args[0];
+    expect(barArg.type.name).toEqual(`Boolean`);
+  });
+});

--- a/src/utils/configToDefine.js
+++ b/src/utils/configToDefine.js
@@ -141,16 +141,17 @@ export function convertObjectFieldMapToConfig(
     } else if (isObject(fc.args)) {
       // `fc.args` is Object in `ObjectTypeComposerFieldConfigMapDefinition`
       Object.keys(fc.args).forEach((argName) => {
+        const sourceArgs = fc.args;
         args[argName] = {
-          ...(isObject(fc.args[argName]) ? fc.args[argName] : null),
+          ...(isObject(sourceArgs[argName]) ? sourceArgs[argName] : null),
           type: isThunk
             ? new ThunkComposer(() =>
                 schemaComposer.typeMapper.convertInputTypeDefinition(
-                  fc.args[argName].type || fc.args[argName]
+                  sourceArgs[argName].type || sourceArgs[argName]
                 )
               )
             : schemaComposer.typeMapper.convertInputTypeDefinition(
-                fc.args[argName].type || fc.args[argName]
+                sourceArgs[argName].type || sourceArgs[argName]
               ),
         };
       });


### PR DESCRIPTION
This PR fixes a bug with thunk composers, outlined in #314 

The root cause is this thunk composer:

https://github.com/graphql-compose/graphql-compose/blob/ffeeab6de8178c7fd34ee96bce308c67caba7ae2/src/utils/configToDefine.js#L146-L157

When this thunk is invoked, the actual value of `fc.args[argName].type` points to the same exact thunk composer because `fc.args` is re-assigned on the last line.

Fixes #314 