### PR TITLE
Improve language and grammar

### DIFF
--- a/docs/basics/understanding-relations.md
+++ b/docs/basics/understanding-relations.md
@@ -3,7 +3,8 @@ id: understanding-relations
 title: Relations between Types
 ---
 
-The most important part of GraphQL is a relations between types.
+
+The most important part of GraphQL is a relation between types.
 
 ## Relation via FieldConfig
 
@@ -32,7 +33,7 @@ const PostTC = schemaComposer.createObjectTC({
 });
 ```
 
-GraphQL allows to create additional fields in your types which may provide data from other type. For example, you may add field `posts` to the `Author` type and write `resolve` function in such way that this field will return array of posts only for current Author.
+GraphQL allows to create additional fields in our types, thus providing data from another type. For example, we may add a field `posts` to the `Author` type and write a `resolve` function, so that this field will return an array of posts only for the current Author.
 
 It can be done in the following manner:
 
@@ -47,7 +48,7 @@ AuthorTC.addFields({
 });
 ```
 
-It's quite easy. But now lets improve our relation and add new arguments `limit` and `skip`:
+It's quite easy. But now let's improve our relation and add new arguments, `limit` and `skip`:
 
 ```js
 AuthorTC.addFields({
@@ -70,7 +71,8 @@ AuthorTC.addFields({
 });
 ```
 
-And this is also very easy, but what if we want provide `filter` argument which adds ability to filter by creation date, and min number of votes:
+What if we want to provide a `filter` argument, which adds the ability to filter by creation date, and min number of votes?
+That would be achieved by the following code:
 
 ```js
 AuthorTC.addFields({
@@ -104,18 +106,18 @@ AuthorTC.addFields({
 });
 ```
 
-Hm, it's became quite long. But what if you have other Types wich have relations with Posts (eg Reviewer, Reader)? I don't think that copy/paste of `resolve` method will be a good idea. Cause in the future you may want to add a new `filter` property and should scan all your code and put additional logic in all `FieldConfigs`. So if you meet with such problem the next section is for you.
+This would work just fine, but it has become quite a lot of code. And what if we have other Types with relations with Posts (eg. Reviewer, Reader)? Copy/pasting our `resolve` method is probably not a good idea. That's because in the future we may want to add a new `filter` property, and that would mean scanning all of our code to add additional logic in all `FieldConfigs`. The next section will detail a better approach to this problem.
 
 ## Relation via Resolver
 
-If you need to use the same FieldConfigs in different Types for such cases graphql-compose provides **[Resolver](basics/what-is-resolver.md)** class. You may create a Resolver which will define `type`, `args` and `resolve` and reuse in all places of your Schema where you need it.
+ `graphql-compose` provides a **[Resolver](basics/what-is-resolver.md)** class that allows using the same FieldConfigs in different Types. We may create a Resolver defining  `type`, `args` and a `resolve` function, then reuse it everywhere we need it in our Schema.
 
-Anyway if you put `posts` resolver in separate file, you will meet with another problems
+However if we define our `posts` resolver in a separate file, we'll then face another problem:
 
-- in `Author` type you will use `criteria = { authorId: source.id }` for resolve method;
+- in `Author` type we will use `criteria = { authorId: source.id }` for the resolve method;
 - in `Reviewer` - `criteria = { reviewers: { $has: source.id } }` and so on.
 
-For such case better to improve `args.filter` by allowing to set `authorId` and `reviewerId` via arguments:
+In this case it's better to improve `args.filter` by allowing to set `authorId` and `reviewerId` via arguments:
 
 ```js
 import { schemaComposer } from 'graphql-compose';
@@ -154,7 +156,7 @@ const postsResolver = schemaComposer.createResolver({
 });
 ```
 
-And now you may create relations via `ObjectTypeComposer.addRelation` method in such way:
+And now we may create relations via `ObjectTypeComposer.addRelation` method like so:
 
 ```js
 AuthorTC.addRelation('posts', {
@@ -176,7 +178,7 @@ ReviewerTC.addRelation('posts', {
 
 ## ObjectTypeComposer.addRelation()
 
-`addRelation` method has following arguments:
+`addRelation` method has the following arguments:
 
 ```js
 ObjectTypeComposer.addRelation(
@@ -193,23 +195,23 @@ ObjectTypeComposer.addRelation(
 
 ### resolver
 
-Should be an arrow function which returns `Resolver`. Wrapping resolver in arrow function helps to solve `hoisting` problem (when two types imports each other).
+Should be an arrow function that returns `Resolver`. Wrapping resolver in an arrow function helps solving the `hoisting` problem (when two types import each other).
 
 ### prepareArgs
 
-At runtime we should have ability to prepare somehow args which will be passed to Resolver.
+At runtime we should have the ability to prepare (ie. assign a value to) the args that will be passed to Resolver.
 
-For example our Resolver has following arguments `filter`, `limit`, `skip` and `sort`.
-`prepareArgs` provides instruction how to setup them:
+For example our Resolver has the arguments `filter`, `limit`, `skip` and `sort`.
+`prepareArgs` provides a way to set them up:
 
-- `limit: 10` - hide `limit` arg from schema and set it equal to 10
-- `filter: (source) => value` - hide `filter` arg form schema and at runtime evaluate its value
-- `sort: null` - disable argument (hide from schema and do not pass it to resolver)
+- `limit: 10` - hides `limit` arg from schema and set it equal to 10
+- `filter: (source) => value` - hides `filter` arg form schema and at runtime evaluate its value
+- `sort: null` - disables argument (hides it from schema and do not pass it to resolver)
 - all undescribed args (like `skip`) will be avaliable in the schema and will be avaliable in query
 
 ### projection
 
-Is very useful option for extending requested fields in your query. It very good practice to request from database only that fields which were requested in the query. But sometimes we need to request additional fields for fullfilling `findById` resolver with `authorId` value in arguments. For this purpose you need to use `projection`.
+Is a very useful option for extending requested fields in your query. It's very good practice to request from database only the fields included in our query. But sometimes we need additional fields, for example to provide the `findById` resolver with an `authorId`. For this purpose we can use `projection`.
 
 ```js
 PostTC.addRelation('author', {
@@ -221,7 +223,7 @@ PostTC.addRelation('author', {
 });
 ```
 
-So when you make such query
+So the query
 
 ```js
 {
@@ -233,7 +235,7 @@ So when you make such query
 }
 ```
 
-it will be transformed to
+will be transformed into
 
 ```js
 {
@@ -246,4 +248,4 @@ it will be transformed to
 }
 ```
 
-Without `projection` when we will request `author` field its resolver may get `args.authorId` equals to `undefined`. In this situation will not provide any data for `Author`. It happens if fetching only that fields which listed in the query from database. So when client requests `author` field in GraphQL Query he also must request `authorId` explicitly. But why client should care it? So required additional fields should be requested via `projection` option.
+Without `projection` the resolver would try to populate the `author` field, but `args.authorId` would be `undefined`. It would therefore be impossible for the query filter to find matching `authors` and populate the `author` field. Normally when a client wants to retrieve the `author` field in a GraphQL Query, it would also need to provide the `authorId` explicitly. By using a `projection` we lift that responsility from the client, making querying easier and less cluttered.


### PR DESCRIPTION
As discussed [in this PR](https://github.com/graphql-compose/graphql-compose.github.io/pull/34), we're moving [the original improvement PR](https://github.com/graphql-compose/graphql-compose.github.io/pull/33) to the current repo.

Original comment:

> I've added lots of small improvements. Mainly adding missing articles ("the", "a", etc.) and rewriting parts of the text to make it more readable. I hope it helps improving the docs :)