### PR TITLE
fix: update .d.ts for InterfaceTypeComposer

### DIFF
--- a/src/InterfaceTypeComposer.d.ts
+++ b/src/InterfaceTypeComposer.d.ts
@@ -22,7 +22,13 @@ import {
   ObjectTypeComposerArgumentConfigMapDefinition,
   ObjectTypeComposerArgumentConfigDefinition,
 } from './ObjectTypeComposer';
-import { MaybePromise, Extensions, ExtensionsDirective, DirectiveArgs } from './utils/definitions';
+import {
+  MaybePromise,
+  Extensions,
+  ExtensionsDirective,
+  DirectiveArgs,
+  ThunkWithSchemaComposer,
+} from './utils/definitions';
 import { TypeAsString, TypeDefinitionString } from './TypeMapper';
 import { ThunkComposer } from './ThunkComposer';
 import {
@@ -45,6 +51,10 @@ export type InterfaceTypeComposerDefinition<TSource, TContext> =
 
 export type InterfaceTypeComposerAsObjectDefinition<TSource, TContext> = {
   name: string;
+  interfaces?: null | ThunkWithSchemaComposer<
+    Array<InterfaceTypeComposerDefinition<any, TContext>>,
+    SchemaComposer<TContext>
+  >;
   fields?: ObjectTypeComposerFieldConfigMapDefinition<TSource, TContext>;
   resolveType?: null | GraphQLTypeResolver<TSource, TContext>;
   description?: null | string;


### PR DESCRIPTION
GraphQL supports interface inheritance as of 15.0.0. This seems to be working fine with `graphql-compose` without any code changes (at least [our test](https://github.com/gatsbyjs/gatsby/blob/33e0f860b5eb9efee64929df000e854ec664a276/packages/gatsby/src/schema/__tests__/build-schema.js#L270-L276) in Gatsby passes).

But typescript definitions do not reflect that. This PR simply updates them.