### PR TITLE
feat: allow skipping unions when building input types

### DIFF
--- a/src/InterfaceTypeComposer.d.ts
+++ b/src/InterfaceTypeComposer.d.ts
@@ -34,6 +34,7 @@ import { ListComposer } from './ListComposer';
 import { NonNullComposer } from './NonNullComposer';
 import { TypeInPath } from './utils/typeByPath';
 import { SchemaPrinterOptions } from './utils/schemaPrinter';
+import { ToInputTypeOpts } from './utils/toInputType';
 
 export type InterfaceTypeComposerDefinition<TSource, TContext> =
   | TypeAsString
@@ -313,12 +314,12 @@ export class InterfaceTypeComposer<TSource = any, TContext = any> {
 
   public setInputTypeComposer(itc: InputTypeComposer<TContext>): this;
 
-  public getInputTypeComposer(): InputTypeComposer<TContext>;
+  public getInputTypeComposer(opts?: ToInputTypeOpts): InputTypeComposer<TContext>;
 
   /**
    * An alias for `getInputTypeComposer()`
    */
-  public getITC(): InputTypeComposer<TContext>;
+  public getITC(opts?: ToInputTypeOpts): InputTypeComposer<TContext>;
 
   public removeInputTypeComposer(): this;
 

--- a/src/InterfaceTypeComposer.js
+++ b/src/InterfaceTypeComposer.js
@@ -41,6 +41,7 @@ import type {
   ExtensionsDirective,
 } from './utils/definitions';
 import { toInputObjectType } from './utils/toInputType';
+import type { ToInputTypeOpts } from './utils/toInputType';
 import { typeByPath, type TypeInPath } from './utils/typeByPath';
 import {
   getComposeTypeName,
@@ -1001,16 +1002,16 @@ export class InterfaceTypeComposer<TSource, TContext> {
     return this;
   }
 
-  getInputTypeComposer(): InputTypeComposer<TContext> {
+  getInputTypeComposer(opts?: ToInputTypeOpts): InputTypeComposer<TContext> {
     if (!this._gqcInputTypeComposer) {
-      this._gqcInputTypeComposer = toInputObjectType(this);
+      this._gqcInputTypeComposer = toInputObjectType(this, opts);
     }
 
     return this._gqcInputTypeComposer;
   }
 
-  getITC(): InputTypeComposer<TContext> {
-    return this.getInputTypeComposer();
+  getITC(opts?: ToInputTypeOpts): InputTypeComposer<TContext> {
+    return this.getInputTypeComposer(opts);
   }
 
   removeInputTypeComposer(): InterfaceTypeComposer<TSource, TContext> {

--- a/src/ObjectTypeComposer.d.ts
+++ b/src/ObjectTypeComposer.d.ts
@@ -50,6 +50,7 @@ import { NonNullComposer } from './NonNullComposer';
 import { ListComposer } from './ListComposer';
 import { TypeInPath } from './utils/typeByPath';
 import { SchemaPrinterOptions } from './utils/schemaPrinter';
+import { ToInputTypeOpts } from './utils/toInputType';
 
 export type ObjectTypeComposerDefinition<TSource, TContext> =
   | TypeAsString
@@ -493,9 +494,9 @@ export class ObjectTypeComposer<TSource = any, TContext = any> {
 
   public setInputTypeComposer(itc: InputTypeComposer<TContext>): this;
 
-  public getInputTypeComposer(): InputTypeComposer<TContext>;
+  public getInputTypeComposer(opts?: ToInputTypeOpts): InputTypeComposer<TContext>;
 
-  public getITC(): InputTypeComposer<TContext>;
+  public getITC(opts?: ToInputTypeOpts): InputTypeComposer<TContext>;
 
   public removeInputTypeComposer(): this;
 

--- a/src/ObjectTypeComposer.js
+++ b/src/ObjectTypeComposer.js
@@ -41,6 +41,7 @@ import {
   convertInterfaceArrayAsThunk,
 } from './utils/configToDefine';
 import { toInputObjectType } from './utils/toInputType';
+import type { ToInputTypeOpts } from './utils/toInputType';
 import { typeByPath, type TypeInPath } from './utils/typeByPath';
 import {
   getComposeTypeName,
@@ -1201,17 +1202,17 @@ export class ObjectTypeComposer<TSource, TContext> {
     return this;
   }
 
-  getInputTypeComposer(): InputTypeComposer<TContext> {
+  getInputTypeComposer(opts?: ToInputTypeOpts): InputTypeComposer<TContext> {
     if (!this._gqcInputTypeComposer) {
-      this._gqcInputTypeComposer = toInputObjectType(this);
+      this._gqcInputTypeComposer = toInputObjectType(this, opts);
     }
 
     return this._gqcInputTypeComposer;
   }
 
   // Alias for getInputTypeComposer()
-  getITC(): InputTypeComposer<TContext> {
-    return this.getInputTypeComposer();
+  getITC(opts?: ToInputTypeOpts): InputTypeComposer<TContext> {
+    return this.getInputTypeComposer(opts);
   }
 
   removeInputTypeComposer(): ObjectTypeComposer<TSource, TContext> {

--- a/src/utils/__tests__/toInputType-test.js
+++ b/src/utils/__tests__/toInputType-test.js
@@ -178,4 +178,48 @@ describe('toInputObjectType()', () => {
       expect(itc.getTypeName()).toBe('ExampleInput');
     }
   });
+
+  describe('fallbackType option', () => {
+    let tc: ObjectTypeComposer;
+
+    beforeEach(() => {
+      sc.clear();
+      sc.addTypeDefs(`
+        union SearchResult = Post | Comment
+
+        type Post {
+          title: String
+        }
+
+        type Comment {
+          text: String
+        }
+      `);
+      tc = ObjectTypeComposer.create(
+        `
+        type Example {
+          name: String
+          union: SearchResult
+        }
+      `,
+        sc
+      );
+    });
+
+    it('should throw error on field with Union type', () => {
+      expect(() => {
+        toInputObjectType(tc);
+      }).toThrowError("Can not convert field 'Example.union' to InputType");
+    });
+
+    it('should use type from fallbackType option for union', () => {
+      const itc = toInputObjectType(tc, { fallbackType: 'JSON' });
+      expect(itc.getFieldTypeName('union')).toBe('JSON');
+    });
+
+    it('should remove union field if fallbackType: null', () => {
+      const itc = toInputObjectType(tc, { fallbackType: null });
+      expect(itc.hasField('union')).toBeFalsy();
+    });
+  });
 });

--- a/src/utils/__tests__/toInputType-test.js
+++ b/src/utils/__tests__/toInputType-test.js
@@ -180,7 +180,7 @@ describe('toInputObjectType()', () => {
   });
 
   describe('fallbackType option', () => {
-    let tc: ObjectTypeComposer;
+    let tc: ObjectTypeComposer<any, any>;
 
     beforeEach(() => {
       sc.clear();

--- a/src/utils/toInputType.d.ts
+++ b/src/utils/toInputType.d.ts
@@ -10,7 +10,7 @@ export interface ToInputTypeOpts {
   /** If ObjectType or Interface received then will be used `ObjectTypeName${suffix}` as name for new Input type */
   postfix?: string;
   /** When Union type is met then Error will be throw. This option helps to return provided fallbackType instead of Error. */
-  fallbackType?: ComposeInputType;
+  fallbackType?: ComposeInputType | null;
 }
 
 /**

--- a/src/utils/toInputType.js
+++ b/src/utils/toInputType.js
@@ -20,7 +20,7 @@ export type ToInputTypeOpts = {
   prefix?: string,
   /** If ObjectType or Interface received then will be used `ObjectTypeName${suffix}` as name for new Input type */
   postfix?: string,
-  /** When Union type is met then Error will be throw. This option helps to return provided fallbackType instead of Error. When set to `null` the field of union type is omitted. */
+  /** When Union type is met then Error will be throw. This option helps to return provided fallbackType instead of Error. */
   fallbackType?: ComposeInputType | null,
 };
 

--- a/src/utils/toInputType.js
+++ b/src/utils/toInputType.js
@@ -10,6 +10,7 @@ import {
   isSomeInputTypeComposer,
   type ComposeOutputType,
   type ComposeInputType,
+  type ComposeInputTypeDefinition,
   type AnyTypeComposer,
 } from './typeHelpers';
 import { inspect } from './misc';
@@ -21,7 +22,7 @@ export type ToInputTypeOpts = {
   /** If ObjectType or Interface received then will be used `ObjectTypeName${suffix}` as name for new Input type */
   postfix?: string,
   /** When Union type is met then Error will be throw. This option helps to return provided fallbackType instead of Error. */
-  fallbackType?: ComposeInputType | null,
+  fallbackType?: ComposeInputTypeDefinition | null,
 };
 
 /**
@@ -57,7 +58,7 @@ export function toInputType(anyTC: AnyTypeComposer<any>, opts?: ToInputTypeOpts)
     if (tc instanceof ObjectTypeComposer || tc instanceof InterfaceTypeComposer) {
       tc = toInputObjectType(tc, opts);
     } else {
-      if (opts?.fallbackType) return opts.fallbackType;
+      if (opts?.fallbackType) return (opts.fallbackType: any);
 
       if (tc instanceof UnionTypeComposer) {
         throw new Error(
@@ -104,7 +105,7 @@ export function toInputObjectType<TContext>(
   fieldNames.forEach((fieldName) => {
     const fc = tc.getField(fieldName);
 
-    let fieldInputType: ?ComposeInputType;
+    let fieldInputType: ?ComposeInputTypeDefinition;
     try {
       fieldInputType = toInputType(fc.type, opts);
     } catch (e) {

--- a/src/utils/toInputType.js
+++ b/src/utils/toInputType.js
@@ -20,8 +20,8 @@ export type ToInputTypeOpts = {
   prefix?: string,
   /** If ObjectType or Interface received then will be used `ObjectTypeName${suffix}` as name for new Input type */
   postfix?: string,
-  /** When Union type is met then Error will be throw. This option helps to return provided fallbackType instead of Error. */
-  fallbackType?: ComposeInputType,
+  /** When Union type is met then Error will be throw. This option helps to return provided fallbackType instead of Error. When set to `null` the field of union type is omitted. */
+  fallbackType?: ComposeInputType | null,
 };
 
 /**
@@ -108,7 +108,8 @@ export function toInputObjectType<TContext>(
     try {
       fieldInputType = toInputType(fc.type, opts);
     } catch (e) {
-      if (opts?.fallbackType) {
+      if (opts?.fallbackType || opts?.fallbackType === null) {
+        // Setting to null effectively skips this field
         fieldInputType = opts?.fallbackType;
       } else {
         throw new Error(


### PR DESCRIPTION
In the previous version of `graphql-compose` (v6) it was possible to skip unions when building input types. We are still relying on this behavior in Gatsby (and [actually miss it a lot](https://github.com/gatsbyjs/gatsby/pull/29090#discussion_r572370812))

`graphql-compose` v7 has `fallbackType` option but it doesn't allow you to skip the field altogether - it will still add the field with this fallback type.

This PR adds a simple workaround to make omitting unions possible again. As long as you pass `null` in `fallbackType` it will effectively omit fields of the union type when building input types.