### PR TITLE
perf: optimize expensive .find() calls within loops

### DIFF
--- a/src/utils/configToDefine.js
+++ b/src/utils/configToDefine.js
@@ -202,6 +202,12 @@ export function defineEnumValues(
     isPlainObj(valueMap),
     `${type.name} values must be an object with value names as keys.`
   );
+
+  const astNodeMap = Object.create(null);
+  for (const valueNode of parentAstNode?.values ?? []) {
+    astNodeMap[valueNode.name.value] = valueNode;
+  }
+
   return Object.keys(valueMap).map((valueName) => {
     const value = valueMap[valueName];
     invariant(
@@ -218,8 +224,7 @@ export function defineEnumValues(
       description: value.description,
       isDeprecated: Boolean(value.deprecationReason),
       deprecationReason: value.deprecationReason,
-      // $FlowFixMe
-      astNode: parentAstNode?.values?.find((v) => v.name.value === valueName),
+      astNode: astNodeMap[valueName],
       value: value.hasOwnProperty('value') ? value.value : valueName,
       extensions: undefined,
     };

--- a/src/utils/configToDefine.js
+++ b/src/utils/configToDefine.js
@@ -259,13 +259,17 @@ export function defineInputFieldMap(
     `${config.name} fields must be an object with field names as keys or a ` +
       'function which returns such an object.'
   );
+  const astNodeMap = Object.create(null);
+  for (const fieldNode of parentAstNode?.fields ?? []) {
+    astNodeMap[fieldNode.name.value] = fieldNode;
+  }
+
   const resultFieldMap = Object.create(null);
   for (const fieldName of Object.keys(fieldMap)) {
     const field = {
       ...fieldMap[fieldName],
       name: fieldName,
-      // $FlowFixMe
-      astNode: parentAstNode?.fields?.find((f) => f.name.value === fieldName),
+      astNode: astNodeMap[fieldName],
     };
     invariant(
       !field.hasOwnProperty('resolve'),


### PR DESCRIPTION
Hey @nodkz 👋 

We've faced significant performance regression in Gatsby when building a huge schema on v7. For v6 that schema took 12 seconds to build, for v7 - 66 seconds (this schema has 50000+ values in several of its enum types - don't ask why 😅).

I've narrowed down the problem to expensive `.find()` calls when assigning `astNode` which makes corresponding methods O(N^2). For 50000+ values that gets pretty messy.

This PR replaces those `.find()` calls in loops with quick map lookups which makes is O(N). And in my tests that beast schema builds in 12 seconds again with this PR.