### PR TITLE
fix: handle scalar arguments with object default values

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,6 @@
   "javascript.validate.enable": false,
   "javascript.autoClosingTags": false,
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   },
 }

--- a/src/__tests__/github_issues/407-test.ts
+++ b/src/__tests__/github_issues/407-test.ts
@@ -1,0 +1,45 @@
+import { print } from 'graphql';
+import GraphQLJSON from 'graphql-type-json';
+import { schemaComposer } from '../..';
+
+describe('github issue #407', () => {
+  it('defaultValue can take an object with JSON type', () => {
+    const inputTC = schemaComposer.createInputTC({
+      name: 'InputWithJSONAndDefaultValue',
+      fields: {
+        json: {
+          type: GraphQLJSON,
+          defaultValue: {},
+        },
+      },
+    });
+    const inputType = inputTC.getType();
+    expect(inputType.astNode).toMatchObject({
+      kind: 'InputObjectTypeDefinition',
+      name: { kind: 'Name', value: 'InputWithJSONAndDefaultValue' },
+      fields: [
+        {
+          kind: 'InputValueDefinition',
+          name: { kind: 'Name', value: 'json' },
+          type: {
+            kind: 'NamedType',
+            name: { kind: 'Name', value: 'JSON' },
+          },
+          defaultValue: {
+            kind: 'ObjectValue',
+            fields: [],
+          },
+        },
+      ],
+    });
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const sdl = print(inputType.astNode!);
+    expect(sdl).toBe(
+      /* GraphQL */ `
+input InputWithJSONAndDefaultValue {
+  json: JSON = {}
+}
+    `.trim()
+    );
+  });
+});

--- a/src/utils/definitionNode.ts
+++ b/src/utils/definitionNode.ts
@@ -30,7 +30,7 @@ import type {
   GraphQLInputType,
   NameNode,
 } from '../graphql';
-import { GraphQLDirective, astFromValue } from '../graphql';
+import { GraphQLDirective } from '../graphql';
 import type { ObjectTypeComposer } from '../ObjectTypeComposer';
 import type { InputTypeComposer } from '../InputTypeComposer';
 import type { EnumTypeComposer } from '../EnumTypeComposer';
@@ -44,7 +44,7 @@ import { ThunkComposer } from '../ThunkComposer';
 import { NonNullComposer } from '../NonNullComposer';
 import { ListComposer } from '../ListComposer';
 import { inspect } from './misc';
