### PR TITLE
fix: normalize GraphQL 17 fields and preserve metadata

### DIFF
--- a/src/__tests__/InputTypeComposer-test.ts
+++ b/src/__tests__/InputTypeComposer-test.ts
@@ -68,11 +68,48 @@ describe('InputTypeComposer', () => {
     });
 
     it('builds fields compatible with GraphQL input type config', () => {
-      itc.setField('input3', { type: GraphQLString, defaultValue: 'value' });
+      itc.setFields({
+        input3: {
+          type: GraphQLString,
+          default: { value: 'value' },
+          deprecationReason: 'Use input4',
+          extensions: { source: 'test' },
+          directives: [{ name: 'inputDirective' }],
+        },
+        input4: {
+          type: GraphQLString,
+          defaultValue: null,
+          description: undefined,
+          extensions: undefined,
+        },
+      });
 
-      const fieldConfig = itc.getType().toConfig().fields.input3;
-      expect(fieldConfig.type).toBe(GraphQLString);
-      expect(fieldConfig.defaultValue).toBe('value');
+      const typeConfig = itc.getType().toConfig();
+      const input3 = itc.getType().getFields().input3 as any;
+      if (graphqlVersion >= 17) {
+        const { isInputField } = require('graphql/type/definition');
+        expect(isInputField(input3)).toBe(true);
+        expect(input3.parentType).toBe(itc.getType());
+      }
+      expect(typeConfig.fields.input3).toMatchObject({
+        type: GraphQLString,
+        default: { value: 'value' },
+        deprecationReason: 'Use input4',
+        extensions: { source: 'test' },
+      });
+      expect(input3.astNode?.name.value).toBe('input3');
+      expect(input3.directives).toEqual(
+        expect.arrayContaining([
+          { name: 'inputDirective' },
+          { name: 'deprecated', args: { reason: 'Use input4' } },
+        ])
+      );
+      expect(typeConfig.fields.input4.defaultValue).toBeNull();
+      expect(typeConfig.fields.input4.description).toBeUndefined();
+      expect(typeConfig.fields.input4.extensions).toEqual({});
+
+      const rebuiltType = new GraphQLInputObjectType(typeConfig);
+      expect(rebuiltType.toConfig().fields.input3.type).toBe(GraphQLString);
     });
 
     describe('setFields()', () => {

--- a/src/__tests__/InputTypeComposer-test.ts
+++ b/src/__tests__/InputTypeComposer-test.ts
@@ -67,6 +67,14 @@ describe('InputTypeComposer', () => {
       expect(fieldNames).toContain('input3');
     });
 
+    it('builds fields compatible with GraphQL input type config', () => {
+      itc.setField('input3', { type: GraphQLString, defaultValue: 'value' });
+
+      const fieldConfig = itc.getType().toConfig().fields.input3;
+      expect(fieldConfig.type).toBe(GraphQLString);
+      expect(fieldConfig.defaultValue).toBe('value');
+    });
+
     describe('setFields()', () => {
       it('accept regular fields definition', () => {
         itc.setFields({

--- a/src/__tests__/InterfaceTypeComposer-test.ts
+++ b/src/__tests__/InterfaceTypeComposer-test.ts
@@ -71,6 +71,31 @@ describe('InterfaceTypeComposer', () => {
         expect(fields.field3.type).toBe(GraphQLString);
       });
 
+      it('should build fields compatible with GraphQL interface type config', () => {
+        iftc.setFields({
+          field3: {
+            type: GraphQLString,
+            args: undefined,
+            extensions: { source: 'test' },
+            projection: { field1: true },
+          },
+        });
+
+        const typeConfig = iftc.getType().toConfig();
+        const field = iftc.getType().getFields().field3 as any;
+        if (graphqlVersion >= 17) {
+          const { isField } = require('graphql/type/definition');
+          expect(isField(field)).toBe(true);
+          expect(field.parentType).toBe(iftc.getType());
+        }
+        expect(typeConfig.fields.field3.args).toEqual({});
+        expect(typeConfig.fields.field3.extensions).toEqual({ source: 'test' });
+        expect(field.projection).toEqual({ field1: true });
+
+        const rebuiltType = new GraphQLInterfaceType(typeConfig);
+        expect(rebuiltType.toConfig().fields.field3.type).toBe(GraphQLString);
+      });
+
       it('should add fields with converting types from string to object', () => {
         iftc.setFields({
           field3: { type: 'String' },

--- a/src/__tests__/ObjectTypeComposer-test.ts
+++ b/src/__tests__/ObjectTypeComposer-test.ts
@@ -72,19 +72,74 @@ describe('ObjectTypeComposer', () => {
       });
 
       it('should build fields compatible with GraphQL type config', () => {
+        const resolve = jest.fn();
+        const subscribe = jest.fn();
         tc.setFields({
           field3: {
             type: GraphQLString,
-            args: { arg1: { type: GraphQLInt } },
+            args: {
+              arg1: { type: GraphQLInt, default: { value: 5 } },
+              arg2: {
+                type: GraphQLInt,
+                defaultValue: null,
+                deprecationReason: 'Use arg1',
+                extensions: { source: 'test' },
+                directives: [{ name: 'argDirective' }],
+              },
+            },
+            resolve,
+            subscribe,
+            deprecationReason: 'Use field4',
+            extensions: { source: 'test' },
+            directives: [{ name: 'fieldDirective' }],
             projection: { field1: true },
           },
+          field4: { type: GraphQLString, args: undefined, description: undefined },
         });
 
+        const typeConfig = tc.getType().toConfig();
         const field = tc.getType().getFields().field3 as any;
-        const fieldConfig = tc.getType().toConfig().fields.field3;
+        const [arg1, arg2] = field.args as any[];
+        const fieldConfig = typeConfig.fields.field3;
+        if (graphqlVersion >= 17) {
+          const { isArgument, isField } = require('graphql/type/definition');
+          expect(isField(field)).toBe(true);
+          expect(field.parentType).toBe(tc.getType());
+          expect(isArgument(arg1)).toBe(true);
+          expect(arg1.parent).toBe(field);
+        }
         expect(fieldConfig.type).toBe(GraphQLString);
+        expect(fieldConfig.resolve).toBe(resolve);
+        expect(fieldConfig.subscribe).toBe(subscribe);
+        expect(fieldConfig.deprecationReason).toBe('Use field4');
+        expect(fieldConfig.extensions).toEqual({ source: 'test' });
         expect(fieldConfig.args?.arg1.type).toBe(GraphQLInt);
+        expect(fieldConfig.args?.arg1.default).toEqual({ value: 5 });
+        expect(fieldConfig.args?.arg2.defaultValue).toBeNull();
+        expect(fieldConfig.args?.arg2.extensions).toEqual({ source: 'test' });
+        expect(arg1.isDeprecated).toBe(false);
+        expect(arg2.isDeprecated).toBe(true);
+        expect(arg2.directives).toEqual(
+          expect.arrayContaining([
+            { name: 'argDirective' },
+            { name: 'deprecated', args: { reason: 'Use arg1' } },
+          ])
+        );
+        expect(field.astNode?.name.value).toBe('field3');
+        expect(arg2.astNode?.name.value).toBe('arg2');
+        expect(field.directives).toEqual(
+          expect.arrayContaining([
+            { name: 'fieldDirective' },
+            { name: 'deprecated', args: { reason: 'Use field4' } },
+          ])
+        );
         expect(field.projection).toEqual({ field1: true });
+        expect(typeConfig.fields.field4.args).toEqual({});
+        expect(typeConfig.fields.field4.description).toBeUndefined();
+        expect(typeConfig.fields.field4.extensions).toEqual({});
+
+        const rebuiltType = new GraphQLObjectType(typeConfig);
+        expect(rebuiltType.toConfig().fields.field3.type).toBe(GraphQLString);
       });
 
       it('should add fields with converting types from string to object', () => {

--- a/src/__tests__/ObjectTypeComposer-test.ts
+++ b/src/__tests__/ObjectTypeComposer-test.ts
@@ -71,6 +71,22 @@ describe('ObjectTypeComposer', () => {
         expect(fields.field3.type).toBe(GraphQLString);
       });
 
+      it('should build fields compatible with GraphQL type config', () => {
+        tc.setFields({
+          field3: {
+            type: GraphQLString,
+            args: { arg1: { type: GraphQLInt } },
+            projection: { field1: true },
+          },
+        });
+
+        const field = tc.getType().getFields().field3 as any;
+        const fieldConfig = tc.getType().toConfig().fields.field3;
+        expect(fieldConfig.type).toBe(GraphQLString);
+        expect(fieldConfig.args?.arg1.type).toBe(GraphQLInt);
+        expect(field.projection).toEqual({ field1: true });
+      });
+
       it('should add fields with converting types from string to object', () => {
         tc.setFields({
           field3: { type: 'String' },

--- a/src/utils/__tests__/configToDefine-test.ts
+++ b/src/utils/__tests__/configToDefine-test.ts
@@ -1,0 +1,22 @@
+import { GraphQLInputObjectType, GraphQLObjectType, GraphQLString } from '../../graphql';
+import { defineFieldMap, defineInputFieldMap } from '../configToDefine';
+
+describe('configToDefine', () => {
+  it('rejects a nullish argument config with its schema path', () => {
+    const type = new GraphQLObjectType({ name: 'Output', fields: {} });
+
+    expect(() =>
+      defineFieldMap(type, {
+        field: { type: GraphQLString, args: { arg: undefined as any } },
+      })
+    ).toThrow('Output.field(arg:) argument config must be an object');
+  });
+
+  it('rejects a nullish input field config with its schema path', () => {
+    const type = new GraphQLInputObjectType({ name: 'Input', fields: {} });
+
+    expect(() => defineInputFieldMap(type, { field: null as any })).toThrow(
+      'Input.field field config must be an object'
+    );
+  });
+});

--- a/src/utils/configToDefine.ts
+++ b/src/utils/configToDefine.ts
@@ -105,6 +105,7 @@ export function defineFieldMap(
       field.args = Object.keys(argsConfig).map((argName) => {
         const arg = argsConfig[argName];
         return {
+          ...arg,
           name: argName,
           description: arg.description === undefined ? null : arg.description,
           type: arg.type,
@@ -115,7 +116,31 @@ export function defineFieldMap(
         };
       }) as any;
     }
-    resultFieldMap[fieldName] = field;
+    const normalizedArgs = Array.isArray(field.args) ? field.args : [];
+    if (graphqlVersion >= 17) {
+      const graphqlFieldConfig: any = { ...fieldConfig, args: {}, astNode: fieldNodeAst };
+      normalizedArgs.forEach((arg: any) => {
+        const { name, ...argConfig } = arg;
+        graphqlFieldConfig.args[name] = argConfig;
+      });
+      const graphqlField: any = new (require('graphql/type/definition').GraphQLField)(
+        config,
+        fieldName,
+        graphqlFieldConfig
+      );
+      Object.keys(field).forEach((key) => {
+        if (!(key in graphqlField)) graphqlField[key] = (field as any)[key];
+      });
+      graphqlField.args.forEach((arg: any) => {
+        const legacyArg = normalizedArgs.find((item: any) => item.name === arg.name);
+        Object.keys(legacyArg).forEach((key) => {
+          if (!(key in arg)) arg[key] = legacyArg[key];
+        });
+      });
+      resultFieldMap[fieldName] = graphqlField;
+    } else {
+      resultFieldMap[fieldName] = field;
+    }
   }
   return resultFieldMap;
 }
@@ -267,7 +292,19 @@ export function defineInputFieldMap(
       `${config.name}.${fieldName} field has a resolve property, but ` +
         'Input Types cannot define resolvers.'
     );
-    resultFieldMap[fieldName] = field;
+    if (graphqlVersion >= 17) {
+      const graphqlInputField: any = new (require('graphql/type/definition').GraphQLInputField)(
+        config,
+        fieldName,
+        { ...fieldMap[fieldName], astNode: astNodeMap[fieldName] }
+      );
+      Object.keys(field).forEach((key) => {
+        if (!(key in graphqlInputField)) graphqlInputField[key] = (field as any)[key];
+      });
+      resultFieldMap[fieldName] = graphqlInputField;
+    } else {
+      resultFieldMap[fieldName] = field;
+    }
   }
   return resultFieldMap;
 }

--- a/src/utils/configToDefine.ts
+++ b/src/utils/configToDefine.ts
@@ -46,6 +46,13 @@ function isPlainObj(obj: any): obj is Record<any, any> {
   return obj && typeof obj === 'object' && !Array.isArray(obj);
 }
 
+function copyMissingProperties(target: Record<any, any>, source?: Record<any, any> | null): void {
+  if (source == null) return;
+  Object.keys(source).forEach((key) => {
+    if (!(key in target)) target[key] = source[key];
+  });
+}
+
 export function defineFieldMap(
   config: GraphQLObjectType | GraphQLInterfaceType,
   fieldMap: GraphQLFieldConfigMap<any, any>,
@@ -101,16 +108,20 @@ export function defineFieldMap(
         isPlainObj(argsConfig),
         `${config.name}.${fieldName} args must be an object with argument names as keys.`
       );
-      const fieldArgNodeMap = argAstNodeMap[fieldName] ?? {};
+      const fieldArgNodeMap = argAstNodeMap[fieldName] ?? Object.create(null);
       field.args = Object.keys(argsConfig).map((argName) => {
         const arg = argsConfig[argName];
+        invariant(
+          isPlainObj(arg),
+          `${config.name}.${fieldName}(${argName}:) argument config must be an object`
+        );
         return {
           ...arg,
           name: argName,
           description: arg.description === undefined ? null : arg.description,
           type: arg.type,
-          isDeprecated: Boolean(fieldConfig.deprecationReason),
-          deprecationReason: arg?.deprecationReason,
+          isDeprecated: Boolean(arg.deprecationReason),
+          deprecationReason: arg.deprecationReason,
           defaultValue: arg.defaultValue,
           astNode: fieldArgNodeMap[argName],
         };
@@ -118,24 +129,18 @@ export function defineFieldMap(
     }
     const normalizedArgs = Array.isArray(field.args) ? field.args : [];
     if (graphqlVersion >= 17) {
-      const graphqlFieldConfig: any = { ...fieldConfig, args: {}, astNode: fieldNodeAst };
+      const normalizedArgsByName: Record<string, any> = Object.create(null);
       normalizedArgs.forEach((arg: any) => {
-        const { name, ...argConfig } = arg;
-        graphqlFieldConfig.args[name] = argConfig;
+        normalizedArgsByName[arg.name] = arg;
       });
       const graphqlField: any = new (require('graphql/type/definition').GraphQLField)(
         config,
         fieldName,
-        graphqlFieldConfig
+        { ...fieldConfig, args: normalizedArgsByName, astNode: fieldNodeAst }
       );
-      Object.keys(field).forEach((key) => {
-        if (!(key in graphqlField)) graphqlField[key] = (field as any)[key];
-      });
+      copyMissingProperties(graphqlField, field);
       graphqlField.args.forEach((arg: any) => {
-        const legacyArg = normalizedArgs.find((item: any) => item.name === arg.name);
-        Object.keys(legacyArg).forEach((key) => {
-          if (!(key in arg)) arg[key] = legacyArg[key];
-        });
+        copyMissingProperties(arg, normalizedArgsByName[arg.name]);
       });
       resultFieldMap[fieldName] = graphqlField;
     } else {
@@ -282,8 +287,13 @@ export function defineInputFieldMap(
 
   const resultFieldMap = Object.create(null);
   for (const fieldName of Object.keys(fieldMap)) {
+    const fieldConfig = fieldMap[fieldName];
+    invariant(
+      isPlainObj(fieldConfig),
+      `${config.name}.${fieldName} field config must be an object`
+    );
     const field = {
-      ...fieldMap[fieldName],
+      ...fieldConfig,
       name: fieldName,
       astNode: astNodeMap[fieldName],
     };
@@ -296,11 +306,9 @@ export function defineInputFieldMap(
       const graphqlInputField: any = new (require('graphql/type/definition').GraphQLInputField)(
         config,
         fieldName,
-        { ...fieldMap[fieldName], astNode: astNodeMap[fieldName] }
+        { ...fieldConfig, astNode: astNodeMap[fieldName] }
       );
-      Object.keys(field).forEach((key) => {
-        if (!(key in graphqlInputField)) graphqlInputField[key] = (field as any)[key];
-      });
+      copyMissingProperties(graphqlInputField, field);
       resultFieldMap[fieldName] = graphqlInputField;
     } else {
       resultFieldMap[fieldName] = field;

--- a/src/utils/configToDefine.ts
+++ b/src/utils/configToDefine.ts
@@ -49,7 +49,15 @@ function isPlainObj(obj: any): obj is Record<any, any> {
 function copyMissingProperties(target: Record<any, any>, source?: Record<any, any> | null): void {
   if (source == null) return;
   Object.keys(source).forEach((key) => {
-    if (!(key in target)) target[key] = source[key];
+    if (key === '__proto__' || key === 'constructor' || key === 'prototype') return;
+    if (!(key in target)) {
+      Object.defineProperty(target, key, {
+        value: source[key],
+        enumerable: true,
+        configurable: true,
+        writable: true,
+      });
+    }
   });
 }
 


### PR DESCRIPTION
## Summary

- construct GraphQL 17 GraphQLField, GraphQLArgument, and GraphQLInputField instances for object, interface, and input fields
- preserve resolvers, subscriptions, defaults, extensions, AST nodes, directives, projection, and custom metadata
- centralize null-safe metadata copying and reject invalid nullish argument/input-field configs with schema-path errors
- correct argument isDeprecated state so it follows the argument rather than its parent field

## Why

GraphQL 17 type toConfig methods require normalized runtime field objects. GraphQL Compose was assigning legacy plain field configurations to internal maps, causing schema reconstruction and schema merging to fail. The initial fix removed that crash but needed broader metadata, nullish, interface, and backward-compatibility coverage.

## Coverage

- direct GraphQL 17 identity and parent-link assertions for fields, arguments, interface fields, and input fields
- GraphQL 17 default plus legacy null defaultValue behavior
- undefined argument and metadata handling
- extensions, AST nodes, directives, deprecation, projection, resolve, and subscribe preservation
- object, interface, and input type configuration reconstruction
- explicit nullish validation errors

## Verification

- yarn test: 52 suites and 978 tests passed
- yarn build
- built-package smoke matrix: GraphQL 14.7.0, 15.10.1, 16.14.2, and 17.0.2 passed
- downstream GraphQL 17 consumer API-flow: 163 tests passed
- independent standards and spec reviews: no remaining findings
