### PR TITLE
fix: don't try to instantiate GraphQLType when getting name of named type composer

### DIFF
--- a/src/utils/typeHelpers.ts
+++ b/src/utils/typeHelpers.ts
@@ -335,6 +335,8 @@ export function getComposeTypeName(type: any, sc: SchemaComposer<any>): string {
     throw new Error(`Cannot get type name from string: ${inspect(type)}`);
   } else if (isFunction(type)) {
     return getComposeTypeName((type as any)(sc), sc);
+  } else if (isNamedTypeComposer(type)) {
+    return type.getTypeName();
   } else {
     try {
       const gqlType = getGraphQLType(type) as any;


### PR DESCRIPTION
When using `ObjectTypeComposer.addInterface` with argument being `InterfaceTypeComposer` that reference fields of types that were not created yet we are getting errors. This happens because of this chain:

https://github.com/graphql-compose/graphql-compose/blob/659f821953acd3dbc1aba098a543058f7aa1018c/src/ObjectTypeComposer.ts#L1411

https://github.com/graphql-compose/graphql-compose/blob/659f821953acd3dbc1aba098a543058f7aa1018c/src/ObjectTypeComposer.ts#L1402

https://github.com/graphql-compose/graphql-compose/blob/659f821953acd3dbc1aba098a543058f7aa1018c/src/utils/typeHelpers.ts#L340

https://github.com/graphql-compose/graphql-compose/blob/659f821953acd3dbc1aba098a543058f7aa1018c/src/utils/typeHelpers.ts#L308

The last one tries to "instantiate" it as `GraphQLType` type, but depending on order of type creation not all referenced types are available yet, resulting in very confusing error (Maximum call stack size exceeded) due to trying to use `inspect` in https://github.com/graphql-compose/graphql-compose/blob/659f821953acd3dbc1aba098a543058f7aa1018c/src/utils/typeHelpers.ts#L345

which tries to print object of `InterfaceTypeComposer` type.

I figured that somewhat to workaround this I could add "happy path" in `getComposeTypeName` when passed type is named type composer, somewhat skipping part that would try to instantiate `GraphQLType`.

fixes #372