-import { Kind } from 'graphql';
+import { Kind, astFromValue } from 'graphql';
 
 /**
  * Get astNode for ObjectTypeComposer.
@@ -296,7 +296,7 @@ export function getArgumentsDefinitionNodes(
         ),
         defaultValue:
           (ac.defaultValue !== undefined &&
-            astFromValue(ac.defaultValue, tc.getFieldArgType(fieldName, argName))) ||
+            astFromValueSafe(ac.defaultValue, tc.getFieldArgType(fieldName, argName))) ||
           undefined,
       } as InputValueDefinitionNode;
     })
@@ -343,7 +343,7 @@ export function getInputValueDefinitionNodes(
         directives: getDirectiveNodes(tc.getFieldDirectives(fieldName), tc.schemaComposer),
         defaultValue:
           (fc.defaultValue !== undefined &&
-            astFromValue(fc.defaultValue, tc.getFieldType(fieldName))) ||
+            astFromValueSafe(fc.defaultValue, tc.getFieldType(fieldName))) ||
           undefined,
       } as InputValueDefinitionNode;
     })
@@ -396,5 +396,13 @@ export function parseValueNode(
       return variables ? variables[ast.name.value] : undefined;
     default:
       throw new TypeError(`${typeName} cannot represent value: ${inspect(ast)}`);
+  }
+}
+
+function astFromValueSafe(value: unknown, type: GraphQLInputType): ReturnType<typeof astFromValue> {
+  try {
+    return astFromValue(value, type);
+  } catch (e) {
+    return toValueNode(value);
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -552,6 +552,21 @@
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.2.tgz#30aa825f11d438671d585bd44e7fd564535fc210"
   integrity sha512-82cpyJyKRoQoRi+14ibCeGPu0CwypgtBAdBhq1WfvagpCZNKqwXbKwXllYSMG91DhmG4jt9gN8eP6lGOtozuaw==
 
+"@graphql-tools/utils@^10.2.0":
+  version "10.2.0"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/utils/-/utils-10.2.0.tgz#c7233dc83ba6f88207a22e3f77add53c10e675df"
+  integrity sha512-HYV7dO6pNA2nGKawygaBpk8y+vXOUjjzzO43W/Kb7EPRmXUEQKjHxPYRvQbiF72u1N3XxwGK5jnnFk9WVhUwYw==
+  dependencies:
+    "@graphql-typed-document-node/core" "^3.1.1"
+    cross-inspect "1.0.0"
+    dset "^3.1.2"
+    tslib "^2.4.0"
+
+"@graphql-typed-document-node/core@^3.1.1":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@graphql-typed-document-node/core/-/core-3.2.0.tgz#5f3d96ec6b2354ad6d8a28bf216a1d97b5426861"
+  integrity sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==
+
 "@humanwhocodes/config-array@^0.11.6":
   version "0.11.6"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.11.6.tgz#6a51d603a3aaf8d4cf45b42b3f2ac9318a4adc4b"
@@ -2219,6 +2234,13 @@ create-require@^1.1.0:
   resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
+cross-inspect@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/cross-inspect/-/cross-inspect-1.0.0.tgz#5fda1af759a148594d2d58394a9e21364f6849af"
+  integrity sha512-4PFfn4b5ZN6FMNGSZlyb7wUhuN8wvj8t/VQHZdM4JsDcruGJ8L2kf9zao98QIrBPFCpdk27qst/AGTl7pL3ypQ==
+  dependencies:
+    tslib "^2.4.0"
+
 cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
@@ -2452,6 +2474,11 @@ dot-prop@^5.1.0:
   integrity sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==
   dependencies:
     is-obj "^2.0.0"
+
+dset@^3.1.2:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/dset/-/dset-3.1.3.tgz#c194147f159841148e8e34ca41f638556d9542d2"
+  integrity sha512-20TuZZHCEZ2O71q9/+8BwKwZ0QtD9D8ObhrihJPr+vLLYlSuAU3/zL4cSlgbfeoGHTjCSJBa7NGcrF9/Bx/WJQ==
 
 duplexer2@~0.1.0:
   version "0.1.4"
@@ -3255,10 +3282,10 @@ graphql-type-json@0.3.2:
   resolved "https://registry.yarnpkg.com/graphql-type-json/-/graphql-type-json-0.3.2.tgz#f53a851dbfe07bd1c8157d24150064baab41e115"
   integrity sha512-J+vjof74oMlCWXSvt0DOf2APEdZOCdubEvGDUAlqH//VBYcOYsGgRW7Xzorr44LvkjiuvecWc8fChxuZZbChtg==
 
-graphql@16.1.0:
-  version "16.1.0"
-  resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.1.0.tgz#83bebeae6e119766d04966f09de9305be7fd44e5"
-  integrity sha512-+PIjmhqGHMIxtnlEirRXDHIzs0cAHAozKG5M2w2N4TnS8VzCxO3bbv1AW9UTeycBfl2QsPduxcVrBvANFKQhiw==
+graphql@16.6.0:
+  version "16.6.0"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.6.0.tgz#c2dcffa4649db149f6282af726c8c83f1c7c5fdb"
+  integrity sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==
 
 handlebars@^4.7.6:
   version "4.7.7"
@@ -6455,6 +6482,11 @@ tslib@^2:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
+
+tslib@^2.4.0:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
+  integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
 
 tsutils@^3.21.0:
   version "3.21.0"


### PR DESCRIPTION
Fixes #407 by falling back to `toValueNode` if `astFromValue` fails.