### PR TITLE
feat(toSDL): allow custom sorting and sorting by entity types

### DIFF
--- a/src/InputTypeComposer.ts
+++ b/src/InputTypeComposer.ts
@@ -36,6 +36,7 @@ import {
 } from './utils/typeHelpers';
 import { printInputObject, SchemaPrinterOptions } from './utils/schemaPrinter';
 import { getInputObjectTypeDefinitionNode } from './utils/definitionNode';
+import { getSortMethodFromOption } from './utils/sortTypes';
 
 export type InputTypeComposerDefinition =
   | TypeAsString
@@ -895,7 +896,6 @@ export class InputTypeComposer<TContext = any> {
   toSDL(
     opts?: SchemaPrinterOptions & {
       deep?: boolean;
-      sortTypes?: boolean;
       exclude?: string[];
     }
   ): string {
@@ -906,8 +906,9 @@ export class InputTypeComposer<TContext = any> {
       r += printInputObject(this.getType(), innerOpts);
 
       let nestedTypes = Array.from(this.getNestedTCs({ exclude }));
-      if (opts?.sortAll || opts?.sortTypes) {
-        nestedTypes = nestedTypes.sort((a, b) => a.getTypeName().localeCompare(b.getTypeName()));
+      const sortMethod = getSortMethodFromOption(opts?.sortTypes || opts?.sortAll);
+      if (sortMethod) {
+        nestedTypes.sort(sortMethod);
       }
       nestedTypes.forEach((t) => {
         if (t !== this && !exclude.includes(t.getTypeName())) {

--- a/src/InputTypeComposer.ts
+++ b/src/InputTypeComposer.ts
@@ -906,7 +906,7 @@ export class InputTypeComposer<TContext = any> {
       let r = '';
       r += printInputObject(this.getType(), innerOpts);
 
-      let nestedTypes = Array.from(this.getNestedTCs({ exclude }));
+      const nestedTypes = Array.from(this.getNestedTCs({ exclude }));
       const sortMethod = getSortMethodFromOption(innerOpts.sortAll || innerOpts.sortTypes);
       if (sortMethod) {
         nestedTypes.sort(sortMethod);

--- a/src/InputTypeComposer.ts
+++ b/src/InputTypeComposer.ts
@@ -900,13 +900,14 @@ export class InputTypeComposer<TContext = any> {
     }
   ): string {
     const { deep, ...innerOpts } = opts || {};
+    innerOpts.sortTypes = innerOpts.sortTypes || false;
     const exclude = Array.isArray(innerOpts.exclude) ? innerOpts.exclude : [];
     if (deep) {
       let r = '';
       r += printInputObject(this.getType(), innerOpts);
 
       let nestedTypes = Array.from(this.getNestedTCs({ exclude }));
-      const sortMethod = getSortMethodFromOption(opts?.sortTypes || opts?.sortAll);
+      const sortMethod = getSortMethodFromOption(innerOpts.sortAll || innerOpts.sortTypes);
       if (sortMethod) {
         nestedTypes.sort(sortMethod);
       }

--- a/src/InterfaceTypeComposer.ts
+++ b/src/InterfaceTypeComposer.ts
@@ -1605,7 +1605,7 @@ export class InterfaceTypeComposer<TSource = any, TContext = any> {
       let r = '';
       r += printInterface(this.getType(), innerOpts);
 
-      let nestedTypes = Array.from(this.getNestedTCs({ exclude }));
+      const nestedTypes = Array.from(this.getNestedTCs({ exclude }));
       const sortMethod = getSortMethodFromOption(innerOpts.sortAll || innerOpts.sortTypes);
       if (sortMethod) {
         nestedTypes.sort(sortMethod);

--- a/src/InterfaceTypeComposer.ts
+++ b/src/InterfaceTypeComposer.ts
@@ -1599,13 +1599,14 @@ export class InterfaceTypeComposer<TSource = any, TContext = any> {
     }
   ): string {
     const { deep, ...innerOpts } = opts || {};
+    innerOpts.sortTypes = innerOpts.sortTypes || false;
     const exclude = Array.isArray(innerOpts.exclude) ? innerOpts.exclude : [];
     if (deep) {
       let r = '';
       r += printInterface(this.getType(), innerOpts);
 
       let nestedTypes = Array.from(this.getNestedTCs({ exclude }));
-      const sortMethod = getSortMethodFromOption(opts?.sortTypes || opts?.sortAll);
+      const sortMethod = getSortMethodFromOption(innerOpts.sortAll || innerOpts.sortTypes);
       if (sortMethod) {
         nestedTypes.sort(sortMethod);
       }

--- a/src/InterfaceTypeComposer.ts
+++ b/src/InterfaceTypeComposer.ts
@@ -61,6 +61,7 @@ import { graphqlVersion } from './utils/graphqlVersion';
 import type { ComposeNamedInputType, ComposeNamedOutputType } from './utils/typeHelpers';
 import { printInterface, SchemaPrinterOptions } from './utils/schemaPrinter';
 import { getInterfaceTypeDefinitionNode } from './utils/definitionNode';
+import { getSortMethodFromOption } from './utils/sortTypes';
 
 export type InterfaceTypeComposerDefinition<TSource, TContext> =
   | TypeAsString
@@ -1594,7 +1595,6 @@ export class InterfaceTypeComposer<TSource = any, TContext = any> {
   toSDL(
     opts?: SchemaPrinterOptions & {
       deep?: boolean;
-      sortTypes?: boolean;
       exclude?: string[];
     }
   ): string {
@@ -1605,8 +1605,9 @@ export class InterfaceTypeComposer<TSource = any, TContext = any> {
       r += printInterface(this.getType(), innerOpts);
 
       let nestedTypes = Array.from(this.getNestedTCs({ exclude }));
-      if (opts?.sortAll || opts?.sortTypes) {
-        nestedTypes = nestedTypes.sort((a, b) => a.getTypeName().localeCompare(b.getTypeName()));
+      const sortMethod = getSortMethodFromOption(opts?.sortTypes || opts?.sortAll);
+      if (sortMethod) {
+        nestedTypes.sort(sortMethod);
       }
       nestedTypes.forEach((t) => {
         if (t !== this && !exclude.includes(t.getTypeName())) {

--- a/src/ObjectTypeComposer.ts
+++ b/src/ObjectTypeComposer.ts
@@ -72,6 +72,7 @@ import type {
 import { createThunkedObjectProxy } from './utils/createThunkedObjectProxy';
 import { printObject, SchemaPrinterOptions } from './utils/schemaPrinter';
 import { getObjectTypeDefinitionNode } from './utils/definitionNode';
+import { getSortMethodFromOption } from './utils/sortTypes';
 
 export type ObjectTypeComposerDefinition<TSource, TContext> =
   | TypeAsString
@@ -1859,7 +1860,6 @@ export class ObjectTypeComposer<TSource = any, TContext = any> {
   toSDL(
     opts?: SchemaPrinterOptions & {
       deep?: boolean;
-      sortTypes?: boolean;
       exclude?: string[];
     }
   ): string {
@@ -1870,8 +1870,9 @@ export class ObjectTypeComposer<TSource = any, TContext = any> {
       r += printObject(this.getType(), innerOpts);
 
       let nestedTypes = Array.from(this.getNestedTCs({ exclude }));
-      if (opts?.sortAll || opts?.sortTypes) {
-        nestedTypes = nestedTypes.sort((a, b) => a.getTypeName().localeCompare(b.getTypeName()));
+      const sortMethod = getSortMethodFromOption(opts?.sortTypes || opts?.sortAll);
+      if (sortMethod) {
+        nestedTypes.sort(sortMethod);
       }
       nestedTypes.forEach((t) => {
         if (t !== this && !exclude.includes(t.getTypeName())) {

--- a/src/ObjectTypeComposer.ts
+++ b/src/ObjectTypeComposer.ts
@@ -1870,7 +1870,7 @@ export class ObjectTypeComposer<TSource = any, TContext = any> {
       r += printObject(this.getType(), innerOpts);
 
       let nestedTypes = Array.from(this.getNestedTCs({ exclude }));
-      const sortMethod = getSortMethodFromOption(opts?.sortTypes || opts?.sortAll);
+      const sortMethod = getSortMethodFromOption(opts?.sortAll || opts?.sortTypes);
       if (sortMethod) {
         nestedTypes.sort(sortMethod);
       }

--- a/src/ObjectTypeComposer.ts
+++ b/src/ObjectTypeComposer.ts
@@ -1864,13 +1864,14 @@ export class ObjectTypeComposer<TSource = any, TContext = any> {
     }
   ): string {
     const { deep, ...innerOpts } = opts || {};
+    innerOpts.sortTypes = innerOpts.sortTypes || false;
     const exclude = Array.isArray(innerOpts.exclude) ? innerOpts.exclude : [];
     if (deep) {
       let r = '';
       r += printObject(this.getType(), innerOpts);
 
       let nestedTypes = Array.from(this.getNestedTCs({ exclude }));
-      const sortMethod = getSortMethodFromOption(opts?.sortAll || opts?.sortTypes);
+      const sortMethod = getSortMethodFromOption(innerOpts.sortAll || innerOpts.sortTypes);
       if (sortMethod) {
         nestedTypes.sort(sortMethod);
       }

--- a/src/ObjectTypeComposer.ts
+++ b/src/ObjectTypeComposer.ts
@@ -1870,7 +1870,7 @@ export class ObjectTypeComposer<TSource = any, TContext = any> {
       let r = '';
       r += printObject(this.getType(), innerOpts);
 
-      let nestedTypes = Array.from(this.getNestedTCs({ exclude }));
+      const nestedTypes = Array.from(this.getNestedTCs({ exclude }));
       const sortMethod = getSortMethodFromOption(innerOpts.sortAll || innerOpts.sortTypes);
       if (sortMethod) {
         nestedTypes.sort(sortMethod);

--- a/src/SchemaComposer.ts
+++ b/src/SchemaComposer.ts
@@ -963,10 +963,13 @@ export class SchemaComposer<TContext = any> extends TypeStorage<any, NamedTypeCo
     typeName: string,
     opts?: SchemaPrinterOptions & {
       deep?: boolean;
-      sortTypes?: boolean;
       exclude?: string[];
     }
   ): string {
+    opts = {
+      sortTypes: false,
+      ...opts
+    };
     return this.getAnyTC(typeName).toSDL(opts);
   }
 

--- a/src/SchemaComposer.ts
+++ b/src/SchemaComposer.ts
@@ -966,10 +966,6 @@ export class SchemaComposer<TContext = any> extends TypeStorage<any, NamedTypeCo
       exclude?: string[];
     }
   ): string {
-    opts = {
-      sortTypes: false,
-      ...opts
-    };
     return this.getAnyTC(typeName).toSDL(opts);
   }
 

--- a/src/UnionTypeComposer.ts
+++ b/src/UnionTypeComposer.ts
@@ -38,6 +38,7 @@ import {
 import { graphqlVersion } from './utils/graphqlVersion';
 import { printUnion, SchemaPrinterOptions } from './utils/schemaPrinter';
 import { getUnionTypeDefinitionNode } from './utils/definitionNode';
+import { getSortMethodFromOption } from './utils/sortTypes';
 
 export type UnionTypeComposerDefinition<TSource, TContext> =
   | TypeAsString
@@ -791,7 +792,6 @@ export class UnionTypeComposer<TSource = any, TContext = any> {
   toSDL(
     opts?: SchemaPrinterOptions & {
       deep?: boolean;
-      sortTypes?: boolean;
       exclude?: string[];
     }
   ): string {
@@ -802,8 +802,9 @@ export class UnionTypeComposer<TSource = any, TContext = any> {
       r += printUnion(this.getType(), innerOpts);
 
       let nestedTypes = Array.from(this.getNestedTCs({ exclude }));
-      if (opts?.sortAll || opts?.sortTypes) {
-        nestedTypes = nestedTypes.sort((a, b) => a.getTypeName().localeCompare(b.getTypeName()));
+      const sortMethod = getSortMethodFromOption(opts?.sortTypes || opts?.sortAll);
+      if (sortMethod) {
+        nestedTypes.sort(sortMethod);
       }
       nestedTypes.forEach((t) => {
         if (t !== this && !exclude.includes(t.getTypeName())) {

--- a/src/UnionTypeComposer.ts
+++ b/src/UnionTypeComposer.ts
@@ -802,7 +802,7 @@ export class UnionTypeComposer<TSource = any, TContext = any> {
       let r = '';
       r += printUnion(this.getType(), innerOpts);
 
-      let nestedTypes = Array.from(this.getNestedTCs({ exclude }));
+      const nestedTypes = Array.from(this.getNestedTCs({ exclude }));
       const sortMethod = getSortMethodFromOption(innerOpts.sortAll || innerOpts.sortTypes);
       if (sortMethod) {
         nestedTypes.sort(sortMethod);

--- a/src/UnionTypeComposer.ts
+++ b/src/UnionTypeComposer.ts
@@ -796,13 +796,14 @@ export class UnionTypeComposer<TSource = any, TContext = any> {
     }
   ): string {
     const { deep, ...innerOpts } = opts || {};
+    innerOpts.sortTypes = innerOpts.sortTypes || false;
     const exclude = Array.isArray(innerOpts.exclude) ? innerOpts.exclude : [];
     if (deep) {
       let r = '';
       r += printUnion(this.getType(), innerOpts);
 
       let nestedTypes = Array.from(this.getNestedTCs({ exclude }));
-      const sortMethod = getSortMethodFromOption(opts?.sortTypes || opts?.sortAll);
+      const sortMethod = getSortMethodFromOption(innerOpts.sortAll || innerOpts.sortTypes);
       if (sortMethod) {
         nestedTypes.sort(sortMethod);
       }

--- a/src/__tests__/SchemaComposer-test.ts
+++ b/src/__tests__/SchemaComposer-test.ts
@@ -1448,7 +1448,6 @@ describe('SchemaComposer', () => {
   });
 
   describe('misc methods', () => {
-
     const toSDL_sortTypeDefs = dedent`
       type Starship {
         id: ID!
@@ -1544,7 +1543,6 @@ describe('SchemaComposer', () => {
     });
 
     describe('toSDL({ sortTypes })', () => {
-
       it('should print types in alphabetic order by default', () => {
         const sc = new SchemaComposer();
         sc.addTypeDefs(toSDL_sortTypeDefs);
@@ -1552,7 +1550,7 @@ describe('SchemaComposer', () => {
         const printed = sc.toSDL();
         const printedUndefined = sc.toSDL({ sortTypes: undefined });
         const printedTrue = sc.toSDL({ sortTypes: true });
-        const printedAlpha = sc.toSDL({ sortTypes: "ALPHABETIC" });
+        const printedAlpha = sc.toSDL({ sortTypes: 'ALPHABETIC' });
 
         expect(printed).toBe(dedent`
           interface Character {
@@ -1651,7 +1649,7 @@ describe('SchemaComposer', () => {
         const sc = new SchemaComposer();
         sc.addTypeDefs(toSDL_sortTypeDefs);
 
-        const printed = sc.toSDL({ sortTypes: "GROUP_BY_TYPE" });
+        const printed = sc.toSDL({ sortTypes: 'GROUP_BY_TYPE' });
 
         expect(printed).toBe(dedent`
           type Query {
@@ -1747,10 +1745,12 @@ describe('SchemaComposer', () => {
         const sc = new SchemaComposer();
         sc.addTypeDefs(toSDL_sortTypeDefs);
 
-        const printed = sc.toSDL({ sortTypes: function (tc1, tc2) {
-          const diff = tc2.getTypeName().localeCompare(tc1.getTypeName());
-          return diff < 0 ? -1 : diff > 0 ? +1 : 0;
-        } });
+        const printed = sc.toSDL({
+          sortTypes: function (tc1, tc2) {
+            const diff = tc2.getTypeName().localeCompare(tc1.getTypeName());
+            return diff < 0 ? -1 : diff > 0 ? +1 : 0;
+          },
+        });
 
         expect(printed).toBe(dedent`
           """
@@ -1937,7 +1937,6 @@ describe('SchemaComposer', () => {
           }
         `);
       });
-
     });
 
     describe('getTypeSDL()', () => {

--- a/src/__tests__/SchemaComposer-test.ts
+++ b/src/__tests__/SchemaComposer-test.ts
@@ -1448,6 +1448,74 @@ describe('SchemaComposer', () => {
   });
 
   describe('misc methods', () => {
+
+    const toSDL_sortTypeDefs = dedent`
+      type Starship {
+        id: ID!
+        name: String!
+        length(unit: LengthUnit = METER): Float
+      }
+      scalar Date
+      enum Episode {
+        NEWHOPE
+        EMPIRE
+        JEDI
+      }
+      enum LengthUnit {
+        CENTIMETER
+        METER
+        KILOMETER
+      }
+      interface Character {
+        id: ID!
+        name: String!
+        friends: [Character]
+        appearsIn: [Episode!]!
+      }
+      type Human implements Character {
+        id: ID!
+        name: String!
+        friends: [Character]
+        appearsIn: [Episode!]!
+        starships: [Starship]
+        totalCredits: Int
+      }
+      type Droid implements Character {
+        id: ID!
+        name: String!
+        friends: [Character]
+        appearsIn: [Episode!]!
+        primaryFunction: String
+      }
+      union SearchResult = Human | Droid | Starship
+      type Query {
+        heroes(episode: Episode): [SearchResult]
+        droid(id: ID!): Droid
+        searchReviews(
+          episodes: [Episode]
+          dateStart: Date
+          dateEnd: Date
+          minStars: Int
+          maxStars: Int
+        ): [Review]
+      }
+      input ReviewInput {
+        stars: Int!
+        commentary: String
+      }
+      type Review {
+        stars: Int!
+        commentary: String
+        dateCreated: Date
+      }
+      type Mutation {
+        createReview(
+          episode: Episode!
+          review: ReviewInput!
+        ): Review
+      }
+    `;
+
     it('toSDL()', () => {
       const sc = new SchemaComposer();
       sc.Query.addFields({ existedInQuery: 'String' });
@@ -1473,6 +1541,403 @@ describe('SchemaComposer', () => {
           existedInSubscription: String
         }
       `);
+    });
+
+    describe('toSDL({ sortTypes })', () => {
+
+      it('should print types in alphabetic order by default', () => {
+        const sc = new SchemaComposer();
+        sc.addTypeDefs(toSDL_sortTypeDefs);
+
+        const printed = sc.toSDL();
+        const printedUndefined = sc.toSDL({ sortTypes: undefined });
+        const printedTrue = sc.toSDL({ sortTypes: true });
+        const printedAlpha = sc.toSDL({ sortTypes: "ALPHABETIC" });
+
+        expect(printed).toBe(dedent`
+          interface Character {
+            id: ID!
+            name: String!
+            friends: [Character]
+            appearsIn: [Episode!]!
+          }
+
+          scalar Date
+
+          type Droid implements Character {
+            id: ID!
+            name: String!
+            friends: [Character]
+            appearsIn: [Episode!]!
+            primaryFunction: String
+          }
+
+          enum Episode {
+            NEWHOPE
+            EMPIRE
+            JEDI
+          }
+
+          """
+          The \`Float\` scalar type represents signed double-precision fractional values as specified by [IEEE 754](https://en.wikipedia.org/wiki/IEEE_floating_point).
+          """
+          scalar Float
+
+          type Human implements Character {
+            id: ID!
+            name: String!
+            friends: [Character]
+            appearsIn: [Episode!]!
+            starships: [Starship]
+            totalCredits: Int
+          }
+
+          """
+          The \`ID\` scalar type represents a unique identifier, often used to refetch an object or as key for a cache. The ID type appears in a JSON response as a String; however, it is not intended to be human-readable. When expected as an input type, any string (such as \`"4"\`) or integer (such as \`4\`) input value will be accepted as an ID.
+          """
+          scalar ID
+
+          """
+          The \`Int\` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1.
+          """
+          scalar Int
+
+          enum LengthUnit {
+            CENTIMETER
+            METER
+            KILOMETER
+          }
+
+          type Mutation {
+            createReview(episode: Episode!, review: ReviewInput!): Review
+          }
+
+          type Query {
+            heroes(episode: Episode): [SearchResult]
+            droid(id: ID!): Droid
+            searchReviews(episodes: [Episode], dateStart: Date, dateEnd: Date, minStars: Int, maxStars: Int): [Review]
+          }
+
+          type Review {
+            stars: Int!
+            commentary: String
+            dateCreated: Date
+          }
+
+          input ReviewInput {
+            stars: Int!
+            commentary: String
+          }
+
+          union SearchResult = Human | Droid | Starship
+
+          type Starship {
+            id: ID!
+            name: String!
+            length(unit: LengthUnit = METER): Float
+          }
+
+          """
+          The \`String\` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text.
+          """
+          scalar String
+        `);
+        expect(printed).toBe(printedUndefined);
+        expect(printed).toBe(printedTrue);
+        expect(printed).toBe(printedAlpha);
+      });
+
+      it('should allow to print types grouped by type', () => {
+        const sc = new SchemaComposer();
+        sc.addTypeDefs(toSDL_sortTypeDefs);
+
+        const printed = sc.toSDL({ sortTypes: "GROUP_BY_TYPE" });
+
+        expect(printed).toBe(dedent`
+          type Query {
+            heroes(episode: Episode): [SearchResult]
+            droid(id: ID!): Droid
+            searchReviews(episodes: [Episode], dateStart: Date, dateEnd: Date, minStars: Int, maxStars: Int): [Review]
+          }
+
+          type Mutation {
+            createReview(episode: Episode!, review: ReviewInput!): Review
+          }
+
+          scalar Date
+
+          """
+          The \`Float\` scalar type represents signed double-precision fractional values as specified by [IEEE 754](https://en.wikipedia.org/wiki/IEEE_floating_point).
+          """
+          scalar Float
+
+          """
+          The \`ID\` scalar type represents a unique identifier, often used to refetch an object or as key for a cache. The ID type appears in a JSON response as a String; however, it is not intended to be human-readable. When expected as an input type, any string (such as \`"4"\`) or integer (such as \`4\`) input value will be accepted as an ID.
+          """
+          scalar ID
+
+          """
+          The \`Int\` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1.
+          """
+          scalar Int
+
+          """
+          The \`String\` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text.
+          """
+          scalar String
+
+          enum Episode {
+            NEWHOPE
+            EMPIRE
+            JEDI
+          }
+
+          enum LengthUnit {
+            CENTIMETER
+            METER
+            KILOMETER
+          }
+
+          union SearchResult = Human | Droid | Starship
+
+          interface Character {
+            id: ID!
+            name: String!
+            friends: [Character]
+            appearsIn: [Episode!]!
+          }
+
+          type Droid implements Character {
+            id: ID!
+            name: String!
+            friends: [Character]
+            appearsIn: [Episode!]!
+            primaryFunction: String
+          }
+
+          type Human implements Character {
+            id: ID!
+            name: String!
+            friends: [Character]
+            appearsIn: [Episode!]!
+            starships: [Starship]
+            totalCredits: Int
+          }
+
+          type Review {
+            stars: Int!
+            commentary: String
+            dateCreated: Date
+          }
+
+          type Starship {
+            id: ID!
+            name: String!
+            length(unit: LengthUnit = METER): Float
+          }
+
+          input ReviewInput {
+            stars: Int!
+            commentary: String
+          }
+        `);
+      });
+
+      it('should allow to print types with custom sorting function', () => {
+        const sc = new SchemaComposer();
+        sc.addTypeDefs(toSDL_sortTypeDefs);
+
+        const printed = sc.toSDL({ sortTypes: function (tc1, tc2) {
+          const diff = tc2.getTypeName().localeCompare(tc1.getTypeName());
+          return diff < 0 ? -1 : diff > 0 ? +1 : 0;
+        } });
+
+        expect(printed).toBe(dedent`
+          """
+          The \`String\` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text.
+          """
+          scalar String
+
+          type Starship {
+            id: ID!
+            name: String!
+            length(unit: LengthUnit = METER): Float
+          }
+
+          union SearchResult = Human | Droid | Starship
+
+          input ReviewInput {
+            stars: Int!
+            commentary: String
+          }
+
+          type Review {
+            stars: Int!
+            commentary: String
+            dateCreated: Date
+          }
+
+          type Query {
+            heroes(episode: Episode): [SearchResult]
+            droid(id: ID!): Droid
+            searchReviews(episodes: [Episode], dateStart: Date, dateEnd: Date, minStars: Int, maxStars: Int): [Review]
+          }
+
+          type Mutation {
+            createReview(episode: Episode!, review: ReviewInput!): Review
+          }
+
+          enum LengthUnit {
+            CENTIMETER
+            METER
+            KILOMETER
+          }
+
+          """
+          The \`Int\` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1.
+          """
+          scalar Int
+
+          """
+          The \`ID\` scalar type represents a unique identifier, often used to refetch an object or as key for a cache. The ID type appears in a JSON response as a String; however, it is not intended to be human-readable. When expected as an input type, any string (such as \`"4"\`) or integer (such as \`4\`) input value will be accepted as an ID.
+          """
+          scalar ID
+
+          type Human implements Character {
+            id: ID!
+            name: String!
+            friends: [Character]
+            appearsIn: [Episode!]!
+            starships: [Starship]
+            totalCredits: Int
+          }
+
+          """
+          The \`Float\` scalar type represents signed double-precision fractional values as specified by [IEEE 754](https://en.wikipedia.org/wiki/IEEE_floating_point).
+          """
+          scalar Float
+
+          enum Episode {
+            NEWHOPE
+            EMPIRE
+            JEDI
+          }
+
+          type Droid implements Character {
+            id: ID!
+            name: String!
+            friends: [Character]
+            appearsIn: [Episode!]!
+            primaryFunction: String
+          }
+
+          scalar Date
+
+          interface Character {
+            id: ID!
+            name: String!
+            friends: [Character]
+            appearsIn: [Episode!]!
+          }
+        `);
+      });
+
+      it('should allow to print types without sorting', () => {
+        const sc = new SchemaComposer();
+        sc.addTypeDefs(toSDL_sortTypeDefs);
+
+        const printed = sc.toSDL({ sortTypes: false });
+
+        expect(printed).toBe(dedent`
+          type Query {
+            heroes(episode: Episode): [SearchResult]
+            droid(id: ID!): Droid
+            searchReviews(episodes: [Episode], dateStart: Date, dateEnd: Date, minStars: Int, maxStars: Int): [Review]
+          }
+
+          union SearchResult = Human | Droid | Starship
+
+          type Human implements Character {
+            id: ID!
+            name: String!
+            friends: [Character]
+            appearsIn: [Episode!]!
+            starships: [Starship]
+            totalCredits: Int
+          }
+
+          """
+          The \`ID\` scalar type represents a unique identifier, often used to refetch an object or as key for a cache. The ID type appears in a JSON response as a String; however, it is not intended to be human-readable. When expected as an input type, any string (such as \`"4"\`) or integer (such as \`4\`) input value will be accepted as an ID.
+          """
+          scalar ID
+
+          """
+          The \`String\` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text.
+          """
+          scalar String
+
+          interface Character {
+            id: ID!
+            name: String!
+            friends: [Character]
+            appearsIn: [Episode!]!
+          }
+
+          enum Episode {
+            NEWHOPE
+            EMPIRE
+            JEDI
+          }
+
+          type Starship {
+            id: ID!
+            name: String!
+            length(unit: LengthUnit = METER): Float
+          }
+
+          """
+          The \`Float\` scalar type represents signed double-precision fractional values as specified by [IEEE 754](https://en.wikipedia.org/wiki/IEEE_floating_point).
+          """
+          scalar Float
+
+          enum LengthUnit {
+            CENTIMETER
+            METER
+            KILOMETER
+          }
+
+          """
+          The \`Int\` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1.
+          """
+          scalar Int
+
+          type Droid implements Character {
+            id: ID!
+            name: String!
+            friends: [Character]
+            appearsIn: [Episode!]!
+            primaryFunction: String
+          }
+
+          type Review {
+            stars: Int!
+            commentary: String
+            dateCreated: Date
+          }
+
+          scalar Date
+
+          type Mutation {
+            createReview(episode: Episode!, review: ReviewInput!): Review
+          }
+
+          input ReviewInput {
+            stars: Int!
+            commentary: String
+          }
+        `);
+      });
+
     });
 
     describe('getTypeSDL()', () => {

--- a/src/utils/getFromSchema.ts
+++ b/src/utils/getFromSchema.ts
@@ -1,0 +1,68 @@
+import { BUILT_IN_DIRECTIVES, SchemaComposer } from '../SchemaComposer';
+import { ObjectTypeComposer } from '../ObjectTypeComposer';
+import { InputTypeComposer } from '../InputTypeComposer';
+import { InterfaceTypeComposer } from '../InterfaceTypeComposer';
+import { UnionTypeComposer } from '../UnionTypeComposer';
+import type { NamedTypeComposer } from './typeHelpers';
+
+export type SchemaFilterTypes = {
+  include?: string[];
+  exclude?: string[];
+  omitDirectiveDefinitions?: boolean;
+};
+
+export function getTypesFromSchema(
+  sc: SchemaComposer<any>,
+  filter?: SchemaFilterTypes,
+): Set<NamedTypeComposer<any>> {
+  const { exclude = [], include, omitDirectiveDefinitions } = filter || {};
+
+  const rootTypes = new Set();
+  if (Array.isArray(include) && include.length) {
+    include.forEach((s) => {
+      if (s && typeof s === 'string') {
+        rootTypes.add(sc.getAnyTC(s));
+      }
+    });
+  } else {
+    if (sc.has('Query')) rootTypes.add(sc.getOTC('Query'));
+    if (sc.has('Mutation')) rootTypes.add(sc.getOTC('Mutation'));
+    if (sc.has('Subscription')) rootTypes.add(sc.getOTC('Subscription'));
+  }
+
+  if (!omitDirectiveDefinitions) {
+    const directives = sc._directives.filter((d) => !BUILT_IN_DIRECTIVES.includes(d));
+    // directives may have specific types in arguments, so add them to rootTypes
+    directives.forEach((d) => {
+      if (!Array.isArray(d.args)) return;
+      d.args.forEach((ac: any) => {
+        const tc = sc.getAnyTC(ac.type);
+        if (!exclude.includes(tc.getTypeName())) {
+          rootTypes.add(tc);
+        }
+      });
+    });
+  }
+
+  const typeSet: Set<NamedTypeComposer<any>> = new Set();
+  rootTypes.forEach((tc) => {
+    if (
+      tc instanceof ObjectTypeComposer ||
+      tc instanceof InputTypeComposer ||
+      tc instanceof InterfaceTypeComposer ||
+      tc instanceof UnionTypeComposer
+    ) {
+      typeSet.add(tc);
+      tc.getNestedTCs({ exclude }, typeSet);
+    } else {
+      typeSet.add(tc as any);
+    }
+  });
+  return typeSet;
+}
+
+export function getDirectivesFromSchema(
+  sc: SchemaComposer<any>,
+): any[] {
+  return sc._directives.filter((d) => !BUILT_IN_DIRECTIVES.includes(d));
+}

--- a/src/utils/getFromSchema.ts
+++ b/src/utils/getFromSchema.ts
@@ -13,7 +13,7 @@ export type SchemaFilterTypes = {
 
 export function getTypesFromSchema(
   sc: SchemaComposer<any>,
-  filter?: SchemaFilterTypes,
+  filter?: SchemaFilterTypes
 ): Set<NamedTypeComposer<any>> {
   const { exclude = [], include, omitDirectiveDefinitions } = filter || {};
 
@@ -61,8 +61,6 @@ export function getTypesFromSchema(
   return typeSet;
 }
 
-export function getDirectivesFromSchema(
-  sc: SchemaComposer<any>,
-): any[] {
+export function getDirectivesFromSchema(sc: SchemaComposer<any>): any[] {
   return sc._directives.filter((d) => !BUILT_IN_DIRECTIVES.includes(d));
 }

--- a/src/utils/schemaPrinter.ts
+++ b/src/utils/schemaPrinter.ts
@@ -128,7 +128,10 @@ export function printSchemaComposer(
   const sortMethod = getSortMethodFromOption(optPrinter?.sortTypes, optFilter);
   if (sortMethod) printTypes.sort(sortMethod);
 
-  const res = getDirectivesFromSchema(sc);
+  const res = [];
+  if (!optFilter.omitDirectiveDefinitions) {
+    res.push(...getDirectivesFromSchema(sc).map((d) => printDirective(d, optPrinter)));
+  }
   res.push(...printTypes.map((tc) => tc.toSDL(optPrinter)));
 
   return res.filter(Boolean).join('\n\n');

--- a/src/utils/schemaPrinter.ts
+++ b/src/utils/schemaPrinter.ts
@@ -38,17 +38,10 @@ import {
 import { astFromValue } from 'graphql/utilities/astFromValue';
 
 import { SchemaComposer } from '../SchemaComposer';
-import {
-  SchemaFilterTypes,
-  getTypesFromSchema,
-  getDirectivesFromSchema,
-} from './getFromSchema';
+import { SchemaFilterTypes, getTypesFromSchema, getDirectivesFromSchema } from './getFromSchema';
 import { Maybe } from 'graphql/jsutils/Maybe';
 
-import {
-  CompareTypeComposersOption,
-  getSortMethodFromOption,
-} from './sortTypes';
+import { CompareTypeComposersOption, getSortMethodFromOption } from './sortTypes';
 
 type Options = {
   /**
@@ -102,13 +95,11 @@ export type SchemaPrinterOptions = Options;
 export type SchemaComposerPrinterOptions = Options & SchemaFilterTypes;
 
 interface PrinterFilterOptions {
-  optPrinter: SchemaPrinterOptions,
-  optFilter: SchemaFilterTypes,
+  optPrinter: SchemaPrinterOptions;
+  optFilter: SchemaFilterTypes;
 }
 
-function splitOptionsFilterPrinter(
-  options?: SchemaComposerPrinterOptions,
-): PrinterFilterOptions {
+function splitOptionsFilterPrinter(options?: SchemaComposerPrinterOptions): PrinterFilterOptions {
   const { exclude = [], include, omitDirectiveDefinitions, ...optPrinter } = options || {};
   const optFilter = { exclude, include, omitDirectiveDefinitions };
   return { optPrinter, optFilter };

--- a/src/utils/schemaPrinter.ts
+++ b/src/utils/schemaPrinter.ts
@@ -122,8 +122,8 @@ export function printSchemaComposer(
   options?: SchemaComposerPrinterOptions
 ): string {
   const { optPrinter, optFilter } = splitOptionsFilterPrinter(options);
-  const printTypeSet = getTypesFromSchema(sc, optFilter);
-  const printTypes = Array.from(printTypeSet);
+
+  const printTypes = Array.from(getTypesFromSchema(sc, optFilter));
 
   const sortMethod = getSortMethodFromOption(optPrinter?.sortTypes, optFilter);
   if (sortMethod) printTypes.sort(sortMethod);

--- a/src/utils/sortTypes.ts
+++ b/src/utils/sortTypes.ts
@@ -1,0 +1,117 @@
+import { ScalarTypeComposer } from '../ScalarTypeComposer';
+import { EnumTypeComposer } from '../EnumTypeComposer';
+import { InterfaceTypeComposer } from '../InterfaceTypeComposer';
+import { InputTypeComposer } from '../InputTypeComposer';
+import { ObjectTypeComposer } from '../ObjectTypeComposer';
+import { UnionTypeComposer } from '../UnionTypeComposer';
+import { NamedTypeComposer } from './typeHelpers';
+import { SchemaFilterTypes } from './getFromSchema';
+
+export type CompareTypeComposersResult = -1 | 0 | 1;
+
+export type CompareTypeComposersFn = (
+  tc1: NamedTypeComposer<any>,
+  tc2: NamedTypeComposer<any>,
+) => CompareTypeComposersResult;
+
+export type CompareTypeComposersOption =
+  | boolean
+  | 'ALPHABETIC'
+  | 'GROUP_BY_TYPE'
+  | CompareTypeComposersFn;
+
+const rootOrderDefault = [
+  'Query',
+  'Mutation',
+  'Subscription',
+];
+
+function numberToCompareResult(n: number): CompareTypeComposersResult {
+  return n < 0 ? -1
+    : n > 0 ? 1
+    : 0;
+}
+
+export function printSortAlpha(
+  tc1: NamedTypeComposer<any>,
+  tc2: NamedTypeComposer<any>,
+): CompareTypeComposersResult {
+  return numberToCompareResult(
+    tc1.getTypeName().localeCompare(tc2.getTypeName())
+  );
+}
+
+function sortGetPositionFromArray(
+  tc: NamedTypeComposer<any>,
+  orderArray: string[],
+): number {
+  const order = orderArray.indexOf(tc.getTypeName());
+  return order === -1 ? Infinity : order;
+}
+
+function sortGetPositionOfType(
+  tc: NamedTypeComposer<any>,
+  rootTypes: string[] = [],
+): number[] {
+  switch (true) {
+    case tc instanceof ScalarTypeComposer: return [2];
+    case tc instanceof EnumTypeComposer: return [3];
+    case tc instanceof UnionTypeComposer: return [4];
+    case tc instanceof InterfaceTypeComposer: return [5];
+    case tc instanceof ObjectTypeComposer:
+      const isRoot = rootTypes.includes(tc.getTypeName());
+      if (isRoot) {
+        return [1, sortGetPositionFromArray(tc, rootTypes)];
+      } else {
+        return [6];
+      }
+    case tc instanceof InputTypeComposer: return [7];
+  }
+  throw new Error(`Unknown kind of type ${tc.getTypeName()}`);
+}
+
+function comparePositionLists(
+  p1: number[],
+  p2: number[],
+): CompareTypeComposersResult {
+  let common = Math.min(p1.length, p2.length);
+  for (let i = 0; i < common; i++) {
+    if (p1[i] < p2[i]) return -1;
+    if (p1[i] > p2[i]) return +1;
+  }
+  return 0;
+}
+
+export function fnPrintSortByType(
+  opt?: SchemaFilterTypes,
+): CompareTypeComposersFn {
+  const rootTypes = opt?.include || rootOrderDefault;
+  return function (
+    tc1: NamedTypeComposer<any>,
+    tc2: NamedTypeComposer<any>,
+  ): CompareTypeComposersResult {
+    const pos1 = sortGetPositionOfType(tc1, rootTypes);
+    const pos2 = sortGetPositionOfType(tc2, rootTypes);
+    const diff = comparePositionLists(pos1, pos2);
+    return diff || printSortAlpha(tc1, tc2);
+  }
+}
+
+export function getSortMethodFromOption(
+  sortOption?: CompareTypeComposersOption,
+  printFilter?: SchemaFilterTypes,
+): CompareTypeComposersFn | undefined {
+  switch (sortOption) {
+    case null:
+    case undefined:
+    case false:
+      return;
+    case true:
+    case 'ALPHABETIC':
+      return printSortAlpha;
+    case 'GROUP_BY_TYPE':
+      return fnPrintSortByType(printFilter);
+    default:
+      return sortOption;
+  }
+}

--- a/src/utils/sortTypes.ts
+++ b/src/utils/sortTypes.ts
@@ -12,7 +12,7 @@ export type CompareTypeComposersResult = -1 | 0 | 1;
 
 export type CompareTypeComposersFn = (
   tc1: NamedTypeComposer<any>,
-  tc2: NamedTypeComposer<any>,
+  tc2: NamedTypeComposer<any>
 ) => CompareTypeComposersResult;
 
 export type CompareTypeComposersOption =
@@ -21,29 +21,26 @@ export type CompareTypeComposersOption =
   | 'GROUP_BY_TYPE'
   | CompareTypeComposersFn;
 
-const rootOrderDefault = [
-  'Query',
-  'Mutation',
-  'Subscription',
-];
+const rootOrderDefault = ['Query', 'Mutation', 'Subscription'];
 
 export function printSortAlpha(
   tc1: NamedTypeComposer<any>,
-  tc2: NamedTypeComposer<any>,
+  tc2: NamedTypeComposer<any>
 ): CompareTypeComposersResult {
   const comp = tc1.getTypeName().localeCompare(tc2.getTypeName());
   return comp as CompareTypeComposersResult;
 }
 
-function sortGetPositionOfType(
-  tc: NamedTypeComposer<any>,
-  rootTypes: string[] = [],
-): number[] {
+function sortGetPositionOfType(tc: NamedTypeComposer<any>, rootTypes: string[] = []): number[] {
   switch (true) {
-    case tc instanceof ScalarTypeComposer: return [2];
-    case tc instanceof EnumTypeComposer: return [3];
-    case tc instanceof UnionTypeComposer: return [4];
-    case tc instanceof InterfaceTypeComposer: return [5];
+    case tc instanceof ScalarTypeComposer:
+      return [2];
+    case tc instanceof EnumTypeComposer:
+      return [3];
+    case tc instanceof UnionTypeComposer:
+      return [4];
+    case tc instanceof InterfaceTypeComposer:
+      return [5];
     case tc instanceof ObjectTypeComposer:
       const rootPos = rootTypes.indexOf(tc.getTypeName());
       if (rootPos !== -1) {
@@ -51,16 +48,14 @@ function sortGetPositionOfType(
       } else {
         return [6];
       }
-    case tc instanceof InputTypeComposer: return [7];
+    case tc instanceof InputTypeComposer:
+      return [7];
   }
   throw new Error(`Unknown kind of type ${tc.getTypeName()}`);
 }
 
-function comparePositionLists(
-  p1: number[],
-  p2: number[],
-): CompareTypeComposersResult {
-  let common = Math.min(p1.length, p2.length);
+function comparePositionLists(p1: number[], p2: number[]): CompareTypeComposersResult {
+  const common = Math.min(p1.length, p2.length);
   for (let i = 0; i < common; i++) {
     if (p1[i] < p2[i]) return -1;
     if (p1[i] > p2[i]) return +1;
@@ -68,24 +63,22 @@ function comparePositionLists(
   return 0;
 }
 
-export function fnPrintSortByType(
-  opt?: SchemaFilterTypes,
-): CompareTypeComposersFn {
+export function fnPrintSortByType(opt?: SchemaFilterTypes): CompareTypeComposersFn {
   const rootTypes = opt?.include || rootOrderDefault;
   return function (
     tc1: NamedTypeComposer<any>,
-    tc2: NamedTypeComposer<any>,
+    tc2: NamedTypeComposer<any>
   ): CompareTypeComposersResult {
     const pos1 = sortGetPositionOfType(tc1, rootTypes);
     const pos2 = sortGetPositionOfType(tc2, rootTypes);
     const diff = comparePositionLists(pos1, pos2);
     return diff || printSortAlpha(tc1, tc2);
-  }
+  };
 }
 
 export function getSortMethodFromOption(
   sortOption?: CompareTypeComposersOption,
-  printFilter?: SchemaFilterTypes,
+  printFilter?: SchemaFilterTypes
 ): CompareTypeComposersFn | undefined {
   // if null or undefined, default order is alphabetic
   if (


### PR DESCRIPTION
I know this will very likely need refactoring before being accepted, but I want some input if this feature is desired.

By default, when you call `mySchemaComposer.toSDL()`, all objects are printed to a string, sorted by the name of the entity (be it scalar, enum, interface, input, object or union). I think a much more human friendly way of printing it is:

1. Scalar types
2. Root Object types (Query, Mutation, Subscription)
3. Enum types
4. Interface types
5. Input types
6. Object types
7. Union types

Actually I have almost no experience in GraphQL, I'm starting to learn and use it, but anyway I didn't like that the default way of printing mixes all these entity types. Maybe for an experienced GraphQL user the "ideal" way to sort entities when printing could be different, and the default way to sort entities by type could be changed in that case.

But what do you think?

## How to use it?

```ts
import { SchemaComposer, printSortOptionsByType } from 'graphql-compose';

const schemaComposer = new SchemaComposer();

// build your schema

console.log(schemaComposer.toSDL({
	sortCustomOptions: printSortOptionsByType,
}));
